### PR TITLE
fix(web): resolve homepage conflict markers and fix duplicate CSS imports (#1206)

### DIFF
--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Inter, DM_Sans } from "next/font/google";
 // DO NOT remove the globals2.css import, it contains important global styles for the application
+import "./globals.css";
 import "./globals2.css";
 import "@fortawesome/fontawesome-free/css/all.min.css";
 import { cn } from "@/lib/utils";
@@ -18,6 +19,7 @@ const inter = Inter({
 });
 
 // force-dynamic ensures a unique CSP nonce is generated per request (not cached)
+// Note: This disables Next.js static caching for the layout, causing it to be dynamically rendered on every request.
 export const dynamic = "force-dynamic";
 
 export const metadata: Metadata = {
@@ -44,7 +46,6 @@ export default async function RootLayout({
     <html
       lang="en"
       nonce={nonce}
-      data-nonce={nonce}
       className={cn(
         "font-sans",
         dmSans.variable,

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -2,7 +2,6 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import "./globals.css";
 
 import { type RefObject, useCallback, useEffect, useRef, useState, useSyncExternalStore } from "react";
 import HeroAndDownload from "../components/HeroAndDownload";
@@ -10,7 +9,6 @@ import ScrollToTop from "../components/ScrollToTop";
 
 import { PageWrapper, Section } from "../components/layout";
 
-import { withBasePath } from "@/lib/basePath";
 import { Skeleton } from "../components/ui";
 
 
@@ -510,16 +508,12 @@ export default function Home() {
         </nav>
       </header>
 
- fix-unreachable-launching-soon-modal
       {/* ── Hero ── */}
       <HeroAndDownload
         onJoinTestFlight={() => setAppleModal(true)}
         onShowComingSoon={openComingSoonModal}
       />
 
-      {/* ── Hero + Downloads (new premium design) ── */}
-      <HeroAndDownload onJoinTestFlight={() => setAppleModal(true)} />
- web
       {/* ── Screenshots ── */}
       <Section id="screenshots">
         <PageWrapper>


### PR DESCRIPTION
## Description
This Pull Request resolves issue #1206 by performing cleanup of merge conflict markers on the homepage, resolving duplicate imports, and correcting stylesheet loading.

### Changes:
- **Homepage (`web/src/app/page.tsx`):**
  - Removed duplicate `<HeroAndDownload>` component rendering.
  - Cleaned up malformed git conflict markers (`fix-unreachable-launching-soon-modal` and `web`).
  - Ensured only a single `<HeroAndDownload>` is rendered with all proper props (`onJoinTestFlight` and `onShowComingSoon`).
  - Removed unused import `import { withBasePath } from "@/lib/basePath";`.
  - Removed duplicate CSS import `import "./globals.css";`.
- **Layout (`web/src/app/layout.tsx`):**
  - Added global stylesheet import `import "./globals.css";` to Root Layout so it correctly applies to all application pages.
  - Removed redundant html attribute `data-nonce={nonce}` (retaining standard `nonce={nonce}`).
  - Documented that dynamic rendering (`force-dynamic`) disables static caching for this layout.

Fixes #1206
