### PR TITLE
fix: most viewed articles query never executes due to contradictory enabled condition

### DIFF
--- a/frontend/src/hooks/useGetMostViewedArticle.ts
+++ b/frontend/src/hooks/useGetMostViewedArticle.ts
@@ -27,6 +27,6 @@ export const useGetAuthorMostViewedArticles = ({
       return response.data as ArticleData[];
     },
 
-    enabled: !!isConnected && !!(!userId && others) && !!(!user_id && !others),
+    enabled: !!isConnected && ((others && !!userId) || (!others && !!user_id)),
   });
 };


### PR DESCRIPTION
## Summary

The `enabled` condition in `useGetAuthorMostViewedArticles` was:

```ts
enabled: !!isConnected && !!(!userId && others) && !!(!user_id && !others)
```

This requires `others` to be simultaneously `true` (sub-condition 2) AND `false` (sub-condition 3) — a logical impossibility. As a result, the query is permanently disabled and the "Most Viewed Articles" section in Activity Overview always shows empty.

**Fix:** Changed to:
```ts
enabled: !!isConnected && ((others && !!userId) || (!others && !!user_id))
```

This correctly enables the query when `isConnected` is true AND either:
- `others=true` with a valid `userId`, OR
- `others=false` with a valid `user_id`

Fixes #935
