### PR TITLE
fix: update PrivacyPolicy screen to open official privacy policy URL

### DIFF
--- a/frontend/src/screens/PrivacyPolicy.tsx
+++ b/frontend/src/screens/PrivacyPolicy.tsx
@@ -1,112 +1,53 @@
-import React from 'react';
-import { ScrollView } from 'react-native';
-import { YStack, Text, Separator } from 'tamagui';
+import React, { useEffect } from 'react';
+import { Linking, ActivityIndicator, View, StyleSheet, Platform } from 'react-native';
+import { YStack, Text } from 'tamagui';
 import { hp } from '../helper/Metric';
 
-const TermsAndConditionsScreen = () => {
+const PRIVACY_POLICY_URL =
+  'https://www.freeprivacypolicy.com/live/0b40215e-e456-48cc-a549-424216da1e01';
+
+const PrivacyPolicyScreen = () => {
+  useEffect(() => {
+    const openPrivacyPolicy = async () => {
+      try {
+        if (Platform.OS === 'web') {
+          // On web, open in a new tab
+          window.open(PRIVACY_POLICY_URL, '_blank', 'noopener,noreferrer');
+        } else {
+          // On mobile (Android/iOS), open in default browser
+          const supported = await Linking.canOpenURL(PRIVACY_POLICY_URL);
+          if (supported) {
+            await Linking.openURL(PRIVACY_POLICY_URL);
+          } else {
+            console.error('Cannot open URL:', PRIVACY_POLICY_URL);
+          }
+        }
+      } catch (err) {
+        console.error('Failed to open Privacy Policy URL:', err);
+      }
+    };
+
+    openPrivacyPolicy();
+  }, []);
+
   return (
-    <ScrollView>
-      <YStack padding="$4" space="$4">
-        {/* Title */}
-        <Text fontSize="$8" fontWeight="700">
-          Terms & Conditions
-        </Text>
-
-        <Text color="$gray10">
-          Last updated: 2024
-        </Text>
-
-        <Separator />
-
-        {/* Intro */}
-        <Text>
-          Welcome to <Text fontWeight="600">UltimateHealth</Text>. By accessing or
-          using this application, you agree to comply with and be bound by the
-          following Terms & Conditions.
-        </Text>
-
-        {/* Section */}
-        <Text fontSize="$6" fontWeight="600">
-          1. Acceptance of Terms
-        </Text>
-        <Text>
-          By using this app, you confirm that you are legally permitted to do so
-          and agree to follow all applicable laws and regulations.
-        </Text>
-
-        <Text fontSize="$6" fontWeight="600">
-          2. Purpose of the App
-        </Text>
-        <Text>
-          UltimateHealth is a wellness and lifestyle support application. The
-          content provided is for informational purposes only and should not be
-          considered medical advice.
-        </Text>
-
-        <Text fontSize="$6" fontWeight="600">
-          3. User Responsibilities
-        </Text>
-        <Text>
-          You agree not to misuse the application, attempt unauthorized access,
-          or engage in any activity that disrupts app functionality.
-        </Text>
-
-        <Text fontSize="$6" fontWeight="600">
-          4. Health Disclaimer
-        </Text>
-        <Text>
-          UltimateHealth does not guarantee health outcomes. Always consult a
-          qualified healthcare professional before making medical decisions.
-        </Text>
-
-        <Text fontSize="$6" fontWeight="600">
-          5. Intellectual Property
-        </Text>
-        <Text>
-          All content, branding, and software are the property of UltimateHealth
-          and may not be reused without permission.
-        </Text>
-
-        <Text fontSize="$6" fontWeight="600">
-          6. Privacy
-        </Text>
-        <Text>
-          Your data is handled according to our Privacy Policy. We respect user
-          privacy and do not sell personal information.
-        </Text>
-
-        <Text fontSize="$6" fontWeight="600">
-          7. App Availability
-        </Text>
-        <Text>
-          We may update, modify, or discontinue the app at any time without prior
-          notice.
-        </Text>
-
-        <Text fontSize="$6" fontWeight="600">
-          8. Limitation of Liability
-        </Text>
-        <Text>
-          UltimateHealth is provided “as is” and shall not be liable for any
-          damages arising from the use of this app.
-        </Text>
-
-        <Text fontSize="$6" fontWeight="600">
-          9. Governing Law
-        </Text>
-        <Text>
-          These terms are governed by the laws of India.
-        </Text>
-
-        <Separator />
-
-        {/* Footer */}
-        <Text color="$gray9" fontSize="$4" textAlign="center" marginBottom={hp(5)}>
-          © 2025 UltimateHealth
+    <View style={styles.container}>
+      <YStack alignItems="center" justifyContent="center" space="$3">
+        <ActivityIndicator size="large" />
+        <Text color="$gray10" fontSize="$4" marginTop={hp(2)}>
+          Opening Privacy Policy...
         </Text>
       </YStack>
-    </ScrollView>
+    </View>
   );
 };
 
-export default TermsAndConditionsScreen;
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});
+
+export default PrivacyPolicyScreen;


### PR DESCRIPTION
## Description

### Summary

Fixed the broken Privacy Policy navigation by opening the official UltimateHealth Privacy Policy URL when users click the Privacy Policy option.

### Changes Made

* Added functionality to open the official Privacy Policy URL in the browser.
* Implemented support for both mobile and web platforms.
* Used `Linking.openURL()` for React Native mobile devices.
* Used `window.open()` for web browsers.
* Verified that the Privacy Policy page opens correctly.

### Issue Fixed

Closes #1221

### Type of Change

* [x] Bug fix (change which fixes an issue)
* [ ] New feature (change which adds functionality)
* [ ] Documentation update

### Work Area

* [x] Frontend
* [ ] Backend
* [ ] Documentation
* [ ] Others

### Related Issue

#1221

### Checklist

* [x] I have updated my branch and synced it with the project's branch before making this PR.
* [x] I have optimized the file changes.
* [x] I have added a snapshot of my work example.
* [x] I have made a PR to the project's required branch.

### Undertaking

* [x] My code follows the style guidelines of this project.
* [x] I have performed a self-review of my code.
* [x] I have checked for plagiarism and assure its authenticity.
* [x] I have read and followed the code of conduct for this repository.

### Additional Notes

Official Privacy Policy URL:
https://www.freeprivacypolicy.com/live/0b40215e-e456-48cc-a549-424216da1e01
