### PR TITLE
fix: remove hardcoded Google Gemini API key from .env.example

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -33,7 +33,7 @@ EXPO_PUBLIC_APP_ENV = "development"
   "expo": {
     "name": "UltimateHealth",
     "extra": {
-      "geminiApiKey": "AIza-AQ.Ab8RN6LVTyuc1zr5a4YJVPl84xXgL1FaecqEhQCzT5jB599AHQ"
+      "geminiApiKey": "AIza-YOUR-FREE-KEY-HERE"
     }
   }
 }


### PR DESCRIPTION
#1341
Removes exposed Google Gemini API key from .env.example file.
This file should only contain placeholder values, not actual credentials.