### PR TITLE
fix: guard chatbot state updates after unmount

### DIFF
--- a/frontend/src/screens/ChatbotScreen.tsx
+++ b/frontend/src/screens/ChatbotScreen.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useEffect, useState} from 'react';
+import React, {useCallback, useEffect, useRef, useState} from 'react';
 import {
   Bubble,
   GiftedChat,
@@ -54,6 +54,7 @@ const ChatbotScreen = ({navigation}: ChatBotScreenProps) => {
 
   const [messages, setMessages] = useState<IMessage[]>([]);
   const [isTyping, setIsTyping] = useState<boolean>(true);
+  const isMountedRef = useRef(true);
   const dispatch = useDispatch();
   const {data: user} = useGetProfile();
   // const token = 'GPMFAQIV2BGXCWYMCVQ3IPVXSOOLI53H5NYA'; //token
@@ -66,9 +67,30 @@ const ChatbotScreen = ({navigation}: ChatBotScreenProps) => {
     useLoadAIConversations(isConnected);
 
   useEffect(() => {
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  const safeSetMessages = useCallback(
+    (updater: React.SetStateAction<IMessage[]>) => {
+      if (isMountedRef.current) {
+        setMessages(updater);
+      }
+    },
+    [],
+  );
+
+  const safeSetIsTyping = useCallback((typing: boolean) => {
+    if (isMountedRef.current) {
+      setIsTyping(typing);
+    }
+  }, []);
+
+  useEffect(() => {
     if (conversations) {
       const refined = convertToGiftedFormat(conversations);
-      setMessages([
+      safeSetMessages([
         {
           _id: refined.length + 1,
           text: "Hello! 👋 I'm here to assist you. How can I help you today?",
@@ -82,9 +104,9 @@ const ChatbotScreen = ({navigation}: ChatBotScreenProps) => {
         ...refined.reverse(),
       ]);
 
-      setIsTyping(false);
+      safeSetIsTyping(false);
     }
-  }, [conversations]);
+  }, [conversations, safeSetIsTyping, safeSetMessages]);
 
   const convertToGiftedFormat = (items: Message[]): IMessage[] => {
     return items.map(m => ({
@@ -113,7 +135,7 @@ const ChatbotScreen = ({navigation}: ChatBotScreenProps) => {
     }
     sendMessageToAI(messages[0]?.text ?? 'AI in health within 100 words', {
       onSuccess: (responseData: Message) => {
-        setMessages(previousMessages =>
+        safeSetMessages(previousMessages =>
           GiftedChat.append(previousMessages, [
             {
               _id: responseData._id,
@@ -129,6 +151,9 @@ const ChatbotScreen = ({navigation}: ChatBotScreenProps) => {
         );
       },
       onError: (error: AxiosError) => {
+        if (!isMountedRef.current) {
+          return;
+        }
         console.log('Error', error);
         if (error.response) {
           const statusCode = error.response.status;
@@ -145,7 +170,7 @@ const ChatbotScreen = ({navigation}: ChatBotScreenProps) => {
 
               break;
             case 429:
-              setMessages(previousMessages =>
+              safeSetMessages(previousMessages =>
                 GiftedChat.append(previousMessages, [
                   {
                     _id: previousMessages.length + 1,
@@ -186,11 +211,10 @@ const ChatbotScreen = ({navigation}: ChatBotScreenProps) => {
         }
       },
     });
-    setMessages(previousMessages =>
+    safeSetMessages(previousMessages =>
       GiftedChat.append(previousMessages, messages),
     );
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [isConnected, safeSetMessages, sendMessageToAI]);
 
   return (
     <SafeAreaView style={{flex: 1, backgroundColor: 'white'}} edges={['top']}>


### PR DESCRIPTION
## Summary
- adds an `isMountedRef` lifecycle guard in `ChatbotScreen.tsx`
- routes async conversation loading, AI success/error callbacks, and optimistic message appends through safe setters
- removes the stale empty dependency callback suppression by depending on `isConnected`, `sendMessageToAI`, and the safe setter

## Notes
Current `main` does not contain active `setInterval`/`setTimeout` calls in `ChatbotScreen.tsx`, so this fixes the actual leak path present in the screen: async callbacks trying to update state after navigation/unmount.

## Validation
- `expo lint src/screens/ChatbotScreen.tsx -- --max-warnings=0`
- `git diff --check`

Full `tsc --noEmit` currently fails in existing `react-native-gifted-chat` type declarations under `node_modules` (`disabled` prop/style typing), before this file is reached.

Fixes #753

For GSSoC scoring, please keep/add: `gssoc26`, `level:beginner`, `type:performance`, `type:refactor`, and `gssoc:approved` if required by the tracker.