### PR TITLE
fix: add aria-label to mobile hamburger menu button

### DIFF
--- a/frontend/src/components/HomeScreenHeader.tsx
+++ b/frontend/src/components/HomeScreenHeader.tsx
@@ -44,7 +44,7 @@ import { StatusBar } from 'expo-status-bar';
               <Ionicons name="refresh" size={20} color={'#FF5252'} />
             </Button>
           ) : null}
-          <Button unstyled onPress={handlePresentModalPress}>
+          <Button unstyled onPress={handlePresentModalPress} aria-label="Open navigation menu">
             <AntDesign name="menu-fold" size={20} color={'#191C1B'} />
           </Button>
         </XStack>


### PR DESCRIPTION
The hamburger menu toggle on mobile was an icon-only button with no accessible label. Added aria-label="Open navigation menu" so screen readers can identify its purpose.

Closes #978