### PR TITLE
feat: add GlossaryTooltip component for medical term definitions (#1012)

### DIFF
--- a/web/src/components/ui/glossary-tooltip.tsx
+++ b/web/src/components/ui/glossary-tooltip.tsx
@@ -1,0 +1,80 @@
+"use client"
+
+import * as React from "react"
+import { Popover as PopoverPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+interface GlossaryTooltipProps {
+  term: string
+  definition: string
+  children: React.ReactNode
+  className?: string
+}
+
+function GlossaryTooltip({ term, definition, children, className }: GlossaryTooltipProps) {
+  const [open, setOpen] = React.useState(false)
+  const closeTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const handleOpen = () => {
+    if (closeTimerRef.current) {
+      clearTimeout(closeTimerRef.current)
+      closeTimerRef.current = null
+    }
+    setOpen(true)
+  }
+
+  const handleClose = () => {
+    closeTimerRef.current = setTimeout(() => setOpen(false), 150)
+  }
+
+  React.useEffect(() => {
+    return () => {
+      if (closeTimerRef.current) clearTimeout(closeTimerRef.current)
+    }
+  }, [])
+
+  return (
+    <PopoverPrimitive.Root open={open} onOpenChange={setOpen}>
+      <PopoverPrimitive.Trigger
+        data-slot="glossary-tooltip-trigger"
+        onMouseEnter={handleOpen}
+        onMouseLeave={handleClose}
+        className={cn(
+          "inline cursor-help rounded-sm underline decoration-dotted",
+          "decoration-blue-500 underline-offset-2 text-blue-700",
+          "dark:text-blue-400 dark:decoration-blue-400",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+          className
+        )}
+      >
+        {children}
+      </PopoverPrimitive.Trigger>
+      <PopoverPrimitive.Portal>
+        <PopoverPrimitive.Content
+          data-slot="glossary-tooltip-content"
+          sideOffset={6}
+          onMouseEnter={handleOpen}
+          onMouseLeave={handleClose}
+          className={cn(
+            "z-50 w-72 max-h-48 overflow-y-auto rounded-lg",
+            "origin-(--radix-popover-content-transform-origin)",
+            "bg-popover p-3 text-sm text-popover-foreground",
+            "shadow-md ring-1 ring-foreground/10 outline-hidden duration-100",
+            "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2",
+            "data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+            "data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95",
+            "data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95"
+          )}
+          role="dialog"
+          aria-label={`Definition of ${term}`}
+        >
+          <p className="font-semibold text-foreground mb-1">{term}</p>
+          <p className="text-muted-foreground leading-relaxed">{definition}</p>
+        </PopoverPrimitive.Content>
+      </PopoverPrimitive.Portal>
+    </PopoverPrimitive.Root>
+  )
+}
+
+export { GlossaryTooltip }


### PR DESCRIPTION
Fixes #1012

## What's added

A `GlossaryTooltip` component (`web/src/components/ui/glossary-tooltip.tsx`) that wraps medical terms in articles so readers can see a definition without leaving the page.

Built on the Radix UI `Popover` primitive which is already in the project's dependencies, and follows the same patterns as the other shadcn/ui components in `web/src/components/ui/`.

## How it works

On desktop, hovering over a term opens the tooltip. There's a small 150ms delay before it closes so you can move your cursor onto the tooltip itself without it disappearing on you. On mobile, tap to open, tap again or tap outside to close.

Keyboard users can tab to the term and use Enter/Space to toggle, Escape to close. Long definitions scroll inside the tooltip rather than overflowing.

## Usage

`	sx
import { GlossaryTooltip } from "@/components/ui/glossary-tooltip"

<p>
  Patients with{" "}
  <GlossaryTooltip
    term="Hypertension"
    definition="A condition in which blood pressure remains consistently high."
  >
    hypertension
  </GlossaryTooltip>{" "}
  should monitor their sodium intake.
</p>
`

## Testing checklist

- [ ] Hover over term — tooltip opens and stays open when cursor moves onto the content
- [ ] Move cursor away — tooltip closes after the brief delay
- [ ] Tap on mobile — toggles open/closed
- [ ] Tab to focus, Enter to open, Escape to close
- [ ] Paste in a long definition — content scrolls inside the tooltip
- [ ] Reposition near a viewport edge — Radix repositions it automatically
- [ ] Check in dark mode