### PR TITLE
fix: add accessible labels to social icon links in footer

### DIFF
--- a/frontend/src/screens/AboutPage.tsx
+++ b/frontend/src/screens/AboutPage.tsx
@@ -244,6 +244,7 @@ const AboutScreen = ({ navigation }: AboutScreenProps) => {
             <XStack gap="$4">
               <SocialCircle
                 icon="github"
+                accessibilityLabel="GitHub"
                 onPress={() =>
                   openLink('https://github.com/SB2318/UltimateHealth')
                 }
@@ -252,6 +253,7 @@ const AboutScreen = ({ navigation }: AboutScreenProps) => {
 
               <SocialCircle
                 icon="linkedin"
+                accessibilityLabel="LinkedIn"
                 onPress={() =>
                   openLink('https://linkedin.com/in/ultimate-health-9290873a8/')
                 }
@@ -260,6 +262,7 @@ const AboutScreen = ({ navigation }: AboutScreenProps) => {
 
               <SocialCircle
                 icon="envelope"
+                accessibilityLabel="Email"
                 onPress={() => openLink('mailto:ultimate.health25@gmail.com')}
                 isDarkMode={isDarkMode}
               />
@@ -359,14 +362,17 @@ const SocialCircle = ({
   icon,
   onPress,
   isDarkMode,
+  accessibilityLabel,
 }: {
   icon: string;
   onPress: () => void;
   isDarkMode: boolean;
+  accessibilityLabel?: string;
 }) => (
   <Button
     circular
     size="$5"
+    accessibilityLabel={accessibilityLabel}
     backgroundColor={isDarkMode ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.05)'}
     borderWidth={1}
     borderColor={isDarkMode ? 'rgba(255, 255, 255, 0.2)' : 'rgba(0, 0, 0, 0.1)'}


### PR DESCRIPTION
#### PR Description

The social icon buttons (GitHub, LinkedIn, Email) in the About page footer are icon-only with no accessible labels, making them invisible to screen readers. This adds `accessibilityLabel` to each button via the `SocialCircle` component.

#### Type of Change
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update

#### Select your work-area
- [x] Frontend
- [ ] Backend
- [ ] Documentation
- [ ] Others

#### Related Issue
Closes #913

#### Add your Work Example
No visual change — the buttons work identically, but screen readers now announce "GitHub", "LinkedIn", "Email" instead of silent.

#### Fixes
Closes #913

#### Checklist
- [x] I have updated my branch and synced it with the project main branch before making this PR.
- [x] I have optimized the file changes.
- [ ] I have added a snapshot of my work example.
- [x] I have made a PR to the project main branch.

#### Undertaking
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have checked for plagiarism and assure its authenticity.
- [x] I have read and followed the code of conduct for this repository. I understand that violation of this undertaking may have legal consequences.
- [x] I Agree