### PR TITLE
Fix/user profile lookup by handle

### DIFF
--- a/frontend/src/screens/UserProfileScreen.tsx
+++ b/frontend/src/screens/UserProfileScreen.tsx
@@ -54,7 +54,9 @@ const UserProfileScreen = ({navigation, route}: UserProfileScreenProp) => {
 
   // Get the actual authorId string
  // const actualAuthorId = typeof authorId === 'string' ? authorId : authorId?._id || userId || '';
-  const actualAuthorId = routeUserId || user_id; // Prioritize routeUserId, fallback to current user_id
+  // If only a handle is provided (e.g. from @mention), don't fall back to
+// the logged-in user's ID — let useGetAuthorProfile resolve via handle instead
+const actualAuthorId = routeUserId || authorId || (author_handle ? '' : user_id); // Prioritize routeUserId, fallback to current user_id
   const {
     data: user,
     refetch,

--- a/frontend/src/screens/auth/LogoutScreen.tsx
+++ b/frontend/src/screens/auth/LogoutScreen.tsx
@@ -80,15 +80,11 @@ const LogoutScreen = ({navigation, route}: LogoutScreenProp) => {
                 styles.alertAvatar,
                 !profile_image && {borderWidth: 0.5, borderColor: theme.black.val},
               ]}
-              source={
-  profile_image
-    ? {
-        uri: profile_image.startsWith('https')
-          ? profile_image
-          : `${GET_STORAGE_DATA}/${profile_image}`,
-      }
-    : require('../../assets/images/avatar.jpg')
-}
+              source={{
+                uri: profile_image.startsWith('https')
+                  ? profile_image
+                  : `${GET_STORAGE_DATA}/${profile_image}`,
+              }}
             />
 
             <Text style={[

--- a/frontend/src/screens/auth/LogoutScreen.tsx
+++ b/frontend/src/screens/auth/LogoutScreen.tsx
@@ -80,11 +80,15 @@ const LogoutScreen = ({navigation, route}: LogoutScreenProp) => {
                 styles.alertAvatar,
                 !profile_image && {borderWidth: 0.5, borderColor: theme.black.val},
               ]}
-              source={{
-                uri: profile_image.startsWith('https')
-                  ? profile_image
-                  : `${GET_STORAGE_DATA}/${profile_image}`,
-              }}
+              source={
+  profile_image
+    ? {
+        uri: profile_image.startsWith('https')
+          ? profile_image
+          : `${GET_STORAGE_DATA}/${profile_image}`,
+      }
+    : require('../../assets/images/avatar.jpg')
+}
             />
 
             <Text style={[


### PR DESCRIPTION
#### PR Description
Fixed a bug where clicking on a user mention (@username) in comments 
navigated to the logged-in user's own profile instead of the mentioned 
user's profile. When navigating via mention handle, `routeUserId` is 
absent, causing `actualAuthorId` to fall back to the logged-in user's 
`user_id`. Fixed by preventing the fallback to `user_id` when a handle 
is available, and ensuring `routeUserHandle` correctly inherits 
`author_handle` for handle-based profile lookups.

#### Type of Change
- [x] Bug fix (change which fixes an issue)

#### Select your work-area
- [x] Frontend

#### Related Issue
https://github.com/SB2318/UltimateHealth/issues/1288

#### Add your Work Example
Before: Clicking @username in comments shows logged-in user's own profile.
After: Clicking @username correctly navigates to the mentioned user's profile.

#### Fixes (mention the issue number which this fixes)
#1288

#### Checklist
- [x] I have updated my branch and synced it with the project's 'develop' branch before making this PR.
- [x] I have optimized the file changes.
- [x] I have made a PR to the project's develop branch.

#### Undertaking
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have checked for plagiarism and assure its authenticity.
- [x] I have read and followed the code of conduct for this repository.
- [x] I Agree