### PR TITLE
fix: handle undefined profile_image in LogoutScreen to prevent TypeEr…

### DIFF
--- a/frontend/src/screens/auth/LogoutScreen.tsx
+++ b/frontend/src/screens/auth/LogoutScreen.tsx
@@ -80,11 +80,15 @@ const LogoutScreen = ({navigation, route}: LogoutScreenProp) => {
                 styles.alertAvatar,
                 !profile_image && {borderWidth: 0.5, borderColor: theme.black.val},
               ]}
-              source={{
-                uri: profile_image.startsWith('https')
-                  ? profile_image
-                  : `${GET_STORAGE_DATA}/${profile_image}`,
-              }}
+              source={
+  profile_image
+    ? {
+        uri: profile_image.startsWith('https')
+          ? profile_image
+          : `${GET_STORAGE_DATA}/${profile_image}`,
+      }
+    : require('../../assets/images/avatar.jpg')
+}
             />
 
             <Text style={[


### PR DESCRIPTION
## Description
Fixes #1316

## Root Cause
In `LogoutScreen.tsx` line 84, `.startsWith('https')` was called directly 
on `profile_image` without a null check, causing a TypeError crash for 
users with no profile picture set.

## Fix
Added a null check before accessing `.startsWith()`. When `profile_image` 
is undefined, the component now falls back to a default avatar image 
instead of crashing.

## Files Changed
- `frontend/src/screens/auth/LogoutScreen.tsx`

## Type of Change
- [x] Bug fix