### PR TITLE
fix: hide footer social icons when profile URLs are not configured

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -50,8 +50,8 @@ const CURSOR_GLOW_EVENT = "cursor-glow-preference-change";
 // Owner-configurable frontend URLs (set in deployment env when needed)
 const HELP_CENTER_URL = process.env.NEXT_PUBLIC_HELP_CENTER_URL || "https://uhsocial.in/docs";
 const FEEDBACK_URL = process.env.NEXT_PUBLIC_FEEDBACK_URL || "https://github.com/SB2318/UltimateHealth/issues";
-const TELEGRAM_URL = process.env.NEXT_PUBLIC_TELEGRAM_URL || "https://t.me";
-const INSTAGRAM_URL = process.env.NEXT_PUBLIC_INSTAGRAM_URL || "https://instagram.com";
+const TELEGRAM_URL = process.env.NEXT_PUBLIC_TELEGRAM_URL || "";
+const INSTAGRAM_URL = process.env.NEXT_PUBLIC_INSTAGRAM_URL || "";
 const PRIVACY_POLICY_URL = process.env.NEXT_PUBLIC_PRIVACY_POLICY_URL || "#";
 const TERMS_OF_USE_URL = process.env.NEXT_PUBLIC_TERMS_OF_USE_URL || "#";
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -958,12 +958,16 @@ const moveSlider = (ref: RefObject<HTMLDivElement | null>, dir: number) => {
                 <a href="https://www.linkedin.com/in/ultimate-health-9290873a8/" className="footer-social-icon" target="_blank" rel="noreferrer" title="LinkedIn" aria-label="Open UltimateHealth LinkedIn profile">
                   <i className="fab fa-linkedin-in"></i>
                 </a>
-                <a href={TELEGRAM_URL} className="footer-social-icon" target="_blank" rel="noreferrer" title="Telegram" aria-label="Open UltimateHealth Telegram link">
-                  <i className="fab fa-telegram"></i>
-                </a>
-                <a href={INSTAGRAM_URL} className="footer-social-icon" target="_blank" rel="noreferrer" title="Instagram" aria-label="Open UltimateHealth Instagram link">
-                  <i className="fab fa-instagram"></i>
-                </a>
+                {TELEGRAM_URL && (
+                  <a href={TELEGRAM_URL} className="footer-social-icon" target="_blank" rel="noreferrer" title="Telegram" aria-label="Open UltimateHealth Telegram link">
+                    <i className="fab fa-telegram-plane"></i>
+                  </a>
+                )}
+                {INSTAGRAM_URL && (
+                  <a href={INSTAGRAM_URL} className="footer-social-icon" target="_blank" rel="noreferrer" title="Instagram" aria-label="Open UltimateHealth Instagram link">
+                    <i className="fab fa-instagram"></i>
+                  </a>
+                )}
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
Footer social icons for Telegram and Instagram were linking to bare 
base domains (https://t.me, https://instagram.com) when env vars were 
not configured, redirecting users to generic platform homepages.

## Changes
- Changed fallback values from bare domains to empty strings
- Wrapped anchor tags in conditional rendering so icons only appear
  when NEXT_PUBLIC_INSTAGRAM_URL / NEXT_PUBLIC_TELEGRAM_URL are set

## Screenshots
[
<img width="1627" height="954" alt="Screenshot 2026-06-12 012446" src="https://github.com/user-attachments/assets/f62eeedf-a22e-4840-839d-5044ef7ed8a4" />
<img width="1523" height="750" alt="Screenshot 2026-06-12 012550" src="https://github.com/user-attachments/assets/02933cae-e963-4212-9911-09918b89c165" />
]

- Changed fallback values from bare domains to empty strings
- Wrapped anchor tags in conditional rendering so icons only appear when NEXT_PUBLIC_INSTAGRAM_URL / NEXT_PUBLIC_TELEGRAM_URL are set

Closes #1384

#### Type of Change
- [✅ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update

#### work-area
- [ ✅] Frontend

#### Related Issue
Please provide a link to the issue solved if applicable.


#### Fixes (mention the issue number which this fixes)

#### Checklist
- [ ✅] I have updated my branch and synced it with the project's 'develop' branch before making this PR.
- [ ✅] I have optimized the file changes.
- [ ✅] I have added a snapshot of my work example.
- [ ✅] I have made a PR to the project's develop branch.

#### Undertaking
- [ ✅] My code follows the style guidelines of this project.
- [ ✅] I have performed a self-review of my code.
- [ ✅] I have commented my code, particularly in hard-to-understand areas.
- [ ✅] I have made corresponding changes to the documentation.
- [ ✅] I have checked for plagiarism and assure its authenticity.
- [ ✅] I have read and followed the code of conduct for this repository. I understand that violation of this undertaking may have legal consequences.

- [✅ ] I Agree
