### PR TITLE
feat: add article translation workflow

### DIFF
--- a/frontend/src/helper/APIUtils.ts
+++ b/frontend/src/helper/APIUtils.ts
@@ -26,6 +26,8 @@ const SAVE_ARTICLE = `${PROD_URL}/articles/saveArticle`;
 const LIKE_ARTICLE = `${PROD_URL}/articles/likeArticle`;
 const POST_ARTICLE = `${PROD_URL}/articles`;
 const GET_ARTICLE_BY_ID = `${PROD_URL}/articles`;
+const GET_ARTICLE_TRANSLATIONS = (articleId: string | number) =>
+  `${GET_ARTICLE_BY_ID}/${articleId}/translations`;
 const GET_USER_DETAILS_API = `${PROD_URL}/user/getdetails`;
 const UPDATE_USER_GENERAL_DETAILS = `${PROD_URL}/user/update-general-details`;
 const UPDATE_READ_EVENT = `${PROD_URL}/article/readEvent`;
@@ -113,6 +115,7 @@ export {
   LIKE_ARTICLE,
   POST_ARTICLE,
   GET_ARTICLE_BY_ID,
+  GET_ARTICLE_TRANSLATIONS,
   GET_USER_DETAILS_API,
   UPDATE_USER_GENERAL_DETAILS,
   UPDATE_USER_PASSWORD,

--- a/frontend/src/hooks/useGetArticleTranslations.ts
+++ b/frontend/src/hooks/useGetArticleTranslations.ts
@@ -1,0 +1,25 @@
+import {useQuery, UseQueryResult} from '@tanstack/react-query';
+import axios, {AxiosError} from 'axios';
+import {GET_ARTICLE_TRANSLATIONS} from '../helper/APIUtils';
+import {ArticleData} from '../type';
+
+type ArticleTranslationsRes = {
+  translations: ArticleData[];
+};
+
+export const useGetArticleTranslations = (
+  articleId: number | string,
+  language?: string,
+): UseQueryResult<ArticleTranslationsRes, AxiosError> => {
+  return useQuery({
+    queryKey: ['get-article-translations', articleId, language],
+    queryFn: async () => {
+      const response = await axios.get(GET_ARTICLE_TRANSLATIONS(articleId), {
+        params: language ? {language} : undefined,
+      });
+
+      return response.data as ArticleTranslationsRes;
+    },
+    enabled: !!articleId,
+  });
+};

--- a/frontend/src/hooks/usePostArticle.ts
+++ b/frontend/src/hooks/usePostArticle.ts
@@ -14,6 +14,12 @@ type PostReq = {
   pb_recordId: string;
   allow_podcast: boolean;
   language: string;
+  isTranslation?: boolean;
+  sourceArticleId?: string;
+  sourceArticleRecordId?: string;
+  sourceLanguage?: string;
+  targetLanguage?: string;
+  translationOf?: string;
 };
 
 export const usePostArticleData = (): UseMutationResult<

--- a/frontend/src/screens/article/ArticleDescriptionScreen.tsx
+++ b/frontend/src/screens/article/ArticleDescriptionScreen.tsx
@@ -32,7 +32,8 @@ const ArticleDescriptionScreen = ({
   navigation,
   route,
 }: ArticleDescriptionProp) => {
-  const {article, htmlContent} = route.params;
+  const {article, htmlContent, translationSource} = route.params;
+  const isTranslation = Boolean(translationSource);
   const [title, setTitle] = useState('');
   const [authorName, setAuthorName] = useState('');
   const [description, setDescription] = useState('');
@@ -49,13 +50,16 @@ const ArticleDescriptionScreen = ({
       setAuthorName(article.authorName);
       setDescription(article.description);
       setSelectedGenres(article.tags);
+      if (isTranslation) {
+        setLanguage('');
+      }
       setImageUtils(
         article.imageUtils && article.imageUtils.length > 0
           ? article.imageUtils[0]
           : '',
       );
     }
-  }, []);
+  }, [article, isTranslation]);
   const handleGenrePress = (genre: Category) => {
     if (isSelected(genre)) {
       setSelectedGenres(selectedGenres.filter(item => item.id !== genre.id));
@@ -80,6 +84,15 @@ const ArticleDescriptionScreen = ({
     } else if (selectedGenres.length === 0) {
       Alert.alert('Please select at least one suitable tags for your article.');
       return;
+    } else if (isTranslation && !language) {
+      Alert.alert('Please select a target language for the translation.');
+      return;
+    } else if (
+      isTranslation &&
+      language === translationSource?.sourceLanguage
+    ) {
+      Alert.alert('Please choose a language different from the source article.');
+      return;
     }
 
     // Later purpose
@@ -94,11 +107,12 @@ const ArticleDescriptionScreen = ({
       description: description,
       selectedGenres: selectedGenres,
       imageUtils: imageUtils,
-      articleData: article,
       htmlContent: htmlContent,
       language: language,
       requestId: undefined,
-      pb_record_id: undefined
+      pb_record_id: undefined,
+      articleData: isTranslation ? undefined : article,
+      translationSource,
     });
   };
 
@@ -137,8 +151,14 @@ const ArticleDescriptionScreen = ({
     });
   };
 
+  const availableLanguages = isTranslation
+    ? ttsLanguageList.filter(
+        lang => lang.code !== translationSource?.sourceLanguage,
+      )
+    : ttsLanguageList;
+
   const getLanguageLabel = (value: string) => {
-    return ttsLanguageList.find(lang => lang.code === value)?.name || 'English (India)';
+    return ttsLanguageList.find(lang => lang.code === value)?.name || 'Select language';
   };
 
   const LanguageSelector = () => {
@@ -160,7 +180,7 @@ const ArticleDescriptionScreen = ({
               </TouchableOpacity>
             </View>
             <FlatList
-              data={ttsLanguageList}
+              data={availableLanguages}
               keyExtractor={item => item.code}
               renderItem={({item}) => (
                 <TouchableOpacity
@@ -211,9 +231,23 @@ const ArticleDescriptionScreen = ({
         <View style={styles.headerSection}>
           <Text style={styles.sectionTitle}>Article Details</Text>
           <Text style={styles.sectionSubtitle}>
-            Fill in the information below to create your article
+            {isTranslation
+              ? `Create a translated version of "${translationSource?.sourceTitle}"`
+              : 'Fill in the information below to create your article'}
           </Text>
         </View>
+
+        {isTranslation && (
+          <View style={styles.translationNotice}>
+            <Ionicon name="language-outline" size={20} color={PRIMARY_COLOR} />
+            <View style={styles.translationNoticeTextWrapper}>
+              <Text style={styles.translationNoticeTitle}>Translation article</Text>
+              <Text style={styles.translationNoticeText}>
+                Source language: {getLanguageLabel(translationSource?.sourceLanguage ?? '')}
+              </Text>
+            </View>
+          </View>
+        )}
 
         {/* Image Upload Section */}
         <View style={styles.section}>
@@ -296,7 +330,7 @@ const ArticleDescriptionScreen = ({
               style={styles.languageSelector}
               onPress={() => setLanguageModalVisible(true)}>
               <Text style={styles.languageSelectorText}>
-                {getLanguageLabel(language)}
+                {language ? getLanguageLabel(language) : 'Select target language'}
               </Text>
               <Ionicon name="chevron-down" size={20} color="#6b7280" />
             </TouchableOpacity>
@@ -404,6 +438,30 @@ const styles = StyleSheet.create({
     shadowOpacity: 0.05,
     shadowRadius: 8,
     elevation: 2,
+  },
+  translationNotice: {
+    backgroundColor: 'rgba(59, 130, 246, 0.08)',
+    borderColor: 'rgba(59, 130, 246, 0.25)',
+    borderRadius: 12,
+    borderWidth: 1,
+    flexDirection: 'row',
+    gap: 10,
+    marginBottom: 16,
+    padding: 14,
+  },
+  translationNoticeTextWrapper: {
+    flex: 1,
+  },
+  translationNoticeTitle: {
+    color: '#1a1a1a',
+    fontSize: 15,
+    fontWeight: '700',
+    marginBottom: 2,
+  },
+  translationNoticeText: {
+    color: '#4b5563',
+    fontSize: 13,
+    lineHeight: 18,
   },
   sectionTitle: {
     fontSize: 20,

--- a/frontend/src/screens/article/ArticleScreen.tsx
+++ b/frontend/src/screens/article/ArticleScreen.tsx
@@ -196,6 +196,32 @@ const ArticleScreen = ({navigation, route}: ArticleScreenProp) => {
     }
   };
 
+  const handleTranslateArticle = () => {
+    if (!article) {
+      Alert.alert('Article not found');
+      return;
+    }
+
+    if (!articleContent) {
+      Snackbar.show({
+        text: 'Article content is still loading. Please try again.',
+        duration: Snackbar.LENGTH_SHORT,
+      });
+      return;
+    }
+
+    navigation.navigate('ArticleDescriptionScreen', {
+      article,
+      htmlContent: articleContent,
+      translationSource: {
+        sourceArticleId: article._id,
+        sourceArticleRecordId: article.pb_recordId || recordId,
+        sourceLanguage: article.language || 'en-IN',
+        sourceTitle: article.title,
+      },
+    });
+  };
+
   async function convertHtmlToPlainText(html: string) {
     let modifiedHtml = html.replace(/ style="[^"]*"/g, '');
 
@@ -673,6 +699,17 @@ const ArticleScreen = ({navigation, route}: ArticleScreenProp) => {
 
           <TouchableOpacity
             style={styles.actionButtonFooter}
+            onPress={handleTranslateArticle}>
+            <MaterialCommunityIcons
+              name="translate"
+              size={20}
+              color="#666"
+            />
+            <Text style={styles.actionTextFooter}>Translate</Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            style={styles.actionButtonFooter}
             onPress={handleSave}
             disabled={saveMutationPending}>
             {saveMutationPending ? (
@@ -928,7 +965,8 @@ const styles = StyleSheet.create({
     marginBottom: 10,
   },
   actionButtonFooter: {
-    flexDirection: 'row',
+    flex: 1,
+    flexDirection: 'column',
     alignItems: 'center',
     gap: 5,
   },

--- a/frontend/src/screens/article/EditorScreen.tsx
+++ b/frontend/src/screens/article/EditorScreen.tsx
@@ -34,6 +34,7 @@ const EditorScreen = ({navigation, route}: EditorScreenProp) => {
     requestId,
     htmlContent,
     pb_record_id,
+    translationSource,
   } = route.params;
 
   const RichText = useRef(null);
@@ -67,6 +68,7 @@ const EditorScreen = ({navigation, route}: EditorScreenProp) => {
                 requestId: requestId,
                 pb_record_id: pb_record_id,
                 language: route.params.language,
+                translationSource,
               });
             } else {
               Alert.alert('Error', 'Please enter at least 20 characters');
@@ -90,6 +92,7 @@ const EditorScreen = ({navigation, route}: EditorScreenProp) => {
     requestId,
     dispatch,
     pb_record_id,
+    translationSource,
   ]);
 
   useEffect(() => {

--- a/frontend/src/screens/article/PreviewScreen.tsx
+++ b/frontend/src/screens/article/PreviewScreen.tsx
@@ -42,6 +42,7 @@ export default function PreviewScreen({navigation, route}: PreviewScreenProp) {
     requestId,
     language,
     pb_record_id,
+    translationSource,
   } = route.params;
 
   const [imageUtil, setImageUtil] = useState<string>('');
@@ -258,11 +259,20 @@ export default function PreviewScreen({navigation, route}: PreviewScreenProp) {
                       pb_recordId: data.recordId,
                       allow_podcast: true,
                       language: language,
+                      isTranslation: Boolean(translationSource),
+                      sourceArticleId: translationSource?.sourceArticleId,
+                      sourceArticleRecordId:
+                        translationSource?.sourceArticleRecordId,
+                      sourceLanguage: translationSource?.sourceLanguage,
+                      targetLanguage: language,
+                      translationOf: translationSource?.sourceArticleId,
                     },
                     {
                       onSuccess: () => {
                         Snackbar.show({
-                          text: 'Article added successfully',
+                          text: translationSource
+                            ? 'Translation submitted successfully'
+                            : 'Article added successfully',
                           duration: Snackbar.LENGTH_SHORT,
                         });
 

--- a/frontend/src/type.ts
+++ b/frontend/src/type.ts
@@ -27,10 +27,12 @@ export type RootStackParamList = {
     requestId: string | undefined;
     htmlContent: string | undefined;
     pb_record_id: string | undefined;
+    translationSource?: ArticleTranslationSource;
   };
   ArticleDescriptionScreen: {
     article: ArticleData | null | undefined;
     htmlContent: string | undefined;
+    translationSource?: ArticleTranslationSource;
   };
   PreviewScreen: {
     article: string;
@@ -45,6 +47,7 @@ export type RootStackParamList = {
     articleData: ArticleData | null | undefined;
     requestId: string | undefined;
     pb_record_id: string | undefined;
+    translationSource?: ArticleTranslationSource;
   };
   ArticleScreen: {
     articleId: number;
@@ -561,6 +564,18 @@ export type ArticleData = {
   reviewer_id: string | null | undefined;
   contributors: User[];
   pb_recordId: string;
+  isTranslation?: boolean;
+  sourceArticleId?: string;
+  sourceArticleRecordId?: string;
+  sourceLanguage?: string;
+  translationOf?: string;
+};
+
+export type ArticleTranslationSource = {
+  sourceArticleId: string;
+  sourceArticleRecordId: string;
+  sourceLanguage: string;
+  sourceTitle: string;
 };
 
 export type PodcastData = {

--- a/frontend/src/type.ts
+++ b/frontend/src/type.ts
@@ -565,10 +565,11 @@ export type ArticleData = {
   contributors: User[];
   pb_recordId: string;
   isTranslation?: boolean;
-  sourceArticleId?: string;
+  sourceArticleId?: string | number;
   sourceArticleRecordId?: string;
   sourceLanguage?: string;
-  translationOf?: string;
+  translationOf?: string | number | ArticleData | null;
+  translatedArticles?: ArticleData[];
 };
 
 export type ArticleTranslationSource = {


### PR DESCRIPTION
## Summary
- Add a Translate action on article detail screens that starts a new translation draft from the source article.
- Reuse the article description/editor/preview flow while preventing translations from overwriting the original article.
- Include source article and language metadata in the article submit payload so backend/admin workflows can link translations to the original article.

Closes #644

## Validation
- `git diff --check`
- `npx eslint src/screens/article/ArticleDescriptionScreen.tsx src/screens/article/ArticleScreen.tsx src/screens/article/EditorScreen.tsx src/screens/article/PreviewScreen.tsx src/hooks/usePostArticle.ts src/type.ts` *(blocked by existing repo lint config/dependency issues: missing `react-native/no-inline-styles` rule plus pre-existing warnings in unchanged sections)*
- `npx tsc --noEmit --moduleResolution bundler` *(blocked by pre-existing project-wide TypeScript errors)*