### PR TITLE
fix(web): replace dead anchor tags with Next.js Link component

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -466,7 +466,7 @@ const moveSlider = (ref: RefObject<HTMLDivElement | null>, dir: number) => {
       {/* ── Header ── */}
       <header className={`header${scrolled ? " scrolled" : ""}`} id="header">
         <PageWrapper as="div" className="nav">
-          <a href="#" className="logo">
+          <Link href={withBasePath("/")} className="logo">
             <div className="logo-icon">
               <Image
                 src="https://raw.githubusercontent.com/SB2318/UltimateHealth/refs/heads/main/frontend/src/assets/images/adaptive-icon.png"
@@ -475,7 +475,7 @@ const moveSlider = (ref: RefObject<HTMLDivElement | null>, dir: number) => {
               />
             </div>
             Ultimate-Health
-          </a>
+          </Link>
 
           <ul className="nav-links">
             <li>
@@ -921,7 +921,7 @@ const moveSlider = (ref: RefObject<HTMLDivElement | null>, dir: number) => {
           {/* Quick Links */}
           <div className="footer-links-col">
             <h3>Quick Links</h3>
-            <a href="#">Home</a>
+            <Link href={withBasePath("/")}>Home</Link>
             <a href="#features">Features</a>
             <a href="#programs">Programs</a>
             <a href="#screenshots">Screenshots</a>


### PR DESCRIPTION
## Fix Issue #889

### Changes Made
- Replaced logo dead link `<a href="#">` with `<Link href={withBasePath("/")}>`
- Replaced footer Home link `<a href="#">` with `<Link href={withBasePath("/")}>`
- Verified all remaining anchor tags are appropriately implemented:
  - Smooth scroll anchors (#features, #programs, #screenshots, #contact) ✓
  - External links with target="_blank" and rel="noreferrer" ✓
  - Internal routes using Link components ✓
  - mailto and external documentation links ✓

### Why This Matters
- Enables client-side routing (no full page reloads)
- Automatic route prefetching by Next.js
- Better performance and SEO
- Fixes broken home/logo navigation

### Type of Change
- [x] Bug fix (change which fixes an issue)

### Work Area
- [x] Frontend

Closes #889
