### PR TITLE
fix: make Gmail button open mail client with pre filled recipient

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -786,9 +786,14 @@ export default function Home() {
                 <a href="https://github.com/SB2318" className="dark-social-icon" target="_blank" rel="noreferrer" title="GitHub" aria-label="GitHub">
                   <i className="fab fa-github"></i>
                 </a>
-                <a href="mailto:ultimate.health25@gmail.com" className="dark-social-icon" title="Email" aria-label="Email">
-                  <i className="fas fa-envelope"></i>
-                </a>
+               <a
+                 href="mailto:ultimate.health25@gmail.com?subject=Hello%20UltimateHealth&body=Hi%20UltimateHealth%20Team%2C"
+                 className="dark-social-icon"
+                 title="Email"
+                 aria-label="Send email to UltimateHealth via mail client"
+                 style={{ cursor: "pointer" }}>
+                 <i className="fas fa-envelope"></i>
+                 </a>
                 <a href="https://www.linkedin.com/in/ultimate-health-9290873a8/" className="dark-social-icon" target="_blank" rel="noreferrer" title="LinkedIn" aria-label="LinkedIn">
                   <i className="fab fa-linkedin-in"></i>
                 </a>


### PR DESCRIPTION
#### PR Description
Fixed the Gmail/email button on the Contact page which was not functioning correctly. The anchor tag was missing a proper mailto: link with pre-filled recipient and subject. Updated the href to include mailto:ultimate.health25@gmail.com with a pre-filled subject and body so clicking the button directly opens the user's default mail client with the recipient already filled in.

#### Type of Change
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update

#### Select your work-area
- [x] Frontend
- [ ] Backend
- [ ] Documentation
- [ ] Others

#### Related Issue

https://github.com/SB2318/UltimateHealth/issues/941

#### Add your Work Example

<img width="667" height="61" alt="Screenshot 2026-06-01 193123" src="https://github.com/user-attachments/assets/41f57344-d234-4721-9000-6a64995d500b" />

#### Fixes (mention the issue number which this fixes)
#941 

#### Checklist
- [x] I have updated my branch and synced it with the project's 'develop' branch before making this PR.
- [x] I have optimized the file changes.
- [x] I have added a snapshot of my work example.
- [x] I have made a PR to the project's develop branch.

#### Undertaking
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [] I have made corresponding changes to the documentation.
- [x] I have checked for plagiarism and assure its authenticity.
- [x] I have read and followed the code of conduct for this repository. I understand that violation of this undertaking may have legal consequences.

- [x] I Agree
