### PR TITLE
[Bug] Use stable keys for Most Viewed Articles list rendering (#990)

### DIFF
--- a/frontend/src/components/ActivityOverview.tsx
+++ b/frontend/src/components/ActivityOverview.tsx
@@ -687,7 +687,7 @@ const ActivityOverview = ({
 
           {mostViewedArticles.map((item: ArticleData) => (
             <Card
-              key={item.pb_recordId || item._id}
+              key={item.pb_recordId ?? item._id}
               elevate
               bordered
               borderWidth={0.6}


### PR DESCRIPTION
﻿Replaces array index keys with stable identifiers (item.pb_recordId with fallback item._id) in the Most Viewed Articles list rendering.

**Changes:**
- Changed key={index} to key={item.pb_recordId ?? item._id} in ActivityOverview.tsx

Closes #990
