### PR TITLE
feat: add clear all filters functionality to article explore screen

### DIFF
--- a/frontend/src/screens/HomeScreen.tsx
+++ b/frontend/src/screens/HomeScreen.tsx
@@ -54,6 +54,7 @@ import {
   BaseEmptyState,
 } from '../components/EmptyStates';
 
+
 // Loading State Component with Animation
 const LoadingState = () => {
   return (
@@ -280,18 +281,23 @@ const HomeScreen = ({navigation}: HomeScreenProps) => {
   };
 
   const handleFilterReset = () => {
-    // Update Redux State Variables
-    setSelectCategoryList([]);
-    setSortingType('');
-    setSessionSelectedLanguages([]);
-    dispatch(
-      setSelectedTags({
-        selectedTags: articleCategories,
-      }),
-    );
-    dispatch(setSortType({sortType: ''}));
-    dispatch(setFilteredArticles({filteredArticles: allArticlesRef.current}));
-  };
+  // Reset Redux filter states
+  setSelectCategoryList([]);
+  setSortingType('');
+  setSessionSelectedLanguages([]);
+  dispatch(setSelectedTags({ selectedTags: articleCategories }));
+  dispatch(setSortType({ sortType: '' }));
+
+  // Clear search text and exit search mode
+  dispatch(setSearchMode({ searchMode: false }));
+  dispatch(setSearchedArticles({ searchedArticles: [] }));
+
+  // Reset local Saved filter chip
+  setShowSavedOnly(false);
+
+  // Reset filtered articles to the full accumulated list
+  dispatch(setFilteredArticles({ filteredArticles: allArticlesRef.current }));
+};
 
   const handleFilterApply = () => {
     // Update Redux State Variables


### PR DESCRIPTION
closes(#1081)
git add frontend/src/screens/HomeScreen.tsx
- Updated handleFilterReset() in HomeScreen.tsx to reset:
  - All selected categories/tags
  - Sort type (recent/oldest/popular)
  - Language filters (session + preferences)
  - Search mode and search text input
  - 'Saved' articles filter chip
- The existing refresh icon in HomeScreenHeader now fully resets the feed to default
- Improves UX by allowing one-tap filter reset instead of manual deselection"
