### PR TITLE
Bugfix: Optimize category modal performance

### DIFF
--- a/frontend/src/components/CategoriesFlatlistModal.tsx
+++ b/frontend/src/components/CategoriesFlatlistModal.tsx
@@ -45,14 +45,37 @@ const CategoriesFlatlistModal = ({
     );
   }, [categories, searchQuery]);
 
+  // Memoize selected category identifiers for constant-time lookup during item rendering
+  const selectCategoryKeys = useMemo(() => {
+
+    const keys = new Set<string>();
+
+    selectCategoryList.forEach((category) => {
+      if(category.id !== undefined){
+        keys.add(`id:${category.id}`);
+      }
+
+      if(category._id !== undefined){
+        keys.add(`_id:${category._id}`);
+      }
+
+      if(category.name !== undefined){
+        keys.add(`name:${category.name}`);
+      }
+    });
+
+    return keys;
+  }, [selectCategoryList]);
+
   // Function to render each category item
   const renderItem = useCallback(
     ({item}: {item: Category}) => {
-      const isSelected = selectCategoryList.some(i => 
-        (i.id !== undefined && item?.id !== undefined && i.id === item.id) ||
-        (i._id !== undefined && item?._id !== undefined && i._id === item._id) ||
-        (i.name === item?.name)
-      );
+
+      const isSelected = 
+        (item?.id !== undefined && selectCategoryKeys.has(`id:${item.id}`)) ||
+        (item?._id !== undefined && selectCategoryKeys.has(`_id:${item._id}`)) ||
+        (item?.name !== undefined && selectCategoryKeys.has(`name:${item.name}`));
+        
       return (
         <AccessibleTouchable
           accessibilityLabel={item.name}

--- a/frontend/src/components/CategoriesFlatlistModal.tsx
+++ b/frontend/src/components/CategoriesFlatlistModal.tsx
@@ -20,6 +20,7 @@ const CategoriesFlatlistModal = ({
   handleCategorySelection,
   selectCategoryList,
 }: HomeScreenCategoriesFlatlistProps) => {
+  const SEARCH_DEBOUNCE_DELAY = 300; // ms
   const [searchQuery, setSearchQuery] = useState('');
   const [debouncedSearchQuery, setDebouncedSearchQuery] = useState('');
 
@@ -42,7 +43,7 @@ const CategoriesFlatlistModal = ({
 
     const timeout = setTimeout(() => {
       setDebouncedSearchQuery(searchQuery);
-    }, 300);
+    }, SEARCH_DEBOUNCE_DELAY);
 
     return () => {
       clearTimeout(timeout);

--- a/frontend/src/components/CategoriesFlatlistModal.tsx
+++ b/frontend/src/components/CategoriesFlatlistModal.tsx
@@ -1,5 +1,5 @@
 import {StyleSheet, Text, View, TextInput} from 'react-native';
-import React, {useCallback, useMemo, useState} from 'react';
+import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import AccessibleTouchable from './common/AccessibleTouchable';
 import {
   BottomSheetModal,
@@ -21,6 +21,7 @@ const CategoriesFlatlistModal = ({
   selectCategoryList,
 }: HomeScreenCategoriesFlatlistProps) => {
   const [searchQuery, setSearchQuery] = useState('');
+  const [debouncedSearchQuery, setDebouncedSearchQuery] = useState('');
 
   const renderBackdrop = useCallback(
     (props: BottomSheetBackdropProps) => (
@@ -36,14 +37,26 @@ const CategoriesFlatlistModal = ({
   // Define snap points for the bottom sheet
   const snapPoints = useMemo(() => ['25%', '75%', '95%'], []);
 
+  // Debounce search input to avoid filtering categories on every keystroke
+  useEffect(() => {
+
+    const timeout = setTimeout(() => {
+      setDebouncedSearchQuery(searchQuery);
+    }, 300);
+
+    return () => {
+      clearTimeout(timeout);
+    };
+  }, [searchQuery]);
+
   // Filter categories based on search
   const filteredCategories = useMemo(() => {
-    if (!searchQuery.trim()) return categories;
+    if (!debouncedSearchQuery.trim()) return categories;
     return categories.filter(cat =>
       cat && cat.name && typeof cat.name === 'string' &&
-      cat.name.toLowerCase().includes((searchQuery || '').toLowerCase())
+      cat.name.toLowerCase().includes((debouncedSearchQuery || '').toLowerCase())
     );
-  }, [categories, searchQuery]);
+  }, [categories, debouncedSearchQuery]);
 
   // Memoize selected category identifiers for constant-time lookup during item rendering
   const selectCategoryKeys = useMemo(() => {
@@ -75,7 +88,7 @@ const CategoriesFlatlistModal = ({
         (item?.id !== undefined && selectCategoryKeys.has(`id:${item.id}`)) ||
         (item?._id !== undefined && selectCategoryKeys.has(`_id:${item._id}`)) ||
         (item?.name !== undefined && selectCategoryKeys.has(`name:${item.name}`));
-        
+
       return (
         <AccessibleTouchable
           accessibilityLabel={item.name}


### PR DESCRIPTION
#### PR Description
- This PR improves the performance of the `CategoriesFlatlistModal` component by optimizing category selection lookups and reducing unnecessary search filtering operations.
- Changes made:
  - Replaced repeated Array.some() traversal scans with a memoized Set of selected category identifiers while preserving the existing category matching behavior (id, _id, and name checks).
  - Introduced a debounced search query state to prevent unnecessary execution of filtering logic on every keystroke.
- Benifits:
  - Faster category selection state evaluation.
  - Improved responsiveness while searching categories.
  - Better scalability as the number of categories and selected items grows.
  - Preserves existing functionality and selection behavior.

#### Type of Change
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update

#### Select your work-area
- [x] Frontend
- [ ] Backend
- [ ] Documentation
- [ ] Others

#### Related Issue
- This PR addresses the performance optimization request raised in issue: #1223 .

#### Add your Work Example
<img width="1377" height="737" alt="image" src="https://github.com/user-attachments/assets/8126c184-0763-4091-b48a-0e08d29fc352" />

#### Fixes (mention the issue number which this fixes)
- Closes #1223 

#### Checklist
- [x] I have updated my branch and synced it with the project's 'develop' branch before making this PR.
- [x] I have optimized the file changes.
- [x] I have added a snapshot of my work example.
- [x] I have made a PR to the project's develop branch.

#### Undertaking
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have checked for plagiarism and assure its authenticity.
- [x] I have read and followed the code of conduct for this repository. I understand that violation of this undertaking may have legal consequences.

- [x] I Agree
