### PR TITLE
fix: remove /api prefix from share URL to fix redirect to Swagger docs

### DIFF
--- a/frontend/src/components/ArticleCard.tsx
+++ b/frontend/src/components/ArticleCard.tsx
@@ -90,10 +90,9 @@ const ArticleCard = ({
   const handleShare = async () => {
     try {
       const url =
-        `https://uhsocial.in/api/share/article?articleId=${item._id}` +
-        `&authorId=${(item.authorId as any)?._id || item.authorId}` +
-        `&recordId=${item.pb_recordId}`;
-
+  `https://uhsocial.in/share/article?articleId=${item._id}` +
+  `&authorId=${(item.authorId as any)?._id || item.authorId}` +
+  `&recordId=${item.pb_recordId}`;
       const result = await Share.open({
         title: item.title,
         message: `${item.title} : Check out this awesome post on UltimateHealth app!`,


### PR DESCRIPTION
#### PR Description
Removed `/api` prefix from the share URL in ArticleCard.tsx. 
The URL was incorrectly pointing to `/api/share/article` which 
redirected users to the Swagger API documentation page instead 
of the intended share endpoint.

#### Type of Change
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update

#### Select your work-area
- [x] Frontend
- [ ] Backend
- [ ] Documentation
- [ ] Others

#### Related Issue
https://github.com/SB2318/UltimateHealth/issues/1153

#### Fixes 
#1153 

#### Checklist
- [] I have updated my branch and synced it with the project's 'develop' branch before making this PR.
- [x] I have optimized the file changes.
- [] I have added a snapshot of my work example.
- [] I have made a PR to the project's develop branch.

#### Undertaking
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have checked for plagiarism and assure its authenticity.
- [ ] I have read and followed the code of conduct for this repository. I understand that violation of this undertaking may have legal consequences.

- [x] I Agree
