### PR TITLE
feat: add auto scrolling to screenshots carousel

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -329,9 +329,41 @@ export default function Home() {
     }
   };
 
-  const moveSlider = (ref: RefObject<HTMLDivElement | null>, dir: number) => {
-    ref.current?.scrollBy({ left: dir * SLIDER_SCROLL_AMOUNT, behavior: "smooth" });
-  };
+const moveSlider = (ref: RefObject<HTMLDivElement | null>, dir: number) => {
+  const slider = ref.current;
+  if (!slider) return;
+
+  const maxScroll = slider.scrollWidth - slider.clientWidth;
+  const nextScroll = slider.scrollLeft + dir * SLIDER_SCROLL_AMOUNT;
+
+  if (slider.scrollLeft >= maxScroll - 5) {
+    slider.scrollTo({ left: 0, behavior: "auto" });
+    return;
+  }
+
+  if (nextScroll > maxScroll) {
+    slider.scrollTo({ left: maxScroll, behavior: "smooth" });
+    return;
+  }
+
+  if (nextScroll < 0) {
+    slider.scrollTo({ left: maxScroll, behavior: "auto" });
+    return;
+  }
+
+  slider.scrollTo({ left: nextScroll, behavior: "smooth" });
+};
+  useEffect(() => {
+    const interval = setInterval(() => {
+      moveSlider(userSliderRef, 1);
+
+      if (adminSliderOpen) {
+        moveSlider(adminSliderRef, 1);
+      }
+    }, 1500);
+
+    return () => clearInterval(interval);
+  }, [adminSliderOpen]);
 
   // ── TestFlight invite ──
   const sendTesterEmail = async () => {

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -334,24 +334,32 @@ const moveSlider = (ref: RefObject<HTMLDivElement | null>, dir: number) => {
   if (!slider) return;
 
   const maxScroll = slider.scrollWidth - slider.clientWidth;
-  const nextScroll = slider.scrollLeft + dir * SLIDER_SCROLL_AMOUNT;
+  const currentScroll = slider.scrollLeft;
+  const targetScroll = currentScroll + dir * SLIDER_SCROLL_AMOUNT;
 
-  if (slider.scrollLeft >= maxScroll - 5) {
-    slider.scrollTo({ left: 0, behavior: "auto" });
-    return;
+  if (dir === 1) {
+    if (currentScroll >= maxScroll) {
+      slider.scrollTo({ left: 0, behavior: "auto" });
+      return;
+    }
+
+    if (targetScroll > maxScroll) {
+      slider.scrollTo({ left: maxScroll, behavior: "smooth" });
+      return;
+    }
   }
 
-  if (nextScroll > maxScroll) {
-    slider.scrollTo({ left: maxScroll, behavior: "smooth" });
-    return;
+  if (dir === -1) {
+    if (currentScroll <= 0 || targetScroll < 0) {
+      slider.scrollTo({ left: maxScroll, behavior: "auto" });
+      return;
+    }
   }
 
-  if (nextScroll < 0) {
-    slider.scrollTo({ left: maxScroll, behavior: "auto" });
-    return;
-  }
-
-  slider.scrollTo({ left: nextScroll, behavior: "smooth" });
+  slider.scrollTo({
+    left: Math.max(0, Math.min(targetScroll, maxScroll)),
+    behavior: "smooth",
+  });
 };
   useEffect(() => {
     const interval = setInterval(() => {


### PR DESCRIPTION
#### PR Description
Added automatic scrolling functionality to the screenshots carousel section. The carousel now transitions through screenshots automatically while preserving the existing left and right navigation controls. A looping behavior has been implemented so that after reaching the final screenshot, the carousel returns to the beginning, improving the overall user experience and reducing the need for manual interaction.

#### Type of Change
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Documentation update

#### Select your work-area
- [x] Frontend
- [ ] Backend
- [ ] Documentation
- [ ] Others

#### Related Issue
https://github.com/SB2318/UltimateHealth/issues/841

#### Add your Work Example
**Before Implementation**

- Screenshot carousel required manual navigation using the left and right arrow buttons.
- Screenshots did not transition automatically.

https://github.com/user-attachments/assets/4d0f4179-fab8-44ed-a72b-7030a8299a03

**After Implementation**

- Added automatic scrolling to the screenshots carousel.
- Existing navigation arrows continue to work as expected.
- Carousel loops through screenshots automatically, improving user experience.

https://github.com/user-attachments/assets/73b19b9d-1a69-455b-8852-fe9092919d62

#### Fixes (mention the issue number which this fixes)
closes#841

#### Checklist
- [x] I have updated my branch and synced it with the project's 'develop' branch before making this PR.
- [x] I have optimized the file changes.
- [x] I have added a snapshot of my work example.
- [x] I have made a PR to the project's develop branch.

#### Undertaking
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have checked for plagiarism and assure its authenticity.
- [x] I have read and followed the code of conduct for this repository. I understand that violation of this undertaking may have legal consequences.

- [x] I Agree
