### PR TITLE
fix: guard auth submissions against duplicates

### DIFF
--- a/frontend/src/hooks/__tests__/useSubmissionGuard.test.ts
+++ b/frontend/src/hooks/__tests__/useSubmissionGuard.test.ts
@@ -1,0 +1,39 @@
+import {act, renderHook} from '@testing-library/react-native';
+
+import {useSubmissionGuard} from '../useSubmissionGuard';
+
+describe('useSubmissionGuard', () => {
+  it('blocks repeated acquire calls until released', () => {
+    const {result} = renderHook(() => useSubmissionGuard());
+
+    act(() => {
+      expect(result.current.acquire()).toBe(true);
+    });
+
+    expect(result.current.isGuarded).toBe(true);
+
+    act(() => {
+      expect(result.current.acquire()).toBe(false);
+    });
+
+    act(() => {
+      result.current.release();
+    });
+
+    expect(result.current.isGuarded).toBe(false);
+
+    act(() => {
+      expect(result.current.acquire()).toBe(true);
+    });
+  });
+
+  it('does not acquire when an external mutation is pending', () => {
+    const {result} = renderHook(() => useSubmissionGuard(true));
+
+    act(() => {
+      expect(result.current.acquire()).toBe(false);
+    });
+
+    expect(result.current.isGuarded).toBe(true);
+  });
+});

--- a/frontend/src/hooks/useSubmissionGuard.ts
+++ b/frontend/src/hooks/useSubmissionGuard.ts
@@ -1,0 +1,27 @@
+import {useCallback, useRef, useState} from 'react';
+
+export function useSubmissionGuard(externalPending = false) {
+  const lockRef = useRef(false);
+  const [internalPending, setInternalPending] = useState(false);
+
+  const acquire = useCallback(() => {
+    if (lockRef.current || externalPending) {
+      return false;
+    }
+
+    lockRef.current = true;
+    setInternalPending(true);
+    return true;
+  }, [externalPending]);
+
+  const release = useCallback(() => {
+    lockRef.current = false;
+    setInternalPending(false);
+  }, []);
+
+  return {
+    acquire,
+    release,
+    isGuarded: externalPending || internalPending,
+  };
+}

--- a/frontend/src/screens/auth/LoginScreen.tsx
+++ b/frontend/src/screens/auth/LoginScreen.tsx
@@ -20,6 +20,7 @@ import {
 
 import {useRequestVerification} from '@/src/hooks/useResendVerification';
 import {useSendOtpMutation} from '@/src/hooks/useSendOtp';
+import {useSubmissionGuard} from '@/src/hooks/useSubmissionGuard';
 import {useLoginMutation} from '@/src/hooks/useUserLogin';
 import EmailInputBottomSheet from '../../components/EmailInputModal';
 import Loader from '../../components/Loader';
@@ -59,6 +60,10 @@ const LoginScreen = ({navigation, route}: LoginScreenProp) => {
   const {mutate: sendOtp, isPending: sendOtpPending} = useSendOtpMutation();
 
   const {mutate: login, isPending: loginPending} = useLoginMutation();
+  const loginGuard = useSubmissionGuard(loginPending);
+  const emailActionGuard = useSubmissionGuard(
+    sendOtpPending || resendVerificationPending,
+  );
 
   const handleSecureEntryClickEvent = () => {
     setSecureTextEntry(!secureTextEntry);
@@ -111,6 +116,10 @@ const LoginScreen = ({navigation, route}: LoginScreenProp) => {
   }
 
   const validateAndSubmit = async () => {
+    if (!loginGuard.acquire()) {
+      return;
+    }
+
     if (validate()) {
       setPasswordMessage(false);
       setEmailMessage(false);
@@ -210,9 +219,11 @@ const LoginScreen = ({navigation, route}: LoginScreenProp) => {
               Alert.alert('Error', 'User not found');
             }
           },
+          onSettled: loginGuard.release,
         },
       );
     } else {
+      loginGuard.release();
       setOutput(true);
       setPasswordMessage(false);
       setEmailMessage(false);
@@ -439,8 +450,8 @@ const LoginScreen = ({navigation, route}: LoginScreenProp) => {
                 }
                 validateAndSubmit();
               }}
-              disabled={loginPending}
-              opacity={loginPending ? 0.5 : 1}
+              disabled={loginGuard.isGuarded}
+              opacity={loginGuard.isGuarded ? 0.5 : 1}
               width="100%">
               <Text fontSize={18} color="$white" fontWeight="600">
                 Login
@@ -507,6 +518,10 @@ const LoginScreen = ({navigation, route}: LoginScreenProp) => {
         <EmailInputBottomSheet
           visible={emailInputVisible}
           callback={(email: string) => {
+            if (!emailActionGuard.acquire()) {
+              return;
+            }
+
             setOtpMail(email);
             if (requestVerificationMode) {
               resendVerification(
@@ -559,6 +574,7 @@ const LoginScreen = ({navigation, route}: LoginScreenProp) => {
                       }
                     }
                   },
+                  onSettled: emailActionGuard.release,
                 },
               );
             } else {
@@ -591,6 +607,7 @@ const LoginScreen = ({navigation, route}: LoginScreenProp) => {
                       Alert.alert('Error', 'Network error.');
                     }
                   },
+                  onSettled: emailActionGuard.release,
                 },
               );
             }

--- a/frontend/src/screens/auth/NewPasswordScreen.tsx
+++ b/frontend/src/screens/auth/NewPasswordScreen.tsx
@@ -15,6 +15,7 @@ import {
 
 import { ON_PRIMARY_COLOR, PRIMARY_COLOR } from '@/src/helper/Theme';
 import { useChangePasswordMutation } from '@/src/hooks/useChangePassword';
+import { useSubmissionGuard } from '@/src/hooks/useSubmissionGuard';
 import AntDesign from '@expo/vector-icons/AntDesign';
 import Entypo from '@expo/vector-icons/Entypo';
 import Icon from '@expo/vector-icons/Ionicons';
@@ -36,6 +37,7 @@ export default function NewPasswordScreen({
   const [secureTextEntry, setSecureTextEntry] = useState(true);
   const [secureNewTextEntry, setSecureNewTextEntry] = useState(true);
   const {mutate: changePassword, isPending} = useChangePasswordMutation();
+  const passwordResetGuard = useSubmissionGuard(isPending);
 
   const handleSecureEntryClickEvent = () => {
     setSecureTextEntry(!secureTextEntry);
@@ -48,9 +50,14 @@ export default function NewPasswordScreen({
   };
 
   const handlePasswordSubmit = () => {
+    if (!passwordResetGuard.acquire()) {
+      return;
+    }
+
     const showError = (msg: string) => {
       Alert.alert(msg);
       setErrorMessage(msg);
+      passwordResetGuard.release();
     };
 
     if (!password?.trim()) {
@@ -103,6 +110,7 @@ export default function NewPasswordScreen({
             Alert.alert('Error', 'Something went wrong. Please try again.');
           }
         },
+        onSettled: passwordResetGuard.release,
       },
     );
   };
@@ -426,8 +434,10 @@ export default function NewPasswordScreen({
                 !password ||
                 !confirmPassword ||
                 password !== confirmPassword ||
-                !passwordVerify
+                !passwordVerify ||
+                passwordResetGuard.isGuarded
               }
+              opacity={passwordResetGuard.isGuarded ? 0.5 : 1}
               shadowColor="$blue8"
               shadowRadius={12}
               shadowOffset={{width: 0, height: 4}}

--- a/frontend/src/screens/auth/OtpScreen.tsx
+++ b/frontend/src/screens/auth/OtpScreen.tsx
@@ -1,4 +1,5 @@
 import { useSendOtpMutation } from '@/src/hooks/useSendOtp';
+import { useSubmissionGuard } from '@/src/hooks/useSubmissionGuard';
 import { useVerifyOtpMutation } from '@/src/hooks/useVerifyOtp';
 import axios, { AxiosError, isAxiosError } from 'axios';
 import React, { useRef, useState } from 'react';
@@ -26,12 +27,19 @@ export default function OtpScreen({navigation, route}: OtpScreenProp) {
   const [errorMessages, setErrorMessages] = useState<string[]>();
   const {mutate: sendOtp, isPending: sendOtpPending} = useSendOtpMutation();
   const {mutate: checkOtp, isPending: checkOtpPending} = useVerifyOtpMutation();
+  const verifyOtpGuard = useSubmissionGuard(checkOtpPending);
+  const resendOtpGuard = useSubmissionGuard(sendOtpPending);
 
   const handleSubmit = () => {
+    if (!verifyOtpGuard.acquire()) {
+      return;
+    }
+
     //navigation.navigate('NewPasswordScreen');
     const fullCode = otp!.join('');
     if (!fullCode || fullCode.length === 0) {
       setErrorMessages(['Please provide otp inputs']);
+      verifyOtpGuard.release();
       return;
     } else {
       setErrorMessages(undefined);
@@ -52,6 +60,7 @@ export default function OtpScreen({navigation, route}: OtpScreenProp) {
             setErrorMessages(['Invalid or expired otp']);
             Alert.alert('Invalid or expired otp');
           },
+          onSettled: verifyOtpGuard.release,
         },
       );
     }
@@ -213,7 +222,8 @@ export default function OtpScreen({navigation, route}: OtpScreenProp) {
               //alignSelf="center"
               height={56}
               marginTop="$5"
-              disabled={!otp.every(d => d)}
+              disabled={!otp.every(d => d) || verifyOtpGuard.isGuarded}
+              opacity={verifyOtpGuard.isGuarded ? 0.5 : 1}
               shadowColor="$blue8"
               shadowRadius={12}
               shadowOffset={{width: 0, height: 4}}
@@ -231,6 +241,10 @@ export default function OtpScreen({navigation, route}: OtpScreenProp) {
               <Button
                 chromeless
                 onPress={() => {
+                  if (!resendOtpGuard.acquire()) {
+                    return;
+                  }
+
                   sendOtp(
                     {
                       email,
@@ -264,9 +278,12 @@ export default function OtpScreen({navigation, route}: OtpScreenProp) {
                           Alert.alert('Error', 'Network error.');
                         }
                       },
+                      onSettled: resendOtpGuard.release,
                     },
                   );
                 }}
+                disabled={resendOtpGuard.isGuarded}
+                opacity={resendOtpGuard.isGuarded ? 0.5 : 1}
                 padding="$2"
                 height="auto">
                 <XStack ai="center" gap="$2">

--- a/frontend/src/screens/auth/SignUpScreenFirst.tsx
+++ b/frontend/src/screens/auth/SignUpScreenFirst.tsx
@@ -20,6 +20,7 @@ import {
 } from 'react-native-image-picker';
 import {useCheckUserHandleAvailability} from '@/src/hooks/useCheckUserHandleAvailability';
 import {useVerificationMailMutation} from '@/src/hooks/useMailVerification';
+import {useSubmissionGuard} from '@/src/hooks/useSubmissionGuard';
 import {useRegdMutation} from '@/src/hooks/useUserRegistration';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 let validator = require('email-validator');
@@ -49,6 +50,8 @@ const SignupPageFirst = ({navigation}: SignUpScreenFirstProp) => {
     useVerificationMailMutation();
 
   const {mutate: register, isPending: registerPending} = useRegdMutation();
+  const registerGuard = useSubmissionGuard(registerPending || loading);
+  const verifyEmailGuard = useSubmissionGuard(verifyEmailPending);
 
   const selectImage = async () => {
     const options: ImageLibraryOptions = {
@@ -90,6 +93,10 @@ const SignupPageFirst = ({navigation}: SignUpScreenFirstProp) => {
 
 
   const handleVerifyModalCallback = () => {
+    if (!verifyEmailGuard.acquire()) {
+      return;
+    }
+
     if (token.length > 0) {
       verifyEmailMutation(
         {
@@ -142,9 +149,11 @@ const SignupPageFirst = ({navigation}: SignUpScreenFirstProp) => {
               });
             }
           },
+          onSettled: verifyEmailGuard.release,
         },
       );
     } else {
+      verifyEmailGuard.release();
       Alert.alert(
         'Failed to authenticate, Token not found',
         'Please try again',
@@ -152,17 +161,25 @@ const SignupPageFirst = ({navigation}: SignUpScreenFirstProp) => {
     }
   };
   const handleSubmit = () => {
+    if (!registerGuard.acquire()) {
+      return;
+    }
+
     if (!name || !userHandle || !email || !password || !role) {
       Alert.alert('Please fill in all fields');
+      registerGuard.release();
       return;
     } else if (validator.validate(email) === false) {
       Alert.alert('Email id is not valid');
+      registerGuard.release();
       return;
     } else if (password.length < 6) {
       Alert.alert('Password must be at least of 6 length');
+      registerGuard.release();
       return;
     } else if (handleAvailability && !handleAvailability.isAvailable) {
       Alert.alert('User handle is not available', 'Please choose a different handle.');
+      registerGuard.release();
       return;
     }
 
@@ -179,6 +196,7 @@ const SignupPageFirst = ({navigation}: SignUpScreenFirstProp) => {
       };
       setPendingSubmitAction(() => () => {
         console.log('General');
+        registerGuard.release();
         navigation.navigate('SignUpScreenSecond', {
           user: detail,
         });
@@ -198,6 +216,7 @@ const SignupPageFirst = ({navigation}: SignUpScreenFirstProp) => {
   const handleSecurityWarningCancel = () => {
     setSecurityWarningVisible(false);
     setPendingSubmitAction(null);
+    registerGuard.release();
   };
 
   const callRegisterAPI = (profile_url: string) => {
@@ -249,6 +268,7 @@ const SignupPageFirst = ({navigation}: SignUpScreenFirstProp) => {
             Alert.alert('Registration failed', 'Please try again');
           }
         },
+        onSettled: registerGuard.release,
       },
     );
   };
@@ -285,6 +305,7 @@ const SignupPageFirst = ({navigation}: SignUpScreenFirstProp) => {
               } catch (err) {
                 console.error('Upload failed');
                 Alert.alert('Error', 'Upload failed');
+                registerGuard.release();
               }
             },
           },
@@ -497,6 +518,8 @@ const SignupPageFirst = ({navigation}: SignUpScreenFirstProp) => {
             alignItems="center"
             alignSelf="center"
             width="100%"
+            disabled={registerGuard.isGuarded}
+            opacity={registerGuard.isGuarded ? 0.5 : 1}
             onPress={handleSubmit}>
             <Text color="white" fontWeight="bold" fontSize={18}>
               {role === 'general' ? 'Register' : 'Continue'}

--- a/frontend/src/screens/auth/SignUpScreenSecond.tsx
+++ b/frontend/src/screens/auth/SignUpScreenSecond.tsx
@@ -12,6 +12,7 @@ import Snackbar from 'react-native-snackbar';
 import useUploadImage from '../../hooks/useUploadImage';
 import {SafeAreaView} from 'react-native-safe-area-context';
 import {useVerificationMailMutation} from '@/src/hooks/useMailVerification';
+import {useSubmissionGuard} from '@/src/hooks/useSubmissionGuard';
 import {useRegdMutation} from '@/src/hooks/useUserRegistration';
 let validator = require('email-validator');
 
@@ -31,6 +32,8 @@ const SignupPageSecond = ({navigation, route}: SignUpScreenSecondProp) => {
   const {mutate: verifyEmailMutation, isPending: verifyMutationPending} =
     useVerificationMailMutation();
   const {mutate: register, isPending: registerPending} = useRegdMutation();
+  const registerGuard = useSubmissionGuard(registerPending || loading);
+  const verifyEmailGuard = useSubmissionGuard(verifyMutationPending);
   const theme = useTheme();
   const callRegisterAPI = (
     profile_url: string,
@@ -92,11 +95,16 @@ const SignupPageSecond = ({navigation, route}: SignUpScreenSecondProp) => {
             Alert.alert('Registration failed', 'Please try again');
           }
         },
+        onSettled: registerGuard.release,
       },
     );
   };
 
   const handleVerifyModalCallback = () => {
+    if (!verifyEmailGuard.acquire()) {
+      return;
+    }
+
     if (token.length > 0) {
       verifyEmailMutation(
         {
@@ -148,9 +156,11 @@ const SignupPageSecond = ({navigation, route}: SignUpScreenSecondProp) => {
               });
             }
           },
+          onSettled: verifyEmailGuard.release,
         },
       );
     } else {
+      verifyEmailGuard.release();
       Alert.alert(
         'Failed to authenticate, Token not found',
         'Please try again',
@@ -159,6 +169,10 @@ const SignupPageSecond = ({navigation, route}: SignUpScreenSecondProp) => {
   };
 
   const handleSubmit = () => {
+    if (!registerGuard.acquire()) {
+      return;
+    }
+
     if (
       !specialization ||
       !education ||
@@ -167,12 +181,15 @@ const SignupPageSecond = ({navigation, route}: SignUpScreenSecondProp) => {
       !phone
     ) {
       Alert.alert('Please fill in all fields');
+      registerGuard.release();
       return;
     } else if (validator.validate(businessEmail) === false) {
       Alert.alert('Please enter a valid mail id');
+      registerGuard.release();
       return;
     } else if (phone.length < 10) {
       Alert.alert('Please enter a valid phone number');
+      registerGuard.release();
       return;
     } else {
       let contactDetail: Contactdetail = {
@@ -198,6 +215,7 @@ const SignupPageSecond = ({navigation, route}: SignUpScreenSecondProp) => {
   const handleSecurityWarningCancel = () => {
     setSecurityWarningVisible(false);
     setPendingContactDetail(null);
+    registerGuard.release();
   };
 
   const registerDoctor = async (contactDetail: Contactdetail) => {
@@ -236,6 +254,7 @@ const SignupPageSecond = ({navigation, route}: SignUpScreenSecondProp) => {
               } catch (err) {
                 console.error('Registration failed', err);
                 Alert.alert('Error Occured', 'Registration failed');
+                registerGuard.release();
               }
             },
           },
@@ -382,6 +401,8 @@ const SignupPageSecond = ({navigation, route}: SignUpScreenSecondProp) => {
             width="100%"
             size="$6"
             marginTop="$2"
+            disabled={registerGuard.isGuarded}
+            opacity={registerGuard.isGuarded ? 0.5 : 1}
             onPress={handleSubmit}>
             <Text color="$white" fontWeight="700" fontSize={18}>
               Register


### PR DESCRIPTION
## Summary
- add a reusable submission guard hook to block repeated auth actions before React Query pending state re-renders
- guard login, forgot-password OTP, resend verification, OTP verification, signup, doctor signup, and reset-password submissions
- disable and dim guarded buttons while a submission is in progress

## Related Issue
Closes #1085

## Testing
- yarn test src/hooks/__tests__/useSubmissionGuard.test.ts --runInBand
- yarn type-check
- yarn lint

Note: lint passes with existing repository warnings and no errors.