### PR TITLE
test: add unit tests for Redux slices and fix GlassButton testID (#673)

### DIFF
--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -9,6 +9,6 @@ module.exports = {
     '^@/(.*)$': '<rootDir>/$1',
   },
   transformIgnorePatterns: [
-    'node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg|@gorhom/bottom-sheet|tamagui|@tamagui/.*|expo-router|react-native-reanimated)'
+    'node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg|@gorhom/bottom-sheet|tamagui|@tamagui/.*|expo-router|react-native-reanimated|immer|@reduxjs)'
   ],
 };

--- a/frontend/src/components/GlassButton.tsx
+++ b/frontend/src/components/GlassButton.tsx
@@ -160,6 +160,7 @@ export const GlassButton: React.FC<GlassButtonProps> = ({
       >
         {loading ? (
           <ActivityIndicator
+            testID="loading-spinner"
             size="small"
             color={
               variant === 'primary' || variant === 'secondary' || variant === 'danger'

--- a/frontend/src/store/__tests__/NetworkSlice.test.ts
+++ b/frontend/src/store/__tests__/NetworkSlice.test.ts
@@ -1,0 +1,22 @@
+import reducer, { setConnected } from '../NetworkSlice';
+
+describe('NetworkSlice reducers', () => {
+  const initialState = {
+    isConnected: true,
+  };
+
+  it('should return the initial state', () => {
+    expect(reducer(undefined, { type: 'unknown' })).toEqual(initialState);
+  });
+
+  it('should handle setConnected to false', () => {
+    const actual = reducer(initialState, setConnected(false));
+    expect(actual.isConnected).toEqual(false);
+  });
+
+  it('should handle setConnected to true', () => {
+    const disconnectedState = { isConnected: false };
+    const actual = reducer(disconnectedState, setConnected(true));
+    expect(actual.isConnected).toEqual(true);
+  });
+});

--- a/frontend/src/store/__tests__/UserSlice.test.ts
+++ b/frontend/src/store/__tests__/UserSlice.test.ts
@@ -1,0 +1,59 @@
+import reducer, {
+  setUserId,
+  setSocialUserId,
+  setUserToken,
+  setUserHandle,
+  setGuestMode,
+  resetUserState,
+} from '../UserSlice';
+
+describe('UserSlice reducers', () => {
+  const initialState = {
+    user_id: '',
+    user_token: '',
+    user_handle: '',
+    social_user_id: '',
+    isGuest: false,
+  };
+
+  it('should return the initial state', () => {
+    expect(reducer(undefined, { type: 'unknown' })).toEqual(initialState);
+  });
+
+  it('should handle setUserId', () => {
+    const actual = reducer(initialState, setUserId('test_id_123'));
+    expect(actual.user_id).toEqual('test_id_123');
+  });
+
+  it('should handle setSocialUserId', () => {
+    const actual = reducer(initialState, setSocialUserId('social_123'));
+    expect(actual.social_user_id).toEqual('social_123');
+  });
+
+  it('should handle setUserToken', () => {
+    const actual = reducer(initialState, setUserToken('token_abc'));
+    expect(actual.user_token).toEqual('token_abc');
+  });
+
+  it('should handle setUserHandle', () => {
+    const actual = reducer(initialState, setUserHandle('handle_xyz'));
+    expect(actual.user_handle).toEqual('handle_xyz');
+  });
+
+  it('should handle setGuestMode', () => {
+    const actual = reducer(initialState, setGuestMode(true));
+    expect(actual.isGuest).toEqual(true);
+  });
+
+  it('should handle resetUserState', () => {
+    const modifiedState = {
+      user_id: 'test_id_123',
+      user_token: 'token_abc',
+      user_handle: 'handle_xyz',
+      social_user_id: 'social_123',
+      isGuest: true,
+    };
+    const actual = reducer(modifiedState, resetUserState());
+    expect(actual).toEqual(initialState);
+  });
+});

--- a/frontend/src/store/__tests__/alertSlice.test.ts
+++ b/frontend/src/store/__tests__/alertSlice.test.ts
@@ -1,0 +1,58 @@
+import reducer, { showAlert, hideAlert } from '../alertSlice';
+
+describe('alertSlice reducers', () => {
+  const initialState = {
+    visible: false,
+    title: '',
+    message: '',
+    onConfirm: null,
+    onCancel: null,
+  };
+
+  it('should return the initial state', () => {
+    expect(reducer(undefined, { type: 'unknown' })).toEqual(initialState);
+  });
+
+  it('should handle showAlert', () => {
+    const mockPayload = {
+      title: 'Warning',
+      message: 'Are you sure?',
+      onConfirm: () => {},
+      onCancel: () => {},
+    };
+
+    const actual = reducer(initialState, showAlert(mockPayload));
+    expect(actual.visible).toEqual(true);
+    expect(actual.title).toEqual('Warning');
+    expect(actual.message).toEqual('Are you sure?');
+    expect(actual.onConfirm).toBe(mockPayload.onConfirm);
+    expect(actual.onCancel).toBe(mockPayload.onCancel);
+  });
+
+  it('should handle showAlert without optional callbacks', () => {
+    const mockPayload = {
+      title: 'Success',
+      message: 'Operation completed',
+    };
+
+    const actual = reducer(initialState, showAlert(mockPayload));
+    expect(actual.visible).toEqual(true);
+    expect(actual.title).toEqual('Success');
+    expect(actual.message).toEqual('Operation completed');
+    expect(actual.onConfirm).toBeNull();
+    expect(actual.onCancel).toBeNull();
+  });
+
+  it('should handle hideAlert', () => {
+    const visibleState = {
+      visible: true,
+      title: 'Warning',
+      message: 'Are you sure?',
+      onConfirm: () => {},
+      onCancel: () => {},
+    };
+
+    const actual = reducer(visibleState, hideAlert());
+    expect(actual).toEqual(initialState);
+  });
+});

--- a/frontend/src/store/__tests__/dataSlice.test.ts
+++ b/frontend/src/store/__tests__/dataSlice.test.ts
@@ -1,0 +1,146 @@
+import reducer, {
+  setFilteredArticles,
+  setSearchedArticles,
+  setSelectedTags,
+  setSortType,
+  setSearchMode,
+  setArticle,
+  setTags,
+  setSuggestion,
+  setSuggestionAccepted,
+  setSelectePodcastCategories,
+  setPodcasts,
+  appendPodcasts,
+  setaddedPodcastId,
+  setRemovePlaylistId,
+} from '../dataSlice';
+
+describe('dataSlice reducers', () => {
+  const defaultArticle = {
+    _id: '',
+    title: '',
+    authorName: '',
+    authorId: '',
+    content: '',
+    summary: '',
+    tags: [],
+    lastUpdated: '',
+    imageUtils: [],
+    viewCount: 0,
+    description: '',
+    viewUsers: [],
+    repostUsers: [],
+    likeCount: 0,
+    likedUsers: [],
+    savedUsers: [],
+    mentionedUsers: [],
+    assigned_date: null,
+    discardReason: '',
+    status: '',
+    reviewer_id: undefined,
+    contributors: [],
+    pb_recordId: '',
+    language: "en-IN"
+  };
+
+  const initialState = {
+    filteredArticles: [],
+    searchedArticles: [],
+    selectedTags: [],
+    sortType: '',
+    searchMode: false,
+    article: defaultArticle,
+    categories: [],
+    articleContent: '',
+    suggestion: '',
+    suggestionAccepted: false,
+    selectedPodcastCategories: [],
+    podcasts: [],
+    addedPodcastId: '',
+    removePlaylistId: '',
+  };
+
+  it('should return the initial state', () => {
+    // @ts-ignore
+    expect(reducer(undefined, { type: 'unknown' })).toEqual(initialState);
+  });
+
+  it('should handle setFilteredArticles', () => {
+    const mockArticles = [{ _id: '1', title: 'Test' }];
+    const actual = reducer(initialState, setFilteredArticles({ filteredArticles: mockArticles }));
+    expect(actual.filteredArticles).toEqual(mockArticles);
+  });
+
+  it('should handle setSearchedArticles', () => {
+    const mockArticles = [{ _id: '2', title: 'Test Search' }];
+    const actual = reducer(initialState, setSearchedArticles({ searchedArticles: mockArticles }));
+    expect(actual.searchedArticles).toEqual(mockArticles);
+  });
+
+  it('should handle setSelectedTags', () => {
+    const mockTags = [{ name: 'Health' }];
+    const actual = reducer(initialState, setSelectedTags({ selectedTags: mockTags }));
+    expect(actual.selectedTags).toEqual(mockTags);
+  });
+
+  it('should handle setSortType', () => {
+    const actual = reducer(initialState, setSortType({ sortType: 'recent' }));
+    expect(actual.sortType).toEqual('recent');
+  });
+
+  it('should handle setSearchMode', () => {
+    const actual = reducer(initialState, setSearchMode({ searchMode: true }));
+    expect(actual.searchMode).toEqual(true);
+  });
+
+  it('should handle setArticle', () => {
+    const newArticle = { ...defaultArticle, title: 'New Article' };
+    const actual = reducer(initialState, setArticle({ article: newArticle }));
+    expect(actual.article).toEqual(newArticle);
+  });
+
+  it('should handle setTags', () => {
+    const tags = [{ name: 'Tech' }];
+    const actual = reducer(initialState, setTags({ tags }));
+    expect(actual.categories).toEqual(tags);
+  });
+
+  it('should handle setSuggestion', () => {
+    const actual = reducer(initialState, setSuggestion({ suggestion: 'Great post!' }));
+    expect(actual.suggestion).toEqual('Great post!');
+  });
+
+  it('should handle setSuggestionAccepted', () => {
+    const actual = reducer(initialState, setSuggestionAccepted({ selection: true }));
+    expect(actual.suggestionAccepted).toEqual(true);
+  });
+
+  it('should handle setSelectePodcastCategories', () => {
+    const categories = ['Tech', 'Health'];
+    const actual = reducer(initialState, setSelectePodcastCategories(categories));
+    expect(actual.selectedPodcastCategories).toEqual(categories);
+  });
+
+  it('should handle setPodcasts', () => {
+    const mockPodcasts = [{ _id: 'pod1' }];
+    const actual = reducer(initialState, setPodcasts(mockPodcasts));
+    expect(actual.podcasts).toEqual(mockPodcasts);
+  });
+
+  it('should handle appendPodcasts', () => {
+    const mockState = { ...initialState, podcasts: [{ _id: 'pod1' } as any] };
+    const actual = reducer(mockState, appendPodcasts([{ _id: 'pod2' }]));
+    expect(actual.podcasts.length).toEqual(2);
+    expect(actual.podcasts[1]._id).toEqual('pod2');
+  });
+
+  it('should handle setaddedPodcastId', () => {
+    const actual = reducer(initialState, setaddedPodcastId('pod123'));
+    expect(actual.addedPodcastId).toEqual('pod123');
+  });
+
+  it('should handle setRemovePlaylistId', () => {
+    const actual = reducer(initialState, setRemovePlaylistId('playlist456'));
+    expect(actual.removePlaylistId).toEqual('playlist456');
+  });
+});


### PR DESCRIPTION
Closes #673 

Hey @SB2318! I have implemented full unit test coverage for the core Redux slices as requested.

### Changes Made:
- Created a `__tests__` directory under `src/store`
- Wrote 100% pure test coverage for:
  - `UserSlice.test.ts` (Validates token setting, handle updates, guest mode toggles, and state resets)
  - `dataSlice.test.ts` (Validates article filtering, tags, suggestions, and podcast slice appends)
  - `alertSlice.test.ts` (Validates UI overlay state transitions)
  - `NetworkSlice.test.ts` (Validates connectivity booleans)
- **Bonus Fix:** Fixed a pre-existing failing test in `GlassButton.test.tsx` by adding the missing `testID="loading-spinner"` to the `ActivityIndicator` component so Jest can properly find it during the loading state assertion.
- Added `immer` and `@reduxjs` to `transformIgnorePatterns` in `jest.config.js` to fix the ESModule parsing errors that prevented the test suites from running.

### Verification
All 37 test suites pass perfectly locally. Let me know if you need any adjustments!