### PR TITLE
[UI] Standardize icon sizing inside Badge component (#994)

### DIFF
--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -23,12 +23,17 @@ const sizeClasses: Record<BadgeSize, string> = {
   md: "px-3.5 py-1 text-sm",
 };
 
+const iconSizeClasses: Record<BadgeSize, string> = {
+  sm: "h-3 w-3",
+  md: "h-4 w-4",
+};
+
 const Badge = ({ label, variant = "default", size = "md", icon }: BadgeProps) => {
   return (
     <span
       className={`inline-flex items-center gap-1.5 rounded-full font-medium transition-all duration-200 ${variantClasses[variant]} ${sizeClasses[size]}`}
     >
-      {icon && <span className="flex-shrink-0">{icon}</span>}
+      {icon && <span className={`flex-shrink-0 text-current ${iconSizeClasses[size]}`}>{icon}</span>}
       {label}
     </span>
   );


### PR DESCRIPTION
﻿Standardizes icon sizing inside the Badge component by mapping icon dimensions to badge size variants.

**Changes:**
- Added iconSizeClasses record mapping sm → h-3 w-3 and md → h-4 w-4
- Icon wrapper now applies 	ext-current to inherit badge text color
- Consistent icon alignment and spacing across all badge variants

Closes #994
