### PR TITLE
fix: remove duplicate Font Awesome CDN link in favor of local import

### DIFF
--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -34,23 +34,10 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
-  return (<html lang="en" className={inter.variable}>
-  <head>
-    <link
-      rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"
-    />
-  </head>
-  <body>{children}</body>
-</html>
-}>) {
+
   return (
     <html lang="en" className={cn("font-sans", dmSans.variable, interHeading.variable)}>
       <head>
-        <link
-          rel="stylesheet"
-          href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"
-        />
       </head>
       <body className={`${inter.className} antialiased`}><TooltipProvider>{children}</TooltipProvider></body>
     </html>


### PR DESCRIPTION
Closes #983

## Description
Removes the duplicate Font Awesome CDN stylesheet link from layout.tsx. The local import via \@fortawesome/fontawesome-free/css/all.min.css\ is already present and preferred.

## Changes
- Removed redundant CDN \<link>\ from \<head>\
- Fixed corrupted JSX structure (double return from bad merge)
- Kept local npm import of fontawesome CSS