### PR TITLE
feat: add smooth scrolling and active navigation highlight

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -208,6 +208,12 @@ body {
 .nav-links a:hover::after {
   width: 100%;
 }
+.nav-links a.active {
+  color: var(--primary);
+}
+.nav-links a.active::after {
+  width: 100%;
+}
 
 .nav-btn-sm {
   background: var(--gradient-primary);

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -72,8 +72,8 @@ export default function Home() {
   }, []);
 
   // Active section tracking via IntersectionObserver
+  const sectionIds = ["screenshots", "features", "programs", "contact"];
   useEffect(() => {
-    const sectionIds = ["downloads", "screenshots", "features", "programs", "contact"];
 
     const visibleSections = new Set<string>();
 
@@ -87,7 +87,9 @@ export default function Home() {
           }
         });
 
-        // Pick the section closest to top of viewport among visible ones
+        // Pick the section closest to top of viewport among visible ones.
+        // Sorts by absolute distance of section's top edge from viewport top (0),
+        // so whichever section is nearest the top of the screen wins.
         if (visibleSections.size > 0) {
           const topSection = sectionIds
             .filter((id) => visibleSections.has(id))
@@ -189,11 +191,11 @@ export default function Home() {
             Ultimate-Health
           </a>
           <ul className="nav-links">
-            <li><a href="#screenshots" className={activeSection === "screenshots" ? "active" : ""}>Screenshots</a></li>
-            <li><a href="#features" className={activeSection === "features" ? "active" : ""}>Features</a></li>
-            <li><a href="#programs" className={activeSection === "programs" ? "active" : ""}>Programs</a></li>
+            <li><a href="#screenshots" className={activeSection === "screenshots" ? "active" : ""} aria-current={activeSection === "screenshots" ? "location" : undefined}>Screenshots</a></li>
+            <li><a href="#features" className={activeSection === "features" ? "active" : ""} aria-current={activeSection === "features" ? "location" : undefined}>Features</a></li>
+            <li><a href="#programs" className={activeSection === "programs" ? "active" : ""} aria-current={activeSection === "programs" ? "location" : undefined}>Programs</a></li>
             <li><a href="https://uhsocial.in/docs" target="_blank" rel="noreferrer">Documentation</a></li>
-            <li><a href="#contact" className={activeSection === "contact" ? "active" : ""}>Contact</a></li>
+            <li><a href="#contact" className={activeSection === "contact" ? "active" : ""} aria-current={activeSection === "contact" ? "location" : undefined}>Contact</a></li>
             <li><a href="#downloads" className="nav-btn-sm">Downloads</a></li>
           </ul>
           <button

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -34,6 +34,8 @@ const adminScreenshots = [
 
 const allScreenshots = [...userScreenshots, ...adminScreenshots];
 
+const TRACKED_SECTION_IDS = ["screenshots", "features", "programs", "contact"];
+
 export default function Home() {
   const [scrolled, setScrolled] = useState(false);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
@@ -72,7 +74,6 @@ export default function Home() {
   }, []);
 
   // Active section tracking via IntersectionObserver
-  const sectionIds = ["screenshots", "features", "programs", "contact"];
   useEffect(() => {
 
     const visibleSections = new Set<string>();
@@ -91,7 +92,7 @@ export default function Home() {
         // Sorts by absolute distance of section's top edge from viewport top (0),
         // so whichever section is nearest the top of the screen wins.
         if (visibleSections.size > 0) {
-          const topSection = sectionIds
+          const topSection = TRACKED_SECTION_IDS
             .filter((id) => visibleSections.has(id))
             .map((id) => ({ id, top: document.getElementById(id)?.getBoundingClientRect().top ?? Infinity }))
             .sort((a, b) => Math.abs(a.top) - Math.abs(b.top))[0];
@@ -103,7 +104,7 @@ export default function Home() {
       { threshold: 0.3 }
     );
 
-    sectionIds.forEach((id) => {
+    TRACKED_SECTION_IDS.forEach((id) => {
       const el = document.getElementById(id);
       if (el) observer.observe(el);
     });

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -45,6 +45,7 @@ export default function Home() {
   const [currentScreenshot, setCurrentScreenshot] = useState(0);
   const [userSliderOpen, setUserSliderOpen] = useState(true);
   const [adminSliderOpen, setAdminSliderOpen] = useState(false);
+  const [activeSection, setActiveSection] = useState<string>("");
 
   const userSliderRef = useRef<HTMLDivElement>(null);
   const adminSliderRef = useRef<HTMLDivElement>(null);
@@ -68,6 +69,29 @@ export default function Home() {
     );
     document.querySelectorAll(".fade-in").forEach((el) => observer.observe(el));
     return () => observer.disconnect();
+  }, []);
+
+  // Active section tracking via IntersectionObserver
+  useEffect(() => {
+    const sectionIds = ["downloads", "screenshots", "features", "programs", "contact"];
+    const observers: IntersectionObserver[] = [];
+
+    sectionIds.forEach((id) => {
+      const el = document.getElementById(id);
+      if (!el) return;
+      const observer = new IntersectionObserver(
+        (entries) => {
+          entries.forEach((entry) => {
+            if (entry.isIntersecting) setActiveSection(id);
+          });
+        },
+        { threshold: 0.4 }
+      );
+      observer.observe(el);
+      observers.push(observer);
+    });
+
+    return () => observers.forEach((o) => o.disconnect());
   }, []);
 
   // Keyboard nav for screenshot modal
@@ -150,11 +174,11 @@ export default function Home() {
             Ultimate-Health
           </a>
           <ul className="nav-links">
-            <li><a href="#features">Features</a></li>
-            <li><a href="#screenshots">Screenshots</a></li>
-            <li><a href="#programs">Programs</a></li>
+            <li><a href="#features" className={activeSection === "features" ? "active" : ""}>Features</a></li>
+            <li><a href="#screenshots" className={activeSection === "screenshots" ? "active" : ""}>Screenshots</a></li>
+            <li><a href="#programs" className={activeSection === "programs" ? "active" : ""}>Programs</a></li>
             <li><a href="https://uhsocial.in/docs" target="_blank" rel="noreferrer">Documentation</a></li>
-            <li><a href="#contact">Contact</a></li>
+            <li><a href="#contact" className={activeSection === "contact" ? "active" : ""}>Contact</a></li>
             <li><a href="#downloads" className="nav-btn-sm">Downloads</a></li>
           </ul>
           <button

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -74,24 +74,39 @@ export default function Home() {
   // Active section tracking via IntersectionObserver
   useEffect(() => {
     const sectionIds = ["downloads", "screenshots", "features", "programs", "contact"];
-    const observers: IntersectionObserver[] = [];
+
+    const visibleSections = new Set<string>();
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            visibleSections.add(entry.target.id);
+          } else {
+            visibleSections.delete(entry.target.id);
+          }
+        });
+
+        // Pick the section closest to top of viewport among visible ones
+        if (visibleSections.size > 0) {
+          const topSection = sectionIds
+            .filter((id) => visibleSections.has(id))
+            .map((id) => ({ id, top: document.getElementById(id)?.getBoundingClientRect().top ?? Infinity }))
+            .sort((a, b) => Math.abs(a.top) - Math.abs(b.top))[0];
+          if (topSection) setActiveSection(topSection.id);
+        } else {
+          setActiveSection("");
+        }
+      },
+      { threshold: 0.3 }
+    );
 
     sectionIds.forEach((id) => {
       const el = document.getElementById(id);
-      if (!el) return;
-      const observer = new IntersectionObserver(
-        (entries) => {
-          entries.forEach((entry) => {
-            if (entry.isIntersecting) setActiveSection(id);
-          });
-        },
-        { threshold: 0.4 }
-      );
-      observer.observe(el);
-      observers.push(observer);
+      if (el) observer.observe(el);
     });
 
-    return () => observers.forEach((o) => o.disconnect());
+    return () => observer.disconnect();
   }, []);
 
   // Keyboard nav for screenshot modal
@@ -174,8 +189,8 @@ export default function Home() {
             Ultimate-Health
           </a>
           <ul className="nav-links">
-            <li><a href="#features" className={activeSection === "features" ? "active" : ""}>Features</a></li>
             <li><a href="#screenshots" className={activeSection === "screenshots" ? "active" : ""}>Screenshots</a></li>
+            <li><a href="#features" className={activeSection === "features" ? "active" : ""}>Features</a></li>
             <li><a href="#programs" className={activeSection === "programs" ? "active" : ""}>Programs</a></li>
             <li><a href="https://uhsocial.in/docs" target="_blank" rel="noreferrer">Documentation</a></li>
             <li><a href="#contact" className={activeSection === "contact" ? "active" : ""}>Contact</a></li>
@@ -191,8 +206,8 @@ export default function Home() {
           </button>
         </div>
         <nav className={`mobile-nav${mobileMenuOpen ? " open" : ""}`}>
-          <a href="#features" onClick={() => setMobileMenuOpen(false)}>Features</a>
           <a href="#screenshots" onClick={() => setMobileMenuOpen(false)}>Screenshots</a>
+          <a href="#features" onClick={() => setMobileMenuOpen(false)}>Features</a>
           <a href="#programs" onClick={() => setMobileMenuOpen(false)}>Programs</a>
           <a href="https://uhsocial.in/docs" target="_blank" rel="noreferrer">Documentation</a>
           <a href="#contact" onClick={() => setMobileMenuOpen(false)}>Contact</a>


### PR DESCRIPTION
## PR Description
Implements smooth scrolling and active navigation highlight for the landing page navbar as requested in #698.

`scroll-behavior: smooth` was already present in `globals.css`, so smooth scrolling was handled via CSS. The main addition is an `IntersectionObserver`-based active section tracker that dynamically highlights the corresponding navbar link as the user scrolls — zero dependencies, lightweight native browser API solution.

Also reordered navbar links to match the actual page section order (Screenshots → Features → Programs → Contact) for consistent highlight behavior.

## Type of Change
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Documentation update

## Select your work-area
- [x] Frontend
- [ ] Backend
- [ ] Documentation
- [ ] Others

## Related Issue
Closes #698

## Add your Work Example

| Section | Active Highlight |
|---------|-----------------|
| Screenshots | <img width="1451" height="840" alt="image" src="https://github.com/user-attachments/assets/7193141e-7eca-4f93-947f-fc6fb042d717" /> |
| Features | <img width="1444" height="840" alt="image" src="https://github.com/user-attachments/assets/d0cc0e7d-37fb-4822-8b4c-d3f77ed4d1f5" /> |
| Programs | <img width="1447" height="840" alt="image" src="https://github.com/user-attachments/assets/83d1425d-b3e7-4480-9283-e68d4ba18084" /> |
| Contact |<img width="1445" height="840" alt="image" src="https://github.com/user-attachments/assets/5db2bd72-50d0-4cb3-b31b-959f7d4b2951" /> |

> **Note:** "Documentation" is an external link to `uhsocial.in/docs` and is not a page section, so it is intentionally not tracked or highlighted.

## Fixes
Closes #698

## Checklist
- [x] I have updated my branch and synced it with the project's 'develop' branch before making this PR.
- [x] I have optimized the file changes.
- [x] I have added a snapshot of my work example.
- [x] I have made a PR to the project's develop branch.

## Undertaking
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have checked for plagiarism and assure its authenticity.
- [x] I have read and followed the code of conduct for this repository. I understand that violation of this undertaking may have legal consequences.
- [x] I Agree