### PR TITLE
docs: add backend and frontend repository links in README services section

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,20 +418,20 @@ Builds are also triggered automatically via GitHub Actions on pushes to `main`.
 
 ## Services & API Dependencies
 
-| Service | URL | Purpose |
-|---|---|---|
-| REST API | [uhsocial.in/docs](https://uhsocial.in/docs) | Backend API (Node.js + MongoDB) |
-| Content Intelligence | [uhsocial.in/content-intel/docs](https://uhsocial.in/content-intel/docs) | Plagiarism and grammar checks (Python) |
-| Web Frontend | [uhsocial.in/frontend/v2](https://uhsocial.in/frontend/v2) | React web app (web branch) |
-| Android App | [Play Store](https://play.google.com/store/apps/details?id=com.anonymous.UltimateHealth) | Published Android app |
+| Service | URL | Purpose | Repository |
+|---|---|---|---|
+| REST API | [uhsocial.in/docs](https://uhsocial.in/docs) | Backend API (Node.js + MongoDB) | [ultimatehealth-backend](https://github.com/SB2318/ultimatehealth-backend) |
+| Content Intelligence | [uhsocial.in/content-intel/docs](https://uhsocial.in/content-intel/docs) | Plagiarism and grammar checks (Python) | [VeriWise-Content-Check](https://github.com/SB2318/VeriWise-Content-Check) |
+| Web Frontend | [uhsocial.in/frontend/v2](https://uhsocial.in/frontend/v2) | React web app (web branch) | [UltimateHealth](https://github.com/SB2318/UltimateHealth) |
+| Android App | [Play Store](https://play.google.com/store/apps/details?id=com.anonymous.UltimateHealth) | Published Android app | [UltimateHealth](https://github.com/SB2318/UltimateHealth) |
 
 ### Submodule Repositories
 
-| Repository | Purpose |
-|---|---|
-| [ultimatehealth-backend](https://github.com/SB2318/ultimatehealth-backend) | Node.js + MongoDB backend |
-| [ultimatehealth-admin](https://github.com/SB2318/ultimatehealth-admin-app) | Admin panel app |
-| [VeriWise-Content-Check](https://github.com/SB2318/VeriWise-Content-Check) | Content integrity checker |
+| Service | Repository |
+|----------|------------|
+| Backend | [ultimatehealth-backend](https://github.com/SB2318/ultimatehealth-backend) |
+| Admin Panel | [ultimatehealth-admin](https://github.com/SB2318/ultimatehealth-admin-app) |
+| Content Checker | [VeriWise-Content-Check](https://github.com/SB2318/VeriWise-Content-Check) |
 
 For local development, update your `.env` to point to either the live APIs or locally running services.
 


### PR DESCRIPTION
#### PR Description
Added direct GitHub repository links for related services (such as backend, admin, and content-checker) under the Services & API Dependencies and Submodule Repositories sections in the README to improve contributor onboarding and repository discoverability.

#### Type of Change
- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [x] Documentation update

#### Select your work-area
- [ ] Frontend
- [ ] Backend
- [x] Documentation
- [ ] Others

#### Related Issue
https://github.com/SB2318/UltimateHealth/issues/1239

#### Add your Work Example
Not applicable (documentation-only update).

#### Fixes (mention the issue number which this fixes)
#closes #1239

#### Checklist
- [x] I have updated my branch and synced it with the project's branch before making this PR.
- [x] I have optimized the file changes.
- [ ] I have added a snapshot of my work example.
- [ ] I have made a PR to the project's branch.

#### Undertaking
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have checked for plagiarism and assure its authenticity.
- [x] I have read and followed the code of conduct for this repository. I understand that violation of this undertaking may have legal consequences.

- [x] I Agree