### PR TITLE
fix: standardize icon sizing inside Badge component

### DIFF
--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -23,12 +23,24 @@ const sizeClasses: Record<BadgeSize, string> = {
   md: "px-3.5 py-1 text-sm",
 };
 
+const iconSizeClasses: Record<BadgeSize, string> = {
+  sm: "w-3 h-3",
+  md: "w-4 h-4",
+};
+
 const Badge = ({ label, variant = "default", size = "md", icon }: BadgeProps) => {
   return (
     <span
       className={`inline-flex items-center gap-1.5 rounded-full font-medium transition-all duration-200 ${variantClasses[variant]} ${sizeClasses[size]}`}
     >
-      {icon && <span className="flex-shrink-0">{icon}</span>}
+      {icon && (
+        <span
+          className={`inline-flex items-center justify-center shrink-0 text-current ${iconSizeClasses[size]}`}
+          aria-hidden="true"
+        >
+          {icon}
+        </span>
+      )}
       {label}
     </span>
   );

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -48,7 +48,6 @@ const iconSizeClasses: Record<BadgeSize, string> = {
   md: "w-4 h-4",
 };
 
-const Badge = ({ label, variant = "default", size = "md", icon }: BadgeProps) => {
 const interactiveClasses =
   "focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-current disabled:cursor-not-allowed disabled:opacity-60";
 
@@ -68,16 +67,24 @@ const getBadgeClasses = (
     .filter(Boolean)
     .join(" ");
 
-const renderBadgeContent = (
-  icon: React.ReactNode,
-  children: React.ReactNode,
-  label?: string
-) => {
-  const content = children ?? label;
+const Badge = (props: BadgeProps) => {
+  const {
+    as: Component = "span",
+    label,
+    children,
+    variant = "default",
+    size = "md",
+    icon,
+    className = "",
+    ...restProps
+  } = props as BadgeSpanProps & BadgeButtonProps & BadgeAnchorProps;
+
+  const isInteractive = Component === "button" || Component === "a";
 
   return (
-    <span
-      className={`inline-flex items-center gap-1.5 rounded-full font-medium transition-colors ${variantClasses[variant]} ${sizeClasses[size]}`}
+    <Component
+      className={getBadgeClasses(variant, size, isInteractive, className)}
+      {...restProps}
     >
       {icon && (
         <span
@@ -87,8 +94,8 @@ const renderBadgeContent = (
           {icon}
         </span>
       )}
-      {label}
-    </span>
+      {children ?? label}
+    </Component>
   );
 };
 


### PR DESCRIPTION
## Description
Fixes inconsistent icon sizing inside the Badge component.

Followed by PR #976

## Changes
- Added `iconSizeClasses` map to standardize icon sizing based on badge size
  - `sm → w-3 h-3`
  - `md → w-4 h-4`
- Wrapped icon in `<span>` with `inline-flex items-center justify-center`
- Added `text-current` so icon inherits badge text color automatically
- Added `shrink-0` to prevent icon from being squeezed
- Added `aria-hidden="true"` since icon is decorative

## Impact
- Icons now auto-size and color without consumer-side styling
- Consistent appearance across all badge variants and sizes

Closes #994