### PR TITLE
feat: add empty state component for offline podcasts screen (#1078)

### DIFF
--- a/frontend/src/components/EmptyStates.tsx
+++ b/frontend/src/components/EmptyStates.tsx
@@ -189,6 +189,16 @@ export const NoPodcastState = ({ onRefresh }: { onRefresh?: () => void }) => (
   />
 );
 
+export const NoOfflinePodcastState = ({ onBrowse }: { onBrowse?: () => void }) => (
+  <BaseEmptyState
+    iconEmoji="🎙️"
+    title="No Offline Podcasts Yet"
+    description="Download podcasts to listen anytime, even without an internet connection."
+    actionText={onBrowse ? "Browse Podcasts" : undefined}
+    onAction={onBrowse}
+  />
+);
+
 export const NoNotificationState = ({ onRefresh }: { onRefresh?: () => void }) => {
   const isDarkMode = useColorScheme() === 'dark';
   return (

--- a/frontend/src/screens/OfflinePodcastList.tsx
+++ b/frontend/src/screens/OfflinePodcastList.tsx
@@ -4,6 +4,7 @@ import {OfflinePodcastListProp, PodcastData} from '../type';
 import {deleteFromDownloads, msToTime, readDownloadedPodcasts} from '../helper/Utils';
 import PodcastCard from '../components/PodcastCard';
 import PodcastEmptyComponent from '../components/PodcastEmptyComponent';
+import {NoOfflinePodcastState} from '../components/EmptyStates';
 import {hp} from '../helper/Metric';
 import {ON_PRIMARY_COLOR} from '../helper/Theme';
 import Snackbar from 'react-native-snackbar';
@@ -113,7 +114,7 @@ export default function OfflinePodcastList({
         data={podcasts}
         keyExtractor={item => item._id.toString()}
         renderItem={renderItem}
-        ListEmptyComponent={<PodcastEmptyComponent />}
+        ListEmptyComponent={<NoOfflinePodcastState onBrowse={() => navigation.navigate('Podcast')} />}
       />
       <CreatePlaylist
         visible={playlistModalOpen}


### PR DESCRIPTION
## PR Description
Added a dedicated empty state component for the Offline Podcasts screen when no podcasts have been downloaded, replacing the blank screen with meaningful feedback and a call-to-action button.

## Type of Change
- [x] New feature (change which adds functionality)

## Select your work-area
- [x] Frontend

## Related Issue
Fixes #1078

## Changes Made
- Added `NoOfflinePodcastState` component in `EmptyStates.tsx`
- Title: "No Offline Podcasts Yet"
- Description: "Download podcasts to listen anytime, even without an internet connection."
- Added "Browse Podcasts" CTA button that navigates users to the Podcast discovery screen
- Replaced blank empty screen with dedicated empty state in `OfflinePodcastList.tsx`
- Follows existing empty state design patterns with animation support
- Supports both light and dark themes

## Fixes
Closes #1078

## Checklist
- [x] I have updated my branch and synced it with the project's develop branch before making this PR.
- [x] I have optimized the file changes.
- [x] I have made a PR to the project's develop branch.

## Undertaking
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have checked for plagiarism and assure its authenticity.
- [x] I have read and followed the code of conduct for this repository. I understand that violation of this undertaking may have legal consequences.
- [x] I Agree