### PR TITLE
fix: resolve latent production bugs in interceptor lifecycle, monitoring init, notification logging, and navigation back-stack

### DIFF
--- a/frontend/index.js
+++ b/frontend/index.js
@@ -6,13 +6,19 @@ import {GestureHandlerRootView} from 'react-native-gesture-handler';
 import App from './App';
 import messaging from '@react-native-firebase/messaging';
 import {StyleSheet} from 'react-native';
-import {initMonitoring} from './src/services/monitoring/sentry';
 
-initMonitoring();
-
-// Firebase background handler must be registered at the app root (run once).
+// Firebase background handler must be registered at the app root (run once,
+// before any component mounts). FCM requires this to be at module scope.
+// NOTE: initMonitoring() is intentionally NOT called here — it has been moved
+// to AppContent.tsx's first useEffect so that expo-application metadata
+// (nativeApplicationVersion, nativeBuildVersion) is fully available before
+// Sentry initialises.
 messaging().setBackgroundMessageHandler(async remoteMessage => {
-  console.log('Background notification received:', remoteMessage);
+  // Only log notification payloads in development to avoid leaking user data
+  // or FCM tokens in production log aggregators.
+  if (__DEV__) {
+    console.log('Background notification received:', remoteMessage);
+  }
 });
 
 const AppWrapper = () => {

--- a/frontend/src/components/AppContent.tsx
+++ b/frontend/src/components/AppContent.tsx
@@ -29,6 +29,7 @@ import {SECURE_KEYS, secureRetrieveItem} from '../helper/SecureStorageUtils';
 import {setUserToken, setGuestMode} from '../store/UserSlice';
 import {RootState} from '../store/ReduxStore';
 import {setupAxiosInterceptor} from '../helper/setupAxiosInterceptor';
+import {initMonitoring} from '../services/monitoring/sentry';
 
 export default function AppContent() {
   const navigationRef = useRef<NavigationContainerRef<any> | null>(null);
@@ -39,8 +40,14 @@ export default function AppContent() {
   const {data: tokenRes = null} = useCheckTokenStatus();
   const {user_token, isGuest} = useSelector((state: RootState) => state.user);
 
-  // Setup axios interceptor and timeout defaults once on mount.
+  // Initialise monitoring and axios interceptors once on mount.
+  // initMonitoring() is placed here (rather than index.js module scope) so that
+  // expo-application metadata is fully available when Sentry reads
+  // nativeApplicationVersion / nativeBuildVersion.
+  // setupAxiosInterceptor() is idempotent — it ejects and re-registers interceptors
+  // on every call, so double-invocations from React Strict Mode are safe.
   useEffect(() => {
+    initMonitoring();
     setupAxiosInterceptor();
   }, []);
 
@@ -79,22 +86,30 @@ export default function AppContent() {
 
   useEffect(() => {
     const unsubscribe = messaging().onMessage(async remoteMessage => {
-      console.log(
-        'Foreground notification received from message:',
-        remoteMessage,
-      );
+      // Only log notification payloads in development to avoid leaking
+      // FCM message content (including user-targeted data fields) to
+      // production log aggregators or crash reporters.
+      if (__DEV__) {
+        console.log(
+          'Foreground notification received from message:',
+          remoteMessage,
+        );
+      }
     });
 
-    // On app open
-
     const unsubscribe1 = addEventListener(state => {
-      console.log('Connection type', state.type);
-      console.log('Is connected?', state.isConnected);
+      if (__DEV__) {
+        console.log('Connection type', state.type);
+        console.log('Is connected?', state.isConnected);
+      }
       /** Dispatch use a reducer to update the value in store */
       dispatch(setConnected(state.isConnected));
     });
+
     const onOpenApp = messaging().onNotificationOpenedApp(remoteMessage => {
-      console.log('Notification caused app to open:', remoteMessage);
+      if (__DEV__) {
+        console.log('Notification caused app to open:', remoteMessage);
+      }
       // const data = remoteMessage.data;
       // handleNotification(data);
     });

--- a/frontend/src/helper/__tests__/ApiTimeout.test.ts
+++ b/frontend/src/helper/__tests__/ApiTimeout.test.ts
@@ -110,6 +110,13 @@ describe('CallAPI helpers', () => {
 });
 
 describe('setupAxiosInterceptor', () => {
+  beforeEach(() => {
+    // Clear all interceptors so each test starts from a clean slate.
+    // This prevents handler counts from accumulating across tests.
+    (axios.interceptors.request as any).handlers = [];
+    (axios.interceptors.response as any).handlers = [];
+  });
+
   it('configures shared axios timeout defaults', () => {
     axios.defaults.timeout = 0;
     axios.defaults.timeoutErrorMessage = undefined;
@@ -118,6 +125,26 @@ describe('setupAxiosInterceptor', () => {
 
     expect(axios.defaults.timeout).toBe(API_REQUEST_TIMEOUT_MS);
     expect(axios.defaults.timeoutErrorMessage).toBe(API_TIMEOUT_ERROR_MESSAGE);
+  });
+
+  it('does not stack interceptors when called multiple times (idempotency)', () => {
+    setupAxiosInterceptor();
+    setupAxiosInterceptor();
+    setupAxiosInterceptor();
+
+    // The eject-before-register guard should ensure only one handler is active
+    // regardless of how many times the function is called. Without the guard,
+    // duplicate interceptors would accumulate and could trigger multiple logout
+    // dispatches, repeated toasts, and performance degradation.
+    const activeReqHandlers = (axios.interceptors.request as any).handlers.filter(
+      (h: any) => h !== null,
+    );
+    const activeResHandlers = (axios.interceptors.response as any).handlers.filter(
+      (h: any) => h !== null,
+    );
+
+    expect(activeReqHandlers).toHaveLength(1);
+    expect(activeResHandlers).toHaveLength(1);
   });
 
   it('attaches authorization header if token exists in secure store', async () => {
@@ -148,5 +175,23 @@ describe('setupAxiosInterceptor', () => {
 
     const resultConfig = await interceptor.fulfilled(config);
     expect(resultConfig.headers.Authorization).toBeUndefined();
+  });
+
+  it('safely handles undefined headers object on request config', async () => {
+    const SecureStore = require('expo-secure-store');
+    SecureStore.getItemAsync.mockResolvedValue('safe-token');
+
+    setupAxiosInterceptor();
+
+    // Simulate a config where headers is undefined (edge-case Axios adapter behaviour)
+    const config = { headers: undefined as any };
+    const handlers = (axios.interceptors.request as any).handlers;
+    const interceptor = handlers.find((h: any) => h && h.fulfilled);
+    expect(interceptor).toBeDefined();
+
+    // Should not throw a TypeError; headers should be initialised and token attached.
+    const resultConfig = await interceptor.fulfilled(config);
+    expect(resultConfig.headers).toBeDefined();
+    expect(resultConfig.headers.Authorization).toBe('Bearer safe-token');
   });
 });

--- a/frontend/src/helper/authAxios.ts
+++ b/frontend/src/helper/authAxios.ts
@@ -12,9 +12,13 @@ const authAxios = axios.create({
   },
 });
 
-// Request interceptor: dynamically attach Bearer token before every request
+// Request interceptor: dynamically attach Bearer token before every request.
+// `config.headers ??= {}` guards against the rare case where an Axios adapter
+// or custom config omits the headers object entirely, preventing a runtime
+// TypeError when setting `config.headers.Authorization`.
 authAxios.interceptors.request.use(
   async (config) => {
+    config.headers ??= {} as typeof config.headers;
     const token = await secureRetrieveItem(SECURE_KEYS.USER_TOKEN);
     if (token) {
       config.headers.Authorization = `Bearer ${token}`;

--- a/frontend/src/helper/setupAxiosInterceptor.ts
+++ b/frontend/src/helper/setupAxiosInterceptor.ts
@@ -27,6 +27,17 @@ import {logApiError} from '../services/monitoring/networkLogger';
 let sessionExpiredNotified = false;
 
 /**
+ * Module-scoped interceptor IDs.
+ *
+ * Storing the numeric IDs returned by `.use()` lets us call `.eject()` before
+ * re-registering — making `setupAxiosInterceptor()` safely idempotent even if
+ * invoked multiple times (e.g. React Strict Mode double-effect, hot reloads).
+ */
+let _axiosReqId: number | null = null;
+let _axiosResId: number | null = null;
+let _authAxiosResId: number | null = null;
+
+/**
  * Resets the session-expired notification flag.
  * Call this from your login success handler so that if the *new* session
  * later expires, the user sees the notification again.
@@ -86,10 +97,12 @@ const handleError = (error: any) => {
  * - Response interceptor for handling 401 (unauthorized) errors
  * - Automatic logout and guest mode activation on session expiry
  *
- * This function is intended to be called **once** inside a `useEffect` with
- * an empty dependency array in `AppContent.tsx`. The `useEffect` lifecycle
- * is the idiomatic React guard against duplicate registrations — no global
- * boolean flag is needed here.
+ * This function is **idempotent**: it ejects any previously registered
+ * interceptors before re-registering, so it is safe to call more than once
+ * (e.g. React Strict Mode double-effect, hot reloads, auth re-initialisation).
+ * The previous doc-comment stated that `useEffect([])` was a sufficient guard —
+ * that is only true in production; in development React Strict Mode deliberately
+ * double-invokes effects, so an explicit eject guard is required.
  *
  * @example
  * ```typescript
@@ -100,6 +113,22 @@ const handleError = (error: any) => {
  * ```
  */
 export const setupAxiosInterceptor = () => {
+  // --- Eject any previously registered interceptors -------------------------
+  // This makes the function idempotent regardless of how many times it is
+  // called. Without ejecting, each call appends a new interceptor handler,
+  // leading to duplicate 401 logouts, repeated error toasts, and performance
+  // degradation from stacked async handlers.
+  if (_axiosReqId !== null) {
+    axios.interceptors.request.eject(_axiosReqId);
+  }
+  if (_axiosResId !== null) {
+    axios.interceptors.response.eject(_axiosResId);
+  }
+  if (_authAxiosResId !== null) {
+    authAxios.interceptors.response.eject(_authAxiosResId);
+  }
+  // --------------------------------------------------------------------------
+
   // Ensure global axios instance has default Content-Type for JSON requests
   axios.defaults.headers.common['Content-Type'] = 'application/json';
 
@@ -111,8 +140,11 @@ export const setupAxiosInterceptor = () => {
   authAxios.defaults.timeoutErrorMessage = API_TIMEOUT_ERROR_MESSAGE;
 
   // Request interceptor: dynamically attach Bearer token before every request.
-  axios.interceptors.request.use(
+  // `config.headers ??= {}` guards against the rare case where an Axios adapter
+  // or custom config omits the headers object entirely.
+  _axiosReqId = axios.interceptors.request.use(
     async config => {
+      config.headers ??= {} as typeof config.headers;
       const token = await secureRetrieveItem(SECURE_KEYS.USER_TOKEN);
       if (token) {
         config.headers.Authorization = `Bearer ${token}`;
@@ -127,6 +159,7 @@ export const setupAxiosInterceptor = () => {
 
   // Attach error handler to both the global axios instance (used by existing hooks)
   // and authAxios (used by migrated code with the request interceptor).
-  axios.interceptors.response.use(response => response, handleError);
-  authAxios.interceptors.response.use(response => response, handleError);
+  // Store returned IDs so we can eject on the next call.
+  _axiosResId = axios.interceptors.response.use(response => response, handleError);
+  _authAxiosResId = authAxios.interceptors.response.use(response => response, handleError);
 };

--- a/frontend/src/navigations/StackNavigation.tsx
+++ b/frontend/src/navigations/StackNavigation.tsx
@@ -54,6 +54,14 @@ import GuestPlaceholderScreen from '../components/GuestPlaceholderScreen';
 
 const Stack = createStackNavigator<RootStackParamList>();
 
+
+const ROOT_SCREENS: string[] = [
+  'TabNavigation',
+  'LoginScreen',
+  'LogoutScreen',
+  'GuestPlaceholderScreen',
+];
+
 const StackNavigation = () => {
   const navigation = useNavigation<NavigationProp<RootStackParamList>>();
   const nav = useNavigation<NavigationProp<TabParamList>>();
@@ -63,30 +71,34 @@ const StackNavigation = () => {
       const currentRoute =
         navigation?.getState()?.routes[navigation?.getState()?.index || 0]
           ?.name;
-      const currTab = nav?.getState().routes[nav?.getState()?.index || 0]?.name;
+      const currTab = nav?.getState()?.routes[nav?.getState()?.index || 0]?.name;
 
-      //console.log('Current Route', currentRoute);
-      //console.log('Current Route', currTab);
-      if (
-        currentRoute === 'TabNavigation' ||
-        currentRoute === 'LoginScreen' ||
+      // Show exit dialog when the user is on a root-level screen (no meaningful
+      // back destination), or when a tab-root is active. ROOT_SCREENS includes
+      // LogoutScreen and GuestPlaceholderScreen so pressing Back mid-logout or
+      // from the guest placeholder doesn't silently fall through.
+      const isRootScreen = currentRoute ? ROOT_SCREENS.includes(currentRoute) : false;
+      const isRootTab =
         currTab === 'Home' ||
         currTab === 'Podcasts' ||
-        currTab === 'Profile'
-      ) {
+        currTab === 'Profile';
+
+      if (isRootScreen || isRootTab) {
         Alert.alert('Warning', 'Do you want to exit?', [
           {text: 'No', onPress: () => null},
           {text: 'Yes', onPress: () => BackHandler.exitApp()},
         ]);
-        return true; // Prevent default behavior
+        return true; // Prevent default back behaviour
       } else if (navigation.canGoBack()) {
-        navigation.goBack(); // Allow back navigation for other screens
+        navigation.goBack(); // Allow back navigation for non-root screens
+        return true;
       } else {
+        // Fallback: no back history and not a known root — treat as exit.
         Alert.alert('Warning', 'Do you want to exit?', [
           {text: 'No', onPress: () => null},
           {text: 'Yes', onPress: () => BackHandler.exitApp()},
         ]);
-        return true; // Prevent default behavior
+        return true;
       }
     };
 


### PR DESCRIPTION
## PR Description
## Fixes #1010 
---

### Problem
Multiple production-level issues identified during code review:
- `setupAxiosInterceptor()` had no eject guard — React Strict Mode double-invocations and hot reloads silently stacked duplicate interceptors, risking repeated 401 logouts and toast spam
- `config.headers` assumed non-null in both request interceptors — potential `TypeError` on edge-case Axios configs
- `initMonitoring()` ran at module-load time before `expo-application` metadata was available
- FCM payload and network state logged unconditionally in production builds
- `LogoutScreen` and `GuestPlaceholderScreen` absent from the hardware back-press root-screen guard

### Implemented
- **Interceptor idempotency**: store IDs from `.use()`, call `.eject()` before re-registering on each `setupAxiosInterceptor()` call
- **Headers null-safety**: `config.headers ??= {}` in both `setupAxiosInterceptor.ts` and `authAxios.ts`
- **Monitoring timing**: move `initMonitoring()` from `index.js` module scope into `AppContent`'s first `useEffect`
- **Log gating**: wrap all FCM/network `console.log` calls in `if (__DEV__)`
- **Back-stack**: introduce `ROOT_SCREENS` constant; add `LogoutScreen` + `GuestPlaceholderScreen`


### Files Changed
`setupAxiosInterceptor.ts` · `authAxios.ts` · `index.js` · `AppContent.tsx` · `StackNavigation.tsx` · `ApiTimeout.test.ts`