### PR TITLE
feat: integrate Knip for unused dependency and dead code detection in Next.js web app

### DIFF
--- a/.github/workflows/knip.yml
+++ b/.github/workflows/knip.yml
@@ -1,0 +1,31 @@
+name: Knip
+
+on:
+  push:
+    branches:
+      - web
+  pull_request:
+    branches:
+      - web
+
+jobs:
+  knip:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        working-directory: web
+        run: npm install
+
+      - name: Run Knip
+        working-directory: web
+        continue-on-error: true
+        run: npm run knip

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,23 @@ Make sure you have [Node.js](https://nodejs.org/) (v18 or higher) and `npm` (or 
 
 ---
 
+## Running Knip
+
+Knip detects unused dependencies, exports, and files in the Next.js web app. From the repository root:
+
+```bash
+cd web
+npm install
+```
+
+Run the following scripts as needed:
+
+- `npm run knip` — check all (dependencies, exports, and files)
+- `npm run knip:deps` — unused dependencies only
+- `npm run knip:files` — unused files only
+
+---
+
 ## 📁 Codebase Directory Structure
 
 All frontend application code is placed in the `/web/src` folder. Please adhere to the following directory layout:

--- a/web/knip.json
+++ b/web/knip.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://unpkg.com/knip@latest/schema.json",
+  "entry": [
+    "src/app/**/*.{ts,tsx}",
+    "src/pages/**/*.{ts,tsx}",
+    "src/components/**/*.{ts,tsx}",
+    "next.config.ts"
+  ],
+  "project": [
+    "src/**/*.{ts,tsx,js,jsx}"
+  ],
+  "ignore": [
+    "public/**",
+    ".next/**",
+    "node_modules/**"
+  ],
+  "ignoreDependencies": [
+    "tw-animate-css",
+    "@tailwindcss/postcss"
+  ]
+}

--- a/web/knip.json
+++ b/web/knip.json
@@ -9,10 +9,12 @@
   "project": [
     "src/**/*.{ts,tsx,js,jsx}"
   ],
+  "$comment": "src/components/ui is temporarily ignored — shadcn/ui generated components not yet fully imported. Remove once component set is reviewed.",
   "ignore": [
     "public/**",
     ".next/**",
-    "node_modules/**"
+    "node_modules/**",
+    "src/components/ui/**"
   ],
   "ignoreDependencies": [
     "tw-animate-css",

--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,10 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "knip": "knip",
+    "knip:deps": "knip --dependencies",
+    "knip:files": "knip --include files"
   },
   "dependencies": {
     "@base-ui/react": "^1.5.0",
@@ -44,6 +47,7 @@
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "16.2.6",
+    "knip": "^5.0.0",
     "tailwindcss": "^4",
     "typescript": "^5"
   }


### PR DESCRIPTION
## Description
Integrates Knip into the Next.js web app to automatically detect unused dependencies, unused files, and dead code paths.

## Related Issue
Closes #883

## What's Changed
- Added `knip` as devDependency in `web/package.json`
- Added three npm scripts to `web/package.json`:
  - `npm run knip` — check all (dependencies, exports, files)
  - `npm run knip:deps` — unused dependencies only
  - `npm run knip:files` — unused files only
- Created `web/knip.json` with Next.js specific entry points and ignores
- Created `.github/workflows/knip.yml` CI workflow targeting `web` branch with `continue-on-error: true`
- Added "Running Knip" section to `CONTRIBUTING.md`

## Type of Change
- [x] New feature

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] Only web/ and .github/workflows/ and CONTRIBUTING.md modified
- [x] PR targets web branch