### PR TITLE
fix: search across all loaded articles

### DIFF
--- a/frontend/src/screens/HomeScreen.tsx
+++ b/frontend/src/screens/HomeScreen.tsx
@@ -469,28 +469,29 @@ const HomeScreen = ({navigation}: HomeScreenProps) => {
   }, [isFetching, refreshing]);
 
   const handleSearch = (textInput: string) => {
-    //console.log('Search Input', textInput);
-    if (textInput === '' || articleData === undefined) {
-      dispatch(setSearchedArticles({searchedArticles: []}));
-      dispatch(setSearchMode({searchMode: false}));
-    } else {
-      dispatch(setSearchMode({searchMode: true}));
-      const matchesSearch = articleData?.articles.filter(article => {
-        const matchesTitle = article.title && typeof article.title === 'string'
+  if (textInput === '' || allArticlesRef.current.length === 0) {
+    dispatch(setSearchedArticles({ searchedArticles: [] }));
+    dispatch(setSearchMode({ searchMode: false }));
+  } else {
+    dispatch(setSearchMode({ searchMode: true }));
+    const matchesSearch = allArticlesRef.current.filter(article => {  // ✅ use full accumulated list
+      const matchesTitle =
+        article.title && typeof article.title === 'string'
           ? article.title.toLowerCase().includes((textInput || '').toLowerCase())
           : false;
-        const matchesTags = article.tags && Array.isArray(article.tags)
-          ? article.tags.some(tag =>
-              tag && tag.name && typeof tag.name === 'string' &&
-              tag.name.toLowerCase().includes((textInput || '').toLowerCase())
+      const matchesTags =
+        article.tags && Array.isArray(article.tags)
+          ? article.tags.some(
+              tag =>
+                tag && tag.name && typeof tag.name === 'string' &&
+                tag.name.toLowerCase().includes((textInput || '').toLowerCase()),
             )
           : false;
-
-        return matchesTitle || matchesTags;
-      });
-      dispatch(setSearchedArticles({searchedArticles: matchesSearch}));
-    }
-  };
+      return matchesTitle || matchesTags;
+    });
+    dispatch(setSearchedArticles({ searchedArticles: matchesSearch }));
+  }
+};
 
   const listData = useMemo(() => {
     if (showSavedOnly) {


### PR DESCRIPTION
## Summary

This PR fixes a search issue in `HomeScreen` where `handleSearch` was filtering only `articleData.articles`, which contains the most recently fetched page of articles.

Since the application accumulates paginated articles in `allArticlesRef.current`, articles from previously loaded pages could be omitted from search results. The search logic has been updated to use `allArticlesRef.current` so that users can search across all loaded articles.

## Changes Made

* Updated `handleSearch` to search against `allArticlesRef.current`
* Ensured search results include articles loaded from previous pages
* Preserved existing search behavior for titles and tags

#### Type of Change

* [x] Bug fix (change which fixes an issue)

#### Select your work-area

* [x] Frontend

#### Related Issue

Fixes: #1358

#### Add your Work Example

Before:

* Search only worked on the most recently fetched page.

After:

* Search works across all loaded articles accumulated through pagination.

#### Fixes (mention the issue number which this fixes)

Closes #1358 

#### Checklist

* [ ] I have updated my branch and synced it with the project's 'develop' branch before making this PR.
* [x] I have optimized the file changes.
* [ ] I have added a snapshot of my work example. 
* [ ] I have made a PR to the project's develop branch.

#### Undertaking

* [x] My code follows the style guidelines of this project.
* [x] I have performed a self-review of my code.
* [x] I have checked for plagiarism and assure its authenticity.
* [x] I have read and followed the code of conduct for this repository.
* [x] I Agree
