### PR TITLE
feat: Add Character Counter and Maximum Length Validation for Podcast Title (#1077)

### DIFF
--- a/frontend/src/screens/PodcastForm.tsx
+++ b/frontend/src/screens/PodcastForm.tsx
@@ -28,6 +28,8 @@ import { ttsLanguageList } from '../helper/Utils';
 
 
 const PodcastForm = ({navigation, route}: PodcastFormProp) => {
+  const MAX_TITLE_LENGTH = 100;
+  const MAX_TITLE_LENGTH = 100;
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   const [selectedGenres, setSelectedGenres] = useState<Category[]>([]);
@@ -264,7 +266,12 @@ const PodcastForm = ({navigation, route}: PodcastFormProp) => {
                 placeholderTextColor="#6b7280"
                 style={styles.inputControl}
                 value={title}
-                onChangeText={setTitle}
+                maxLength={MAX_TITLE_LENGTH}
+                onChangeText={text => {
+                  if (text.length <= MAX_TITLE_LENGTH) {
+                    setTitle(text);
+                  }
+                }}
               />
             </View>
 
@@ -518,6 +525,14 @@ const styles = StyleSheet.create({
     color: '#6b7280',
     fontSize: 13,
     fontWeight: '500',
+  },
+  charCounterWarning: {
+    color: '#FFA500',
+    fontWeight: '600',
+  },
+  charCounterError: {
+    color: '#EF4444',
+    fontWeight: '700',
   },
   languageSelector: {
     height: 50,

--- a/frontend/src/screens/PodcastForm.tsx
+++ b/frontend/src/screens/PodcastForm.tsx
@@ -29,7 +29,6 @@ import { ttsLanguageList } from '../helper/Utils';
 
 const PodcastForm = ({navigation, route}: PodcastFormProp) => {
   const MAX_TITLE_LENGTH = 100;
-  const MAX_TITLE_LENGTH = 100;
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   const [selectedGenres, setSelectedGenres] = useState<Category[]>([]);
@@ -273,6 +272,7 @@ const PodcastForm = ({navigation, route}: PodcastFormProp) => {
                   }
                 }}
               />
+              <Text style={[styles.charCounter, title.length >= MAX_TITLE_LENGTH * 0.9 && styles.charCounterWarning, title.length >= MAX_TITLE_LENGTH && styles.charCounterError]}>{title.length} / {MAX_TITLE_LENGTH}</Text>
             </View>
 
             {/* Language Dropdown */}


### PR DESCRIPTION
#### PR Description
This PR implements a real-time character counter and maximum length validation for the Podcast Title field in the Podcast Creation Form. Users can now see live feedback (e.g., `42 / 100`) while typing the podcast title. The counter turns orange when 90% of the limit is reached and red when the limit is hit. Pasted text is also handled gracefully via the `maxLength` prop. This improves form usability and ensures content consistency.

#### Type of Change
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Documentation update

#### Select your work-area
- [x] Frontend
- [ ] Backend
- [ ] Documentation
- [ ] Others

#### Related Issue
https://github.com/SB2318/UltimateHealth/issues/1077

#### Fixes ( #1077  )
#closes 1077

#### Checklist
- [x] I have updated my branch and synced it with the project's 'develop' branch before making this PR.
- [x] I have optimized the file changes.
- [ ] I have added a snapshot of my work example.
- [x] I have made a PR to the project's develop branch.

#### Undertaking
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have checked for plagiarism and assure its authenticity.
- [x] I have read and followed the code of conduct for this repository. I understand that violation of this undertaking may have legal consequences.

- [x] I Agree