### PR TITLE
feat: add reusable glossary bottom sheet

### DIFF
--- a/frontend/src/components/GlossaryBottomSheet.tsx
+++ b/frontend/src/components/GlossaryBottomSheet.tsx
@@ -1,0 +1,155 @@
+import React, { useEffect, useState } from 'react';
+import { BackHandler } from 'react-native';
+import { Sheet } from '@tamagui/sheet';
+import {
+  Button,
+  Card,
+  Paragraph,
+  ScrollView,
+  Text,
+  XStack,
+  YStack,
+} from 'tamagui';
+import type { GlossaryTerm } from '../constants/glossary';
+
+export type GlossaryBottomSheetProps = GlossaryTerm & {
+  visible: boolean;
+  onClose: () => void;
+};
+
+export default function GlossaryBottomSheet({
+  visible,
+  term,
+  definition,
+  category,
+  relatedTerms = [],
+  onClose,
+}: GlossaryBottomSheetProps) {
+  const [open, setOpen] = useState(visible);
+
+  useEffect(() => {
+    setOpen(visible);
+  }, [visible]);
+
+  useEffect(() => {
+    if (!open) return undefined;
+
+    const subscription = BackHandler.addEventListener('hardwareBackPress', () => {
+      handleClose();
+      return true;
+    });
+
+    return () => subscription.remove();
+  }, [open]);
+
+  const handleClose = () => {
+    setOpen(false);
+    onClose();
+  };
+
+  const handleOpenChange = (isOpen: boolean) => {
+    setOpen(isOpen);
+    if (!isOpen) {
+      onClose();
+    }
+  };
+
+  return (
+    <Sheet
+      modal
+      open={open}
+      onOpenChange={handleOpenChange}
+      dismissOnSnapToBottom
+      dismissOnOverlayPress
+      snapPoints={[55, 35]}
+      animation="medium"
+      zIndex={100000}
+    >
+      <Sheet.Overlay
+        backgroundColor="rgba(15, 23, 42, 0.55)"
+        animation="quick"
+        enterStyle={{ opacity: 0 }}
+        exitStyle={{ opacity: 0 }}
+      />
+      <Sheet.Handle backgroundColor="$gray8" />
+      <Sheet.Frame
+        padding="$5"
+        backgroundColor="$background"
+        borderTopLeftRadius="$8"
+        borderTopRightRadius="$8"
+        accessibilityLabel={`Glossary definition for ${term}`}
+      >
+        <YStack gap="$4" width="100%">
+          <XStack alignItems="flex-start" justifyContent="space-between" gap="$4">
+            <YStack flex={1} gap="$2">
+              {!!category && (
+                <Text
+                  color="$blue10"
+                  fontSize={13}
+                  fontWeight="700"
+                  textTransform="uppercase"
+                  letterSpacing={0.8}
+                >
+                  {category}
+                </Text>
+              )}
+              <Text color="$color12" fontSize={26} fontWeight="800" lineHeight={32}>
+                {term}
+              </Text>
+            </YStack>
+
+            <Button
+              circular
+              size="$3"
+              onPress={handleClose}
+              accessibilityRole="button"
+              accessibilityLabel={`Close glossary definition for ${term}`}
+            >
+              <Text fontSize={20} fontWeight="700">
+                x
+              </Text>
+            </Button>
+          </XStack>
+
+          <ScrollView maxHeight={280} showsVerticalScrollIndicator>
+            <Card
+              bordered
+              elevate
+              padding="$4"
+              borderRadius="$6"
+              backgroundColor="$gray2"
+            >
+              <Paragraph color="$color11" fontSize={16} lineHeight={24}>
+                {definition}
+              </Paragraph>
+            </Card>
+
+            {relatedTerms.length > 0 && (
+              <YStack gap="$3" marginTop="$4">
+                <Text color="$color12" fontSize={16} fontWeight="700">
+                  Related terms
+                </Text>
+                <XStack gap="$2" flexWrap="wrap">
+                  {relatedTerms.map((relatedTerm) => (
+                    <Text
+                      key={relatedTerm}
+                      backgroundColor="$blue3"
+                      color="$blue11"
+                      borderRadius="$10"
+                      paddingHorizontal="$3"
+                      paddingVertical="$2"
+                      fontSize={13}
+                      fontWeight="600"
+                    >
+                      {relatedTerm}
+                    </Text>
+                  ))}
+                </XStack>
+              </YStack>
+            )}
+          </ScrollView>
+        </YStack>
+      </Sheet.Frame>
+    </Sheet>
+  );
+}

--- a/frontend/src/components/__tests__/GlossaryBottomSheet.test.tsx
+++ b/frontend/src/components/__tests__/GlossaryBottomSheet.test.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import GlossaryBottomSheet from '../GlossaryBottomSheet';
+import { testGlossaryTerms } from '../../constants/glossary';
+
+jest.mock('@tamagui/sheet', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+
+  const Sheet = ({ open, children }: { open: boolean; children: React.ReactNode }) =>
+    open ? <View>{children}</View> : null;
+
+  Sheet.Overlay = ({ children }: { children?: React.ReactNode }) => <View>{children}</View>;
+  Sheet.Handle = () => <View />;
+  Sheet.Frame = ({ children, ...props }: { children: React.ReactNode }) => (
+    <View {...props}>{children}</View>
+  );
+
+  return { Sheet };
+});
+
+describe('GlossaryBottomSheet', () => {
+  const glossaryTerm = testGlossaryTerms[0];
+
+  it('renders glossary term details when visible', () => {
+    const { getByText } = render(
+      <GlossaryBottomSheet
+        visible
+        term={glossaryTerm.term}
+        definition={glossaryTerm.definition}
+        category={glossaryTerm.category}
+        relatedTerms={glossaryTerm.relatedTerms}
+        onClose={jest.fn()}
+      />
+    );
+
+    expect(getByText('Hypertension')).toBeTruthy();
+    expect(getByText('Cardiology')).toBeTruthy();
+    expect(getByText(glossaryTerm.definition)).toBeTruthy();
+    expect(getByText('Blood pressure')).toBeTruthy();
+  });
+
+  it('does not render content while hidden', () => {
+    const { queryByText } = render(
+      <GlossaryBottomSheet
+        visible={false}
+        term={glossaryTerm.term}
+        definition={glossaryTerm.definition}
+        onClose={jest.fn()}
+      />
+    );
+
+    expect(queryByText('Hypertension')).toBeNull();
+  });
+
+  it('calls onClose from the accessible close button', () => {
+    const onClose = jest.fn();
+    const { getByLabelText } = render(
+      <GlossaryBottomSheet
+        visible
+        term={glossaryTerm.term}
+        definition={glossaryTerm.definition}
+        onClose={onClose}
+      />
+    );
+
+    fireEvent.press(getByLabelText('Close glossary definition for Hypertension'));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/constants/glossary.ts
+++ b/frontend/src/constants/glossary.ts
@@ -1,0 +1,23 @@
+export type GlossaryTerm = {
+  term: string;
+  definition: string;
+  category?: string;
+  relatedTerms?: string[];
+};
+
+export const testGlossaryTerms: GlossaryTerm[] = [
+  {
+    term: 'Hypertension',
+    definition:
+      'A condition in which blood pressure remains consistently elevated above the healthy range.',
+    category: 'Cardiology',
+    relatedTerms: ['Blood pressure', 'Heart health', 'Stroke risk'],
+  },
+  {
+    term: 'Glucose',
+    definition:
+      'A simple sugar that the body uses as a primary source of energy, especially after digestion.',
+    category: 'Metabolism',
+    relatedTerms: ['Diabetes', 'Insulin'],
+  },
+];


### PR DESCRIPTION
## Summary
- Adds a reusable Tamagui-based `GlossaryBottomSheet` mobile component for medical term definitions.
- Supports dynamic term, definition, optional category, related terms, backdrop dismissal, snap-to-close, close button, Android hardware back close, long-content scrolling, and accessibility labels.
- Adds test glossary JSON data for integration/demo use.
- Adds focused component tests for visible content, hidden state, and accessible close behavior.

Closes #1025

## Verification
- `git diff --check` ✅
- `npm ci` ⚠️ blocked because `frontend/package-lock.json` is already out of sync with `frontend/package.json` (Sentry, knip, and several React Native package specifier mismatches)
- `corepack pnpm install --frozen-lockfile` ⚠️ blocked because `frontend/pnpm-lock.yaml` is also out of sync with `frontend/package.json`
- Tried a no-lockfile local install only for verification, but the React Native workspace install exceeded the local timeout; no dependency or lockfile changes are included in this PR
