### PR TITLE
fix: remove unnecessary storage permission denied alerts on Android (#1084)

### DIFF
--- a/frontend/android/app/src/main/AndroidManifest.xml
+++ b/frontend/android/app/src/main/AndroidManifest.xml
@@ -2,14 +2,12 @@
   <uses-permission android:name="android.permission.INTERNET"/>
   <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
   <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
-  <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
   <uses-permission android:name="android.permission.READ_MEDIA_AUDIO"/>
   <uses-permission android:name="android.permission.READ_PHONE_STATE" tools:node="remove"/>
   <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
   <uses-permission android:name="android.permission.RECORD_AUDIO"/>
   <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" tools:node="remove"/>
   <uses-permission android:name="android.permission.VIBRATE"/>
-  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" tools:node="remove"/>
   <queries>
     <intent>
       <action android:name="android.intent.action.VIEW"/>

--- a/frontend/app.config.js
+++ b/frontend/app.config.js
@@ -45,7 +45,6 @@ const defaultStaticConfig = {
     blockedPermissions: [
       "android.permission.SYSTEM_ALERT_WINDOW",
       "android.permission.READ_PHONE_STATE",
-      "android.permission.WRITE_EXTERNAL_STORAGE"
     ],
     allowBackup: false,
     intentFilters: [

--- a/frontend/src/components/ArticleCard.tsx
+++ b/frontend/src/components/ArticleCard.tsx
@@ -148,7 +148,6 @@ const ArticleCard = ({
     try {
       const storageGranted = await requestStoragePermissions();
       if (!storageGranted) {
-        Alert.alert('Storage permission denied');
         return;
       }
       if (!isConnected) {

--- a/frontend/src/helper/Utils.ts
+++ b/frontend/src/helper/Utils.ts
@@ -2,7 +2,7 @@ import NetInfo from '@react-native-community/netinfo';
 import {Category, CategoryType, PodcastData} from '../type';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import {GET_STORAGE_DATA} from './APIUtils';
-import {Alert, Linking, PermissionsAndroid, Platform} from 'react-native';
+import {Alert, Linking, Platform} from 'react-native';
 import RNFS from 'react-native-fs';
 import {secureClearAllItems} from './SecureStorageUtils';
 import {
@@ -344,13 +344,9 @@ export const requestStoragePermissions = async () => {
 
   if ((Platform.Version as number) < 33) {
     const granted = await PermissionsAndroid.requestMultiple([
-      PermissionsAndroid.PERMISSIONS.READ_EXTERNAL_STORAGE,
-      PermissionsAndroid.PERMISSIONS.WRITE_EXTERNAL_STORAGE,
     ]);
 
     return (
-      granted['android.permission.READ_EXTERNAL_STORAGE'] === PermissionsAndroid.RESULTS.GRANTED &&
-      granted['android.permission.WRITE_EXTERNAL_STORAGE'] === PermissionsAndroid.RESULTS.GRANTED
     );
   } else {
     const granted = await PermissionsAndroid.requestMultiple([
@@ -367,7 +363,6 @@ export const downloadAudio = async (_podcast: PodcastData) => {
   // Check for existing downloads
   const storageGranted = await requestStoragePermissions();
   if (!storageGranted) {
-    Alert.alert('Storage permission denied');
     return;
   }
   const existingPodcasts = await readDownloadedPodcasts();

--- a/frontend/src/screens/PodcastRecorder.tsx
+++ b/frontend/src/screens/PodcastRecorder.tsx
@@ -71,7 +71,6 @@ const PodcastRecorder = ({navigation, route}: PodcastRecorderScreenProps) => {
 
       const storageGranted = await requestStoragePermissions();
       if (!storageGranted) {
-        Alert.alert('Storage permission denied');
         return;
       }
 
@@ -111,15 +110,9 @@ const PodcastRecorder = ({navigation, route}: PodcastRecorderScreenProps) => {
 
   // const startRecording = async () => {
   //   if (Platform.OS === 'android') {
-  //     const granted = await PermissionsAndroid.requestMultiple([
-  //       PermissionsAndroid.PERMISSIONS.RECORD_AUDIO,
-  //       PermissionsAndroid.PERMISSIONS.WRITE_EXTERNAL_STORAGE,
   //     ]);
   //     if (
-  //       granted['android.permission.RECORD_AUDIO'] !==
-  //       PermissionsAndroid.RESULTS.GRANTED
   //     ) {
-  //       console.warn('Permission denied');
   //       return;
   //     }
   //   }


### PR DESCRIPTION
## PR Description
Removed unnecessary Storage Permission Denied alerts on Android and cleaned up legacy storage permission checks that are no longer required with modern Android storage APIs.

## Type of Change
- [x] Bug fix (change which fixes an issue)

## Select your work-area
- [x] Frontend

## Related Issue
Fixes #1084

## Changes Made
- Removed `READ_EXTERNAL_STORAGE` and `WRITE_EXTERNAL_STORAGE` from AndroidManifest.xml
- Removed `WRITE_EXTERNAL_STORAGE` from app.config.js
- Removed legacy `PermissionsAndroid` storage permission checks from Utils.ts
- Removed `Alert.alert('Storage permission denied')` from ArticleCard.tsx and PodcastRecorder.tsx
- Cleaned up commented-out legacy permission code in PodcastRecorder.tsx
- Modern `READ_MEDIA_AUDIO` permission check retained (valid for Android 13+)

## Fixes
Closes #1084

## Checklist
- [x] I have updated my branch and synced it with the project's 'develop' branch before making this PR.
- [x] I have optimized the file changes.
- [x] I have made a PR to the project's develop branch.

## Undertaking
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have checked for plagiarism and assure its authenticity.
- [x] I have read and followed the code of conduct for this repository. I understand that violation of this undertaking may have legal consequences.
- [x] I Agree