### PR TITLE
fix: remove offline podcast from UI after deletion

### DIFF
--- a/frontend/src/screens/OfflinePodcastList.tsx
+++ b/frontend/src/screens/OfflinePodcastList.tsx
@@ -85,11 +85,15 @@ export default function OfflinePodcastList({
           const res = await deleteFromDownloads(item);
 
           if (res) {
-            Snackbar.show({
-              text: 'Podcast has been removed from offline',
-              duration: Snackbar.LENGTH_SHORT,
-            });
-          } else {
+  setPodcasts(prev =>
+    prev.filter(podcast => podcast._id !== item._id)
+  );
+
+  Snackbar.show({
+    text: 'Podcast has been removed from offline',
+    duration: Snackbar.LENGTH_SHORT,
+  });
+} else {
             Snackbar.show({
               text: 'Failed to removed podcast from offline',
               duration: Snackbar.LENGTH_SHORT,


### PR DESCRIPTION
Summary

Fixes the issue where deleted offline podcasts remain visible on the Offline Podcasts screen until the page is reloaded.

Changes Made

- Updated the local "podcasts" state immediately after a successful deletion.
- Removed the deleted podcast from the displayed list using "setPodcasts()".
- Kept existing success and failure snackbar notifications unchanged.

Problem

Previously, "deleteFromDownloads(item)" removed the podcast from persistent storage, but the UI state was not updated. As a result, the deleted podcast card remained visible until the screen was refreshed or reopened.

Solution

After a successful deletion, the podcast is now removed from the local state using:

setPodcasts(prev =>
  prev.filter(podcast => podcast._id !== item._id)
);

This ensures the UI stays synchronized with storage and provides immediate visual feedback to users.

Issue

Closes #1231