### PR TITLE
feat: add article title and description counters

### DIFF
--- a/frontend/src/screens/article/ArticleDescriptionScreen.tsx
+++ b/frontend/src/screens/article/ArticleDescriptionScreen.tsx
@@ -26,7 +26,9 @@ import { KeyboardAwareScrollView } from 'react-native-keyboard-controller';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { ttsLanguageList } from '@/src/helper/Utils';
 
-
+const ARTICLE_TITLE_MAX_LENGTH = 150;
+const ARTICLE_DESCRIPTION_MAX_LENGTH = 500;
+const COUNTER_WARNING_THRESHOLD = 0.9;
 
 const ArticleDescriptionScreen = ({
   navigation,
@@ -158,6 +160,17 @@ const ArticleDescriptionScreen = ({
         lang => lang.code !== translationSource?.sourceLanguage,
       )
     : ttsLanguageList;
+
+  const isNearLimit = (value: string, limit: number) =>
+    value.length >= limit * COUNTER_WARNING_THRESHOLD;
+
+  const handleTitleChange = (text: string) => {
+    setTitle(text.slice(0, ARTICLE_TITLE_MAX_LENGTH));
+  };
+
+  const handleDescriptionChange = (text: string) => {
+    setDescription(text.slice(0, ARTICLE_DESCRIPTION_MAX_LENGTH));
+  };
 
   const getLanguageLabel = (value: string) => {
     return ttsLanguageList.find(lang => lang.code === value)?.name || 'Select language';
@@ -302,8 +315,17 @@ const ArticleDescriptionScreen = ({
               placeholderTextColor="#6b7280"
               style={styles.inputControl}
               value={title}
-              onChangeText={setTitle}
+              onChangeText={handleTitleChange}
+              maxLength={ARTICLE_TITLE_MAX_LENGTH}
             />
+            <Text
+              style={[
+                styles.charCounter,
+                isNearLimit(title, ARTICLE_TITLE_MAX_LENGTH) &&
+                  styles.charCounterWarning,
+              ]}>
+              {title.length} / {ARTICLE_TITLE_MAX_LENGTH}
+            </Text>
           </View>
 
           {/* Author Name */}
@@ -352,8 +374,17 @@ const ArticleDescriptionScreen = ({
               numberOfLines={4}
               autoCapitalize="sentences"
               value={description}
-              onChangeText={setDescription}
+              onChangeText={handleDescriptionChange}
+              maxLength={ARTICLE_DESCRIPTION_MAX_LENGTH}
             />
+            <Text
+              style={[
+                styles.charCounter,
+                isNearLimit(description, ARTICLE_DESCRIPTION_MAX_LENGTH) &&
+                  styles.charCounterWarning,
+              ]}>
+              {description.length} / {ARTICLE_DESCRIPTION_MAX_LENGTH}
+            </Text>
           </View>
         </View>
 
@@ -509,6 +540,17 @@ const styles = StyleSheet.create({
     color: '#222',
     borderWidth: 1,
     borderColor: '#E5E7EB',
+  },
+  charCounter: {
+    marginTop: 6,
+    alignSelf: 'flex-end',
+    color: '#6b7280',
+    fontSize: 13,
+    fontWeight: '500',
+  },
+  charCounterWarning: {
+    color: '#EA580C',
+    fontWeight: '700',
   },
   imageContainer: {
     width: '100%',


### PR DESCRIPTION
## Summary

Adds live character counters and max-length enforcement to the Article Description screen for article title and description fields.

Fixes #1076

## Root Cause

The article creation form accepted title and description text without visible limits or live feedback, so users could only discover length problems late in the flow or after submitting content.

## Changes Made

- Added explicit article title and description length constants.
- Enforced title input at 150 characters and description input at 500 characters with maxLength and paste-safe slicing.
- Added live counters under both fields.
- Highlighted counters when users reach 90% of the configured limit.
- Preserved the existing article navigation payload and submission flow.

## Testing

- git diff --check
- npx eslint src/screens/article/ArticleDescriptionScreen.tsx
- npm run type-check *(fails on existing unrelated errors in ActivityOverview.tsx, GlossaryBottomSheet.tsx, and PodcastSearch.tsx)*
- npm run lint *(fails on existing unrelated repo-wide lint errors/tests; touched ArticleDescriptionScreen.tsx passes scoped ESLint)*

## Impact

Users now get immediate feedback while writing article metadata, and title/description content is prevented from exceeding the configured limits before the editor step.

## Labels Requested

gssoc:approved, level:intermediate, type:feature, quality:clean