### PR TITLE
fix: handle expired JWT and switch to guest mode on 401

### DIFF
--- a/frontend/src/components/AppContent.tsx
+++ b/frontend/src/components/AppContent.tsx
@@ -27,6 +27,7 @@ import {firebaseInit} from '../helper/firebase';
 import {cleanUpDownloads, KEYS, retrieveItem} from '../helper/Utils';
 import { setUserToken, setGuestMode } from '../store/UserSlice';
 import axios from 'axios';
+import {setupAxiosInterceptor} from '../helper/setupAxiosInterceptor';
 
 export default function AppContent() {
   const navigationRef = useRef<NavigationContainerRef<any> | null>(null);
@@ -34,6 +35,8 @@ export default function AppContent() {
   const isDarkMode = useColorScheme() === 'dark';
 
   const {data: tokenRes = null} = useCheckTokenStatus();
+
+  setupAxiosInterceptor();
 
 
 

--- a/frontend/src/helper/setupAxiosInterceptor.ts
+++ b/frontend/src/helper/setupAxiosInterceptor.ts
@@ -1,0 +1,48 @@
+import axios from 'axios';
+import {Alert, Platform, ToastAndroid} from 'react-native';
+import store from '../store/ReduxStore';
+import {
+  setGuestMode,
+  setUserHandle,
+  setUserId,
+  setUserToken,
+} from '../store/UserSlice';
+
+let interceptorInitialized = false;
+let sessionExpiredNotified = false;
+
+export const setupAxiosInterceptor = () => {
+  if (interceptorInitialized) {
+    return;
+  }
+
+  interceptorInitialized = true;
+
+  axios.interceptors.response.use(
+    response => response,
+    error => {
+      if (error?.response?.status === 401) {
+        store.dispatch(setUserToken(''));
+        store.dispatch(setUserId(''));
+        store.dispatch(setUserHandle(''));
+        store.dispatch(setGuestMode(true));
+
+        axios.defaults.headers.common.Authorization = '';
+
+        if (!sessionExpiredNotified) {
+          sessionExpiredNotified = true;
+          const message =
+            'Your session has expired. You are now browsing as a guest.';
+
+          if (Platform.OS === 'android') {
+            ToastAndroid.show(message, ToastAndroid.SHORT);
+          } else {
+            Alert.alert('Session Expired', message);
+          }
+        }
+      }
+
+      return Promise.reject(error);
+    },
+  );
+};

--- a/frontend/src/helper/setupAxiosInterceptor.ts
+++ b/frontend/src/helper/setupAxiosInterceptor.ts
@@ -12,6 +12,7 @@ let interceptorInitialized = false;
 let sessionExpiredNotified = false;
 
 export const setupAxiosInterceptor = () => {
+  // Guard against duplicate interceptor registration during re-renders.
   if (interceptorInitialized) {
     return;
   }
@@ -21,6 +22,7 @@ export const setupAxiosInterceptor = () => {
   axios.interceptors.response.use(
     response => response,
     error => {
+      // Global auth-expiry handler: force logout state and switch to guest mode.
       if (error?.response?.status === 401) {
         store.dispatch(setUserToken(''));
         store.dispatch(setUserId(''));
@@ -29,6 +31,7 @@ export const setupAxiosInterceptor = () => {
 
         axios.defaults.headers.common.Authorization = '';
 
+        // Notify once to avoid alert/toast spam if multiple calls fail together.
         if (!sessionExpiredNotified) {
           sessionExpiredNotified = true;
           const message =


### PR DESCRIPTION
#### PR Description
This PR fixes session-expiry handling on the frontend by adding a global Axios 401 interceptor.  
When a protected API returns `401 Unauthorized` (expired/invalid JWT), the app now clears the authenticated user session and immediately switches to Guest Mode to avoid broken loading states, crashes, or redirect loops.


Detailed changes:
- Added a centralized interceptor setup in [setupAxiosInterceptor.ts](d:\GSSOC\UltimateHealth\frontend\src\helper\setupAxiosInterceptor.ts).
- Registered the interceptor during app bootstrap in [AppContent.tsx](d:\GSSOC\UltimateHealth\frontend\src\components\AppContent.tsx).
- On HTTP 401:
  - Dispatches `setUserToken('')`
  - Dispatches `setUserId('')`
  - Dispatches `setUserHandle('')`
  - Dispatches `setGuestMode(true)`
  - Clears default Axios `Authorization` header
- Added one-time user feedback message:
  - Android: Toast
  - iOS/others: Alert
  - Message: `"Your session has expired. You are now browsing as a guest."`
- Added inline comments in the interceptor for maintainability.

Related issue: Handles expired JWT session fallback to guest mode on unauthorized API responses.

#### Type of Change
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update

#### Select your work-area
- [x] Frontend
- [ ] Backend
- [ ] Documentation
- [ ] Others

#### Fixes (mention the issue number which this fixes)
#closes #736 

#### Checklist
- [x] I have updated my branch and synced it with the project's 'develop' branch before making this PR.
- [x] I have optimized the file changes.
- [ ] I have added a snapshot of my work example.
- [x] I have made a PR to the project's develop branch.

#### Undertaking
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have checked for plagiarism and assure its authenticity.
- [x] I have read and followed the code of conduct for this repository. I understand that violation of this undertaking may have legal consequences.

- [x] I Agree