### PR TITLE
feat: implement tabbed Write/Preview interface in EditorScreen (#1291)

### DIFF
--- a/frontend/src/screens/article/EditorScreen.tsx
+++ b/frontend/src/screens/article/EditorScreen.tsx
@@ -1,28 +1,28 @@
- 
-import React, {useEffect, useRef, useState} from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import {
   StyleSheet,
   Text,
   ScrollView,
   Alert,
   TouchableOpacity,
+  View,
 } from 'react-native';
-import {actions, RichEditor, RichToolbar} from 'react-native-pell-rich-editor';
+import { actions, RichEditor, RichToolbar } from 'react-native-pell-rich-editor';
 import Feather from '@expo/vector-icons/Feather';
 import Entypo from '@expo/vector-icons/Entypo';
 import IonIcon from '@expo/vector-icons/Ionicons';
 import FontAwesome from '@expo/vector-icons/FontAwesome';
-import Fontisto from '@expo/vector-icons/Fontisto';
-import {PRIMARY_COLOR} from '../../helper/Theme';
-import {EditorScreenProp} from '../../type';
-import {launchImageLibrary} from 'react-native-image-picker';
-import {useSafeAreaInsets} from 'react-native-safe-area-context';
-import {useDispatch} from 'react-redux';
-import {setSuggestion, setSuggestionAccepted} from '../../store/dataSlice';
+import { PRIMARY_COLOR } from '../../helper/Theme';
+import { EditorScreenProp } from '../../type';
+import { launchImageLibrary } from 'react-native-image-picker';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useDispatch } from 'react-redux';
+import { setSuggestion, setSuggestionAccepted } from '../../store/dataSlice';
 
-// Feature:
-// If you want to discard your post, in that case no post will upload into storage,
-const EditorScreen = ({navigation, route}: EditorScreenProp) => {
+// Import the existing Preview component so we can use it inside the tab
+import PreviewScreen from './PreviewScreen';
+
+const EditorScreen = ({ navigation, route }: EditorScreenProp) => {
   const insets = useSafeAreaInsets();
   const {
     title,
@@ -35,133 +35,45 @@ const EditorScreen = ({navigation, route}: EditorScreenProp) => {
     htmlContent,
     pb_record_id,
     translationSource,
+    language,
   } = route.params;
 
   const RichText = useRef<RichEditor>(null);
-  const [article, setArticle] = useState('');
+  const [article, setArticle] = useState<string>('');
   const [localImages, setLocalImages] = useState<string[]>([]);
   const [htmlImages, setHtmlImages] = useState<string[]>([]);
-  const [editorReady, setEditorReady] = useState(false);
+  const [editorReady, setEditorReady] = useState<boolean>(false);
+
+  // State to manage the active tab
+  const [activeTab, setActiveTab] = useState<'write' | 'preview'>('write');
   const dispatch = useDispatch();
 
-  React.useEffect(() => {
-    navigation.setOptions({
-      headerRight: () => (
-        <TouchableOpacity
-          style={styles.preview_button}
-          onPress={() => {
-            console.log('Preview button pressed');
-            if (article.length > 20) {
-              //console.log('Preview Screen');
-              dispatch(setSuggestion({suggestion: ''}));
-              dispatch(setSuggestionAccepted({selection: false}));
-              navigation.navigate('PreviewScreen', {
-                article: article,
-                title: title,
-                authorName: authorName,
-                description: description,
-                image: imageUtils,
-                selectedGenres: selectedGenres,
-                localImages: localImages,
-                htmlImages: htmlImages,
-                articleData: articleData,
-                requestId: requestId,
-                pb_record_id: pb_record_id,
-                language: route.params.language,
-                translationSource,
-              });
-            } else {
-              Alert.alert('Error', 'Please enter at least 20 characters');
-            }
-          }}>
-          <Fontisto name="preview" size={26} color="white" />
-        </TouchableOpacity>
-      ),
-    });
-  }, [
-    navigation,
-    article,
-    title,
-    description,
-    imageUtils,
-    selectedGenres,
-    authorName,
-    localImages,
-    htmlImages,
-    articleData,
-    requestId,
-    dispatch,
-    pb_record_id,
-    translationSource,
-  ]);
-
   useEffect(() => {
-    /*
-    const loadArticle = async () => {
-      if (!articleData) {
-        return;
-      }
-      try {
-        if (articleData.content.endsWith('.html')) {
-          await getContent(articleData.content);
-
-          setEditorReady(true);
-        } else {
-          setArticle(articleData.content);
-          setEditorReady(true);
-        }
-      } catch (err) {
-        console.error('Failed to load article:', err);
-      }
-    };
-    */
-
     if (htmlContent) {
       setArticle(htmlContent);
       setEditorReady(true);
     }
-
-    // loadArticle();
   }, [htmlContent]);
 
   React.useEffect(() => {
     if (imageUtils) {
-      setLocalImages(prevImages => [imageUtils, ...prevImages]); // Add imageUtils at the start
+      setLocalImages((prevImages: string[]) => [imageUtils, ...prevImages]);
     }
   }, [imageUtils]);
 
   useEffect(() => {
-    if (editorReady && article && RichText.current) {
+    if (activeTab === 'write' && editorReady && article && RichText.current) {
       RichText.current?.setContentHTML(article);
-      //RichText.current?.focusContentEditor(); 
     }
-  }, [ editorReady]);
+  }, [editorReady, activeTab, article]);
 
-  // this function will be called when the editor has been initialized
   function editorInitializedCallback() {
-    RichText.current?.registerToolbar(function (_items) {
+    RichText.current?.registerToolbar(function (_items: any[]) {
       setEditorReady(true);
     });
   }
 
-  /*
-
-  const getContent = async content => {
-    try {
-      const response = await fetch(`${GET_STORAGE_DATA}/${content}`);
-      const text = await response.text();
-      setArticle(text);
-    } catch (error) {
-      // console.error('Error fetching URI:', error);
-      setArticle(content);
-    }
-  };
-  */
-
-  // Callback after height change
-  function handleHeightChange(_height: number) {
-    // console.log("editor height change:", height);
-  }
+  function handleHeightChange(_height: number) {}
 
   async function onPressAddImage() {
     const result = await launchImageLibrary({
@@ -178,208 +90,211 @@ const EditorScreen = ({navigation, route}: EditorScreenProp) => {
       const width = 1000;
       const height = 1000;
 
-      // imageHTML must be declared before it is referenced in setHtmlImages
       const imageHTML = `<img src="${str}" style="width: ${width}px; height: ${height}px;" />`;
 
-      setLocalImages(prev => [...prev, str]);
-      setHtmlImages(prev => [...prev, imageHTML]);
+      setLocalImages((prev: string[]) => [...prev, str]);
+      setHtmlImages((prev: string[]) => [...prev, imageHTML]);
 
       await RichText.current?.insertHTML(imageHTML);
-
-      //await RichText.current?.insertImage(str);
-    } else {
-      //console.log('No image selected');
     }
   }
 
-  // async function insertVideo() {
-  //   const result = await ImagePicker.launchImageLibrary({
-  //     mediaType: 'video',
-  //     presentationStyle: 'popover',
-  //   });
+  // Helper to handle switching to preview
+  const handleTabSwitch = (tab: 'write' | 'preview') => {
+    if (tab === 'preview' && article.length <= 20) {
+      Alert.alert('Error', 'Please enter at least 20 characters before previewing.');
+      return;
+    }
 
-  //   if (result.assets && result.assets.length > 0) {
-  //     const fileUri = result.assets[0].uri;
-  //     console.log('Image URI:', fileUri);
-  //     setvideoData(`${fileUri}`);
-  //     // Convert the video URI to a Blob
-  //     // await RichText.current?.insertVideo(blobUrl);
-  //     // Insert video through local file url
-  //     RichText.current?.insertVideo(fileUri);
-  //   } else {
-  //     console.log('No video selected');
-  //   }
-  // }
-  /*
-  const onPressAddImage =  () => {
-    const options = {
-      mediaType: 'photo',
-      includeBase64: true,
-    };
-
-    launchImageLibrary(options, async response => {
-      if (response.didCancel) {
-        console.log('User cancelled image picker');
-      } else if (response.error) {
-        console.log('ImagePicker Error: ', response.error);
-      } else if (response.assets) {
-        const {uri, fileSize} = response.assets[0];
-
-        // Check file size (1 MB limit)
-        if (fileSize && fileSize > 1024 * 1024) {
-          Alert.alert('Error', 'File size exceeds 1 MB.');
-          return;
-        }
-
-        // Check dimensions
-        ImageResizer.createResizedImage(uri, 2000, 2000, 'JPEG', 100)
-          .then(async resizedImageUri => {
-            // If the image is resized successfully, upload it
-          })
-          .catch(err => {
-            console.log(err);
-            Alert.alert('Error', 'Could not resize the image.');
-          });
-
-        // setImageUtils(uri ? uri : '');
-        await RichText.current?.insertImage(uri ? uri : '');
-      }
-    });
+    if (tab === 'preview') {
+      dispatch(setSuggestion({ suggestion: '' }));
+      dispatch(setSuggestionAccepted({ selection: false }));
+    }
+    setActiveTab(tab);
   };
-*/
+
   return (
-    <ScrollView
-      style={[styles.container, {paddingBottom: insets.bottom}]}
-      showsVerticalScrollIndicator={false}
-      keyboardShouldPersistTaps="handled">
+    <View style={[styles.container, { paddingBottom: insets.bottom }]}>
+      
+      {/* --- TABBED NAVIGATION UI --- */}
+      <View style={styles.tabContainer}>
+        <TouchableOpacity
+          style={[styles.tabButton, activeTab === 'write' && styles.activeTabButton]}
+          onPress={() => handleTabSwitch('write')}
+        >
+          <Text style={[styles.tabText, activeTab === 'write' && styles.activeTabText]}>
+            Write
+          </Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[styles.tabButton, activeTab === 'preview' && styles.activeTabButton]}
+          onPress={() => handleTabSwitch('preview')}
+        >
+          <Text style={[styles.tabText, activeTab === 'preview' && styles.activeTabText]}>
+            Preview
+          </Text>
+        </TouchableOpacity>
+      </View>
 
-      {/* Writing Helper Text */}
-      <Text style={styles.helperText}>
-        Compose your article with rich formatting tools below
-      </Text>
+      {/* --- CONDITIONAL RENDERING --- */}
+      {activeTab === 'write' ? (
+        <ScrollView
+          style={{ flex: 1 }}
+          showsVerticalScrollIndicator={false}
+          keyboardShouldPersistTaps="handled"
+        >
+          <Text style={styles.helperText}>
+            Compose your article with rich formatting tools below
+          </Text>
 
-      <RichToolbar
-        style={styles.richBar}
-        editor={RichText}
-        disabled={false}
-        iconTint={'#FFFFFF'}
-        selectedIconTint={'#FCD34D'}
-        disabledIconTint={'#9CA3AF'}
-        onPressAddImage={onPressAddImage}
-        iconSize={28}
-        actions={[
-          // Text Formatting Actions
-          actions.setBold,
-          actions.setItalic,
-          actions.setUnderline,
-          actions.setStrikethrough,
+          <RichToolbar
+            style={styles.richBar}
+            editor={RichText}
+            disabled={false}
+            iconTint={'#FFFFFF'}
+            selectedIconTint={'#FCD34D'}
+            disabledIconTint={'#9CA3AF'}
+            onPressAddImage={onPressAddImage}
+            iconSize={28}
+            actions={[
+              actions.setBold,
+              actions.setItalic,
+              actions.setUnderline,
+              actions.setStrikethrough,
+              actions.heading1,
+              actions.heading2,
+              actions.heading3,
+              actions.alignLeft,
+              actions.alignCenter,
+              actions.alignRight,
+              actions.insertBulletsList,
+              actions.insertOrderedList,
+              actions.insertLink,
+              actions.insertImage,
+              actions.blockquote,
+              actions.undo,
+              actions.redo,
+            ]}
+            iconMap={{
+              [actions.setStrikethrough]: ({ tintColor }: { tintColor: string }) => (
+                <FontAwesome name="strikethrough" color={tintColor} size={24} />
+              ),
+              [actions.alignLeft]: ({ tintColor }: { tintColor: string }) => (
+                <Feather name="align-left" color={tintColor} size={28} />
+              ),
+              [actions.alignCenter]: ({ tintColor }: { tintColor: string }) => (
+                <Feather name="align-center" color={tintColor} size={28} />
+              ),
+              [actions.alignRight]: ({ tintColor }: { tintColor: string }) => (
+                <Feather name="align-right" color={tintColor} size={28} />
+              ),
+              [actions.undo]: ({ tintColor }: { tintColor: string }) => (
+                <IonIcon name="arrow-undo" color={tintColor} size={28} />
+              ),
+              [actions.redo]: ({ tintColor }: { tintColor: string }) => (
+                <IonIcon name="arrow-redo" color={tintColor} size={28} />
+              ),
+              [actions.heading1]: ({ tintColor }: { tintColor: string }) => (
+                <Text style={[styles.headingIcon, { color: tintColor }]}>H1</Text>
+              ),
+              [actions.heading2]: ({ tintColor }: { tintColor: string }) => (
+                <Text style={[styles.headingIcon, { color: tintColor }]}>H2</Text>
+              ),
+              [actions.heading3]: ({ tintColor }: { tintColor: string }) => (
+                <Text style={[styles.headingIcon, { color: tintColor }]}>H3</Text>
+              ),
+              [actions.insertImage]: ({ tintColor }: { tintColor: string }) => (
+                <Entypo name="image" color={tintColor} size={26} />
+              ),
+              [actions.blockquote]: ({ tintColor }: { tintColor: string }) => (
+                <Entypo name="quote" color={tintColor} size={28} />
+              ),
+            }}
+            insertImage={onPressAddImage}
+          />
 
-          // Heading Actions
-          actions.heading1,
-          actions.heading2,
-          actions.heading3,
+          <RichEditor
+            disabled={false}
+            containerStyle={styles.editor}
+            ref={RichText}
+            style={styles.rich}
+            placeholder={'Start writing your article here...'}
+            initialContentHTML={article}
+            onChange={(text: string) => setArticle(text)}
+            editorInitializedCallback={editorInitializedCallback}
+            onHeightChange={handleHeightChange}
+            initialHeight={650}
+            useContainer={true}
+            pasteAsPlainText={false}
+          />
 
-          // Alignment Actions
-          actions.alignLeft,
-          actions.alignCenter,
-          actions.alignRight,
-
-          // List Actions
-          actions.insertBulletsList,
-          actions.insertOrderedList,
-
-          // Insert Actions
-          actions.insertLink,
-          actions.insertImage,
-          actions.blockquote,
-
-          // Undo/Redo Actions
-          actions.undo,
-          actions.redo,
-        ]}
-        iconMap={{
-          // Custom Icons for Text Formatting Actions
-          [actions.setStrikethrough]: ({tintColor}: {tintColor: string}) => (
-            <FontAwesome name="strikethrough" color={tintColor} size={24} />
-          ),
-          [actions.alignLeft]: ({tintColor}: {tintColor: string}) => (
-            <Feather name="align-left" color={tintColor} size={28} />
-          ),
-          [actions.alignCenter]: ({tintColor}: {tintColor: string}) => (
-            <Feather name="align-center" color={tintColor} size={28} />
-          ),
-          [actions.alignRight]: ({tintColor}: {tintColor: string}) => (
-            <Feather name="align-right" color={tintColor} size={28} />
-          ),
-          [actions.undo]: ({tintColor}: {tintColor: string}) => (
-            <IonIcon name="arrow-undo" color={tintColor} size={28} />
-          ),
-          [actions.redo]: ({tintColor}: {tintColor: string}) => (
-            <IonIcon name="arrow-redo" color={tintColor} size={28} />
-          ),
-          [actions.heading1]: ({tintColor}: {tintColor: string}) => (
-            <Text style={[styles.headingIcon, {color: tintColor}]}>H1</Text>
-          ),
-          [actions.heading2]: ({tintColor}: {tintColor: string}) => (
-            <Text style={[styles.headingIcon, {color: tintColor}]}>H2</Text>
-          ),
-          [actions.heading3]: ({tintColor}: {tintColor: string}) => (
-            <Text style={[styles.headingIcon, {color: tintColor}]}>H3</Text>
-          ),
-          [actions.insertImage]: ({tintColor}: {tintColor: string}) => (
-            <Entypo name="image" color={tintColor} size={26} />
-          ),
-          [actions.blockquote]: ({tintColor}: {tintColor: string}) => (
-            <Entypo name="quote" color={tintColor} size={28} />
-          ),
-        }}
-        insertImage={onPressAddImage}
-      />
-
-      <RichEditor
-        disabled={false}
-        containerStyle={styles.editor}
-        ref={RichText}
-        style={styles.rich}
-        placeholder={'Start writing your article here...'}
-        initialContentHTML={article}
-        onChange={text => setArticle(text)}
-        editorInitializedCallback={editorInitializedCallback}
-        onHeightChange={handleHeightChange}
-        initialHeight={650}
-        useContainer={true}
-        pasteAsPlainText={false}
-      />
-
-      {/* Character Count Helper */}
-      <Text style={styles.characterCount}>
-        {article.replace(/<[^>]*>/g, '').length} characters
-      </Text>
-    </ScrollView>
+          <Text style={styles.characterCount}>
+            {article.replace(/<[^>]*>/g, '').length} characters
+          </Text>
+        </ScrollView>
+      ) : (
+        /* --- RENDER EXISTING PREVIEW COMPONENT --- */
+        <View style={{ flex: 1 }}>
+          {/* We use 'as any' here to bypass TypeScript's strict screen-to-screen navigation checks */}
+          <PreviewScreen 
+            navigation={navigation as any} 
+            route={{
+              params: {
+                article: article,
+                title: title,
+                authorName: authorName,
+                description: description,
+                image: imageUtils,
+                selectedGenres: selectedGenres,
+                localImages: localImages,
+                htmlImages: htmlImages,
+                articleData: articleData,
+                requestId: requestId,
+                pb_record_id: pb_record_id,
+                language: language,
+                translationSource: translationSource,
+              }
+            } as any} 
+          />
+        </View>
+      )}
+    </View>
   );
 };
 
 export default EditorScreen;
 
 const styles = StyleSheet.create({
-  /********************************/
-  /* styles for html tags */
-  a: {
-    fontWeight: 'bold',
-    color: PRIMARY_COLOR,
-  },
-  div: {
-    fontFamily: 'monospace',
-  },
-  p: {
-    fontSize: 16,
-    lineHeight: 24,
-  },
-  /*******************************/
   container: {
     flex: 1,
     backgroundColor: '#F9FAFB',
   },
+  /* --- TAB STYLES --- */
+  tabContainer: {
+    flexDirection: 'row',
+    backgroundColor: '#FFFFFF',
+    borderBottomWidth: 1,
+    borderBottomColor: '#E5E7EB',
+  },
+  tabButton: {
+    flex: 1,
+    paddingVertical: 14,
+    alignItems: 'center',
+    borderBottomWidth: 2,
+    borderBottomColor: 'transparent',
+  },
+  activeTabButton: {
+    borderBottomColor: PRIMARY_COLOR,
+  },
+  tabText: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: '#6B7280',
+  },
+  activeTabText: {
+    color: PRIMARY_COLOR,
+  },
+  /* ---------------------- */
   helperText: {
     fontSize: 15,
     color: '#6B7280',
@@ -398,7 +313,7 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: '#E5E7EB',
     shadowColor: '#000',
-    shadowOffset: {width: 0, height: 2},
+    shadowOffset: { width: 0, height: 2 },
     shadowOpacity: 0.05,
     shadowRadius: 4,
     elevation: 2,
@@ -420,7 +335,7 @@ const styles = StyleSheet.create({
     marginTop: 8,
     marginBottom: 8,
     shadowColor: PRIMARY_COLOR,
-    shadowOffset: {width: 0, height: 2},
+    shadowOffset: { width: 0, height: 2 },
     shadowOpacity: 0.2,
     shadowRadius: 4,
     elevation: 3,
@@ -442,10 +357,5 @@ const styles = StyleSheet.create({
     borderRadius: 8,
     borderWidth: 1,
     borderColor: '#E5E7EB',
-  },
-  preview_button: {
-    marginRight: 15,
-    paddingHorizontal: 8,
-    paddingVertical: 6,
   },
 });


### PR DESCRIPTION
### Description
Closes #1291

**What this PR does:**
This PR restructures the `EditorScreen` to use a seamless "Write / Preview" tabbed interface, replacing the previous flow that required a navigation jump to a separate screen.

**Why it was implemented:**
As discussed in the issue, a split-screen approach reduces mobile typing space. This tabbed approach preserves the full-screen writing area while allowing users to instantly verify their formatting before publishing, resulting in a much better mobile UX.

**Technical Details:**
- Added a `<TouchableOpacity>` tab toggle at the top of the `EditorScreen`.
- Successfully reused the existing `PreviewScreen` component inside the tab to avoid adding any new markdown parsing dependencies.
- Added type assertions to gracefully handle the screen-to-component navigation prop types.

### Screenshots / Screen Recording
*(Drag and drop a screenshot of the "Write" tab here)*

*(Drag and drop a screenshot of the "Preview" tab here)*

### Checklist
- [x] I have read the Contributing Guidelines
- [x] I have tested this on my local machine / Expo Go
- [x] I'm a GSSoC'26 contributor
