### PR TITLE
fix: add accessible label to mobile hamburger menu

### DIFF
--- a/frontend/src/components/HomeScreenHeader.tsx
+++ b/frontend/src/components/HomeScreenHeader.tsx
@@ -44,7 +44,12 @@ import { StatusBar } from 'expo-status-bar';
               <Ionicons name="refresh" size={20} color={'#FF5252'} />
             </Button>
           ) : null}
-          <Button unstyled onPress={handlePresentModalPress}>
+          <Button
+            unstyled
+            onPress={handlePresentModalPress}
+            accessibilityLabel="Open navigation menu"
+            aria-label="Open navigation menu"
+          >
             <AntDesign name="menu-fold" size={20} color={'#191C1B'} />
           </Button>
         </XStack>


### PR DESCRIPTION
#### PR Description

This PR fixes the accessibility issue reported in #978 by adding an accessible label to the mobile hamburger menu button in the v2 frontend.

Previously, the button was icon-only and did not expose a descriptive label to screen readers, making it difficult for assistive technologies to identify its purpose.

### Changes Made

* Added `aria-label="Open navigation menu"` to the mobile hamburger menu button.
* Added `accessibilityLabel="Open navigation menu"` for accessibility support.
* Updated only the required component (`HomeScreenHeader.tsx`).
* No layout, styling, or functionality changes were made.

#### Type of Change

* [x] Bug fix (change which fixes an issue)
* [ ] New feature (change which adds functionality)
* [ ] Documentation update

#### Select your work-area

* [x] Frontend
* [ ] Backend
* [ ] Documentation
* [ ] Others

#### Related Issue

#978

#### Add your Work Example

📷 Add a screenshot showing the mobile menu button and/or browser inspection highlighting the added `aria-label`.

#### Fixes (mention the issue number which this fixes)

#closes #978

#### Checklist

* [x] I have updated my branch and synced it with the project's 'develop' branch before making this PR.
* [x] I have optimized the file changes.
* [ ] I have added a snapshot of my work example.
* [x] I have made a PR to the project's develop branch.

#### Undertaking

* [x] My code follows the style guidelines of this project.
* [x] I have performed a self-review of my code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have made corresponding changes to the documentation.
* [x] I have checked for plagiarism and assure its authenticity.
* [x] I have read and followed the code of conduct for this repository. I understand that violation of this undertaking may have legal consequences.

* [x] I Agree
