### PR TITLE
fix(web): preserve signature canvas on resize

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -6,6 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
+    "test": "node --no-warnings --test src/app/admin-agreement/signatureValidation.test.mjs",
     "lint": "eslint",
     "knip": "knip",
     "knip:deps": "knip --dependencies",

--- a/web/src/app/admin-agreement/page.tsx
+++ b/web/src/app/admin-agreement/page.tsx
@@ -11,6 +11,8 @@ type Stroke = Point[];
 
 const SIGNATURE_STROKE = "#2d3748";
 const SIGNATURE_LINE_WIDTH = 2;
+const MIN_SIGNATURE_WIDTH_RATIO = 0.1;
+const MIN_SIGNATURE_HEIGHT_RATIO = 0.13;
 
 /* ---------- inner component (needs useSearchParams) ---------- */
 function AdminAgreementContent() {
@@ -63,7 +65,7 @@ function AdminAgreementContent() {
       maxX = Math.max(maxX, p.x);
       maxY = Math.max(maxY, p.y);
     });
-    return maxX - minX > 0.1 && maxY - minY > 0.13;
+    return maxX - minX > MIN_SIGNATURE_WIDTH_RATIO && maxY - minY > MIN_SIGNATURE_HEIGHT_RATIO;
   }, [strokes]);
 
   const canAccept =

--- a/web/src/app/admin-agreement/page.tsx
+++ b/web/src/app/admin-agreement/page.tsx
@@ -7,6 +7,10 @@ import { PageWrapper, Section } from "@/components/layout";
 
 /* ---------- types ---------- */
 interface Point { x: number; y: number }
+type Stroke = Point[];
+
+const SIGNATURE_STROKE = "#2d3748";
+const SIGNATURE_LINE_WIDTH = 2;
 
 /* ---------- inner component (needs useSearchParams) ---------- */
 function AdminAgreementContent() {
@@ -18,7 +22,7 @@ function AdminAgreementContent() {
   const [agreed, setAgreed] = useState(false);
   const [hasSignature, setHasSignature] = useState(false);
   const [isDrawing, setIsDrawing] = useState(false);
-  const [points, setPoints] = useState<Point[]>([]);
+  const [strokes, setStrokes] = useState<Stroke[]>([]);
 
   // ui state
   const [message, setMessage] = useState<{ text: string; type: "success" | "error" | "info" } | null>(null);
@@ -29,13 +33,29 @@ function AdminAgreementContent() {
   const [signedTimestamp, setSignedTimestamp] = useState<string | null>(null);
 
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const strokesRef = useRef<Stroke[]>([]);
+  const activeStrokeRef = useRef<Stroke>([]);
 
   /* ---------- helpers ---------- */
   const isValidFullName = (name: string) =>
     name.trim().split(" ").filter((p) => p.length > 0).length >= 2;
 
+  const canvasHasInk = useCallback(() => {
+    const canvas = canvasRef.current;
+    const ctx = canvas?.getContext("2d");
+    if (!canvas || !ctx) return false;
+
+    const pixels = ctx.getImageData(0, 0, canvas.width, canvas.height).data;
+    for (let index = 3; index < pixels.length; index += 4) {
+      if (pixels[index] !== 0) return true;
+    }
+    return false;
+  }, []);
+
   const isSignatureValid = useCallback(() => {
+    const points = strokes.flat();
     if (points.length < 20) return false;
+
     let minX = Infinity, minY = Infinity, maxX = 0, maxY = 0;
     points.forEach((p) => {
       minX = Math.min(minX, p.x);
@@ -43,8 +63,8 @@ function AdminAgreementContent() {
       maxX = Math.max(maxX, p.x);
       maxY = Math.max(maxY, p.y);
     });
-    return maxX - minX > 50 && maxY - minY > 20;
-  }, [points]);
+    return maxX - minX > 0.1 && maxY - minY > 0.13;
+  }, [strokes]);
 
   const canAccept =
     isValidFullName(fullName) &&
@@ -53,18 +73,39 @@ function AdminAgreementContent() {
     agreed;
 
   /* ---------- canvas setup ---------- */
+  const drawStrokes = useCallback((ctx: CanvasRenderingContext2D, width: number, height: number) => {
+    strokesRef.current.forEach((stroke) => {
+      if (stroke.length === 0) return;
+      ctx.beginPath();
+      ctx.moveTo(stroke[0].x * width, stroke[0].y * height);
+      stroke.slice(1).forEach((point) => ctx.lineTo(point.x * width, point.y * height));
+      ctx.stroke();
+      ctx.closePath();
+    });
+  }, []);
+
   const setupCanvas = useCallback(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
+
     const rect = canvas.getBoundingClientRect();
-    canvas.width = rect.width;
-    canvas.height = rect.height;
+    const pixelRatio = window.devicePixelRatio || 1;
+    canvas.width = Math.round(rect.width * pixelRatio);
+    canvas.height = Math.round(rect.height * pixelRatio);
     const ctx = canvas.getContext("2d")!;
-    ctx.strokeStyle = "#2d3748";
-    ctx.lineWidth = 2;
+    ctx.setTransform(pixelRatio, 0, 0, pixelRatio, 0, 0);
+    ctx.strokeStyle = SIGNATURE_STROKE;
+    ctx.lineWidth = SIGNATURE_LINE_WIDTH;
     ctx.lineCap = "round";
     ctx.lineJoin = "round";
-  }, []);
+    drawStrokes(ctx, rect.width, rect.height);
+
+    const lastPoint = activeStrokeRef.current.at(-1);
+    if (lastPoint) {
+      ctx.beginPath();
+      ctx.moveTo(lastPoint.x * rect.width, lastPoint.y * rect.height);
+    }
+  }, [drawStrokes]);
 
   useEffect(() => {
     setupCanvas();
@@ -91,32 +132,54 @@ function AdminAgreementContent() {
   const getPos = (e: React.MouseEvent | React.TouchEvent): Point => {
     const canvas = canvasRef.current!;
     const rect = canvas.getBoundingClientRect();
-    if ("touches" in e) {
-      return {
-        x: e.touches[0].clientX - rect.left,
-        y: e.touches[0].clientY - rect.top,
-      };
-    }
-    return { x: e.clientX - rect.left, y: e.clientY - rect.top };
+    const clientPoint = "touches" in e ? e.touches[0] : e;
+
+    return {
+      x: (clientPoint.clientX - rect.left) / rect.width,
+      y: (clientPoint.clientY - rect.top) / rect.height,
+    };
+  };
+
+  const toCanvasPoint = (point: Point): Point => {
+    const rect = canvasRef.current!.getBoundingClientRect();
+    return {
+      x: point.x * rect.width,
+      y: point.y * rect.height,
+    };
+  };
+
+  const updateStrokes = (nextStrokes: Stroke[]) => {
+    strokesRef.current = nextStrokes;
+    setStrokes(nextStrokes);
   };
 
   const startDraw = (e: React.MouseEvent | React.TouchEvent) => {
     e.preventDefault();
     if (locked) return;
-    setIsDrawing(true);
+
     const pos = getPos(e);
+    activeStrokeRef.current = [pos];
+    updateStrokes([...strokesRef.current, activeStrokeRef.current]);
+    setIsDrawing(true);
+
+    const canvasPoint = toCanvasPoint(pos);
     const ctx = canvasRef.current!.getContext("2d")!;
     ctx.beginPath();
-    ctx.moveTo(pos.x, pos.y);
+    ctx.moveTo(canvasPoint.x, canvasPoint.y);
   };
 
   const draw = (e: React.MouseEvent | React.TouchEvent) => {
     e.preventDefault();
     if (!isDrawing || locked) return;
+
     const pos = getPos(e);
-    setPoints((prev) => [...prev, pos]);
+    const activeStroke = [...activeStrokeRef.current, pos];
+    activeStrokeRef.current = activeStroke;
+    updateStrokes([...strokesRef.current.slice(0, -1), activeStroke]);
+
+    const canvasPoint = toCanvasPoint(pos);
     const ctx = canvasRef.current!.getContext("2d")!;
-    ctx.lineTo(pos.x, pos.y);
+    ctx.lineTo(canvasPoint.x, canvasPoint.y);
     ctx.stroke();
     setHasSignature(true);
   };
@@ -124,6 +187,7 @@ function AdminAgreementContent() {
   const stopDraw = () => {
     if (isDrawing) {
       canvasRef.current!.getContext("2d")!.closePath();
+      activeStrokeRef.current = [];
       setIsDrawing(false);
     }
   };
@@ -131,9 +195,14 @@ function AdminAgreementContent() {
   const clearSignature = () => {
     if (locked) return;
     const canvas = canvasRef.current!;
-    canvas.getContext("2d")!.clearRect(0, 0, canvas.width, canvas.height);
+    const ctx = canvas.getContext("2d")!;
+    ctx.save();
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.restore();
+    activeStrokeRef.current = [];
+    updateStrokes([]);
     setHasSignature(false);
-    setPoints([]);
   };
 
   /* ---------- showMessage helper ---------- */
@@ -152,7 +221,7 @@ function AdminAgreementContent() {
       showMessage("error", "✗ Please enter your designation", true);
       return;
     }
-    if (!isSignatureValid()) {
+    if (!isSignatureValid() || !canvasHasInk()) {
       showMessage("error", "✗ Please provide a valid signature", true);
       return;
     }

--- a/web/src/app/admin-agreement/page.tsx
+++ b/web/src/app/admin-agreement/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState, useCallback } from "react";
 import { useSearchParams } from "next/navigation";
 import { Suspense } from "react";
 import { PageWrapper, Section } from "@/components/layout";
+import { canvasPixelsHaveInk, isSignatureValid as hasValidSignatureBounds } from "./signatureValidation";
 
 /* ---------- types ---------- */
 interface Point { x: number; y: number }
@@ -11,8 +12,6 @@ type Stroke = Point[];
 
 const SIGNATURE_STROKE = "#2d3748";
 const SIGNATURE_LINE_WIDTH = 2;
-const MIN_SIGNATURE_WIDTH_RATIO = 0.1;
-const MIN_SIGNATURE_HEIGHT_RATIO = 0.13;
 
 /* ---------- inner component (needs useSearchParams) ---------- */
 function AdminAgreementContent() {
@@ -48,24 +47,11 @@ function AdminAgreementContent() {
     if (!canvas || !ctx) return false;
 
     const pixels = ctx.getImageData(0, 0, canvas.width, canvas.height).data;
-    for (let index = 3; index < pixels.length; index += 4) {
-      if (pixels[index] !== 0) return true;
-    }
-    return false;
+    return canvasPixelsHaveInk(pixels);
   }, []);
 
   const isSignatureValid = useCallback(() => {
-    const points = strokes.flat();
-    if (points.length < 20) return false;
-
-    let minX = Infinity, minY = Infinity, maxX = 0, maxY = 0;
-    points.forEach((p) => {
-      minX = Math.min(minX, p.x);
-      minY = Math.min(minY, p.y);
-      maxX = Math.max(maxX, p.x);
-      maxY = Math.max(maxY, p.y);
-    });
-    return maxX - minX > MIN_SIGNATURE_WIDTH_RATIO && maxY - minY > MIN_SIGNATURE_HEIGHT_RATIO;
+    return hasValidSignatureBounds(strokes);
   }, [strokes]);
 
   const canAccept =

--- a/web/src/app/admin-agreement/signatureValidation.js
+++ b/web/src/app/admin-agreement/signatureValidation.js
@@ -1,0 +1,36 @@
+export const MIN_SIGNATURE_POINT_COUNT = 20;
+export const MIN_SIGNATURE_WIDTH_RATIO = 0.1;
+export const MIN_SIGNATURE_HEIGHT_RATIO = 0.13;
+
+export function canvasPixelsHaveInk(pixels) {
+  for (let index = 3; index < pixels.length; index += 4) {
+    if (pixels[index] !== 0) return true;
+  }
+  return false;
+}
+
+export function isSignatureValid(
+  strokes,
+  {
+    minPointCount = MIN_SIGNATURE_POINT_COUNT,
+    minWidthRatio = MIN_SIGNATURE_WIDTH_RATIO,
+    minHeightRatio = MIN_SIGNATURE_HEIGHT_RATIO,
+  } = {},
+) {
+  const points = strokes.flat();
+  if (points.length < minPointCount) return false;
+
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = 0;
+  let maxY = 0;
+
+  points.forEach((point) => {
+    minX = Math.min(minX, point.x);
+    minY = Math.min(minY, point.y);
+    maxX = Math.max(maxX, point.x);
+    maxY = Math.max(maxY, point.y);
+  });
+
+  return maxX - minX > minWidthRatio && maxY - minY > minHeightRatio;
+}

--- a/web/src/app/admin-agreement/signatureValidation.test.mjs
+++ b/web/src/app/admin-agreement/signatureValidation.test.mjs
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { canvasPixelsHaveInk, isSignatureValid } from "./signatureValidation.js";
+
+const makeStroke = (count, getPoint) =>
+  Array.from({ length: count }, (_, index) => getPoint(index, count));
+
+test("canvasPixelsHaveInk returns false for fully transparent pixels", () => {
+  assert.equal(canvasPixelsHaveInk(new Uint8ClampedArray(16)), false);
+});
+
+test("canvasPixelsHaveInk returns true when any alpha channel has ink", () => {
+  const pixels = new Uint8ClampedArray(16);
+  pixels[7] = 255;
+
+  assert.equal(canvasPixelsHaveInk(pixels), true);
+});
+
+test("isSignatureValid rejects signatures with too few points", () => {
+  const strokes = [makeStroke(19, (index) => ({ x: index / 100, y: index / 100 }))];
+
+  assert.equal(isSignatureValid(strokes), false);
+});
+
+test("isSignatureValid rejects signatures that do not span enough canvas area", () => {
+  const strokes = [makeStroke(20, (index) => ({ x: 0.2 + index / 1000, y: 0.3 + index / 1000 }))];
+
+  assert.equal(isSignatureValid(strokes), false);
+});
+
+test("isSignatureValid accepts signatures with enough points and bounds across strokes", () => {
+  const strokes = [
+    makeStroke(10, (index) => ({ x: 0.1 + index * 0.01, y: 0.2 + index * 0.01 })),
+    makeStroke(10, (index) => ({ x: 0.4 + index * 0.01, y: 0.5 + index * 0.01 })),
+  ];
+
+  assert.equal(isSignatureValid(strokes), true);
+});


### PR DESCRIPTION
## Summary

- preserve signature strokes when the browser resizes or device orientation changes
- store stroke coordinates relative to the canvas and redraw them at the new dimensions
- render the canvas using devicePixelRatio for crisp high-DPI output
- verify the rendered canvas contains ink before generating and submitting the PNG
- keep separate strokes disconnected and clear the full physical canvas correctly

## Root cause

Changing canvas width or height clears the canvas bitmap. The resize handler reset those dimensions without redrawing the stored signature, while validation continued to pass using the unchanged point array. This allowed a blank PNG to be submitted.

## Validation

- npm run lint -- src/app/admin-agreement/page.tsx
- npm run build

Closes #1447 