### PR TITLE
fix: Remove saved icon from article chip

### DIFF
--- a/frontend/src/screens/HomeScreen.tsx
+++ b/frontend/src/screens/HomeScreen.tsx
@@ -739,7 +739,7 @@ const HomeScreen = ({navigation}: HomeScreenProps) => {
                   ...styles.labelStyle,
                   color: showSavedOnly ? 'white' : '#4B5563',
                 }}>
-                🔖 Saved
+                Saved
               </Text>
             </TouchableOpacity>
           )}

--- a/frontend/src/screens/article/ArticleScreen.tsx
+++ b/frontend/src/screens/article/ArticleScreen.tsx
@@ -966,19 +966,6 @@ const ArticleScreen = ({navigation, route}: ArticleScreenProp) => {
               <LoadingSpinner size={18} />
             ) : (
               <>
-                <FontAwesome
-                  name={
-                    article?.savedUsers?.includes(user_id)
-                      ? 'bookmark'
-                      : 'bookmark-o'
-                  }
-                  size={18}
-                  color={
-                    article?.savedUsers?.includes(user_id)
-                      ? PRIMARY_COLOR
-                      : footerColors.text
-                  }
-                />
                 <Text
                   style={[
                     styles.actionTextFooter,

--- a/frontend/src/screens/article/ArticleScreen.tsx
+++ b/frontend/src/screens/article/ArticleScreen.tsx
@@ -966,6 +966,19 @@ const ArticleScreen = ({navigation, route}: ArticleScreenProp) => {
               <LoadingSpinner size={18} />
             ) : (
               <>
+                <FontAwesome
+                  name={
+                    article?.savedUsers?.includes(user_id)
+                      ? 'bookmark'
+                      : 'bookmark-o'
+                  }
+                  size={18}
+                  color={
+                    article?.savedUsers?.includes(user_id)
+                      ? PRIMARY_COLOR
+                      : footerColors.text
+                  }
+                />
                 <Text
                   style={[
                     styles.actionTextFooter,


### PR DESCRIPTION
#### PR Description
Removed the saved-state bookmark icon from the article footer pill in ArticleScreen.tsx. The red bookmark icon was causing visual clutter inside the category chip when an article was in the saved state. The icon element has been removed while keeping the "Save" label, save/unsave toggle behavior, saved-state checks, and pill alignment fully intact. The chip now appears cleaner and more consistent with the application's overall design language.

#### Type of Change
- [X] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update

#### Select your work-area
- [X] Frontend
- [ ] Backend
- [ ] Documentation
- [ ] Others

#### Related Issue
Fixes #1063 

#### Add your Work Example
📷 Add a Snapshot

#### Fixes (mention the issue number which this fixes)
Closes #1063 

#### Checklist
- [ ] I have updated my branch and synced it with the project's 'develop' branch before making this PR.
- [ ] I have optimized the file changes.
- [ ] I have added a snapshot of my work example.
- [ ] I have made a PR to the project's develop branch.

#### Undertaking
- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have checked for plagiarism and assure its authenticity.
- [ ] I have read and followed the code of conduct for this repository. I understand that violation of this undertaking may have legal consequences.

- [ ] I Agree
