### PR TITLE
refactor: remove unused user_id from useGetAuthorMostViewedArticles

### DIFF
--- a/frontend/src/components/ActivityOverview.tsx
+++ b/frontend/src/components/ActivityOverview.tsx
@@ -150,7 +150,6 @@ const ActivityOverview = ({
   // GET MOST VIEWED ARTICLE
   const {data: article, isLoading: isArticleLoading} =
     useGetAuthorMostViewedArticles({
-      user_id: user_id,
       userId: userId,
       others: others,
       isConnected: isConnected,

--- a/frontend/src/hooks/useGetMostViewedArticle.ts
+++ b/frontend/src/hooks/useGetMostViewedArticle.ts
@@ -4,17 +4,15 @@ import {ArticleData} from '../type';
 import {GET_MOSTLY_VIEWED} from '../helper/APIUtils';
 
 export const useGetAuthorMostViewedArticles = ({
-  user_id,
   userId,
   others,
   isConnected,
 }: {
-  user_id: string;
   userId?: string;
   others?: boolean;
   isConnected?: boolean;
 }): UseQueryResult<ArticleData[]> => {
-  const targetUserId = others ? userId : user_id;
+  const targetUserId = userId;
 
   return useQuery<ArticleData[]>({
     queryKey: ['get-mostly-viewed-article', targetUserId, others],


### PR DESCRIPTION
### Description

This PR removes the unused `user_id` parameter from the `useGetAuthorMostViewedArticles` hook.

### Changes Made

* Removed the unused `user_id` parameter from the hook signature.
* Removed the corresponding type definition.
* Updated `ActivityOverview.tsx` to use the updated hook signature.
* No functional behavior was changed.

#### Type of Change

* [x] Documentation update

#### Select your work-area

* [x] Frontend

#### Fixes #991

#### Checklist

* [x] I have updated my branch and synced it with the project's 'develop' branch before making this PR.
* [x] I have optimized the file changes.
* [x] I have made a PR to the project's develop branch.

#### Undertaking

* [x] My code follows the style guidelines of this project.
* [x] I have performed a self-review of my code.
* [x] I have checked for plagiarism and assure its authenticity.
* [x] I have read and followed the code of conduct for this repository. I understand that violation of this undertaking may have legal consequences.
