### PR TITLE
feat: implement ImageFallback component

### DIFF
--- a/frontend/src/components/ArticleCard.tsx
+++ b/frontend/src/components/ArticleCard.tsx
@@ -40,6 +40,7 @@ import {useLikeArticle} from '../hooks/useLikeArticle';
 import {useSaveArticle} from '../hooks/useSaveArticle';
 import {useLazyGetArticleContent} from '../hooks/useLazyGetArticleContent';
 import {useRepostArticle} from '../hooks/useArticleRepost';
+import { ImageFallback } from './ImageFallback';
 
 const ArticleCard = ({
   item,
@@ -303,16 +304,17 @@ const ArticleCard = ({
       }}>
       <View style={styles.cardContainer}>
         {/* Image Section */}
-        <Image
-          source={{
-            uri: item?.imageUtils[0]
-              ? item?.imageUtils[0].startsWith('http')
-                ? item?.imageUtils[0]
-                : `${GET_IMAGE}/${item?.imageUtils[0]}`
-              : undefined,
-          }}
-          style={styles.coverImage}
-        />
+        <ImageFallback
+  source={{
+    uri: item?.imageUtils[0]
+      ? item?.imageUtils[0].startsWith('http')
+        ? item?.imageUtils[0]
+        : `${GET_IMAGE}/${item?.imageUtils[0]}`
+      : undefined,
+  }}
+  fallbackSource={require('../assets/images/article_default.jpg')}
+  style={styles.coverImage}
+/>
 
         <View style={styles.contentContainer}>
           {/* Share Icon */}

--- a/frontend/src/components/ImageFallback.test.tsx
+++ b/frontend/src/components/ImageFallback.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { ImageFallback } from './ImageFallback';
+
+describe('ImageFallback Component', () => {
+  const fallbackSource = { uri: 'https://example.com/fallback.jpg' };
+  const primarySource = { uri: 'https://example.com/primary.jpg' };
+
+  it('renders primary image when source is valid', () => {
+    const { getByTestId } = render(
+      <ImageFallback source={primarySource} fallbackSource={fallbackSource} testID="test-image" />
+    );
+    const image = getByTestId('test-image');
+    expect(image.props.source).toEqual(primarySource);
+  });
+
+  it('renders fallback image immediately if primary source uri is empty', () => {
+    const { getByTestId } = render(
+      <ImageFallback source={{ uri: '' }} fallbackSource={fallbackSource} testID="test-image" />
+    );
+    const image = getByTestId('test-image');
+    // Because the URI is empty, it should instantly swap to fallback
+    expect(image.props.source).toEqual(fallbackSource);
+  });
+
+  it('swaps to fallback image when onError is triggered', () => {
+    const { getByTestId } = render(
+      <ImageFallback source={primarySource} fallbackSource={fallbackSource} testID="test-image" />
+    );
+    const image = getByTestId('test-image');
+    
+    // Simulate a network failure loading the image
+    fireEvent(image, 'onError');
+    
+    // It should now have swapped to the fallback
+    expect(image.props.source).toEqual(fallbackSource);
+  });
+});

--- a/frontend/src/components/ImageFallback.tsx
+++ b/frontend/src/components/ImageFallback.tsx
@@ -1,32 +1,35 @@
 import React, { useState } from 'react';
 import { Image, ImageProps, ImageSourcePropType } from 'react-native';
 
-/**
- * Props for the ImageFallback component.
- * Extends standard React Native ImageProps to include a required fallback source.
- */
 interface ImageFallbackProps extends ImageProps {
-  // The local image asset to display if the primary source fails to load
   fallbackSource: ImageSourcePropType;
 }
 
-/**
- * A wrapper around the standard React Native Image component.
- * Gracefully handles broken image URLs or network failures by swapping 
- * to a provided local fallback image.
- */
 export const ImageFallback = ({ source, fallbackSource, style, ...props }: ImageFallbackProps) => {
-  // State to track if the primary image source has failed to load
   const [hasError, setHasError] = useState(false);
+
+  // Check if the primary source is a valid URI object, or a valid local file (number)
+  const isPrimaryUriValid = 
+    typeof source === 'number' || 
+    (typeof source === 'object' && source !== null && 'uri' in source && typeof (source as any).uri === 'string' && (source as any).uri.length > 0);
+
+  // If the primary URI is invalid from the start, or an error occurred, use the fallback
+  const finalSource = (!isPrimaryUriValid || hasError) ? fallbackSource : source;
 
   return (
     <Image
-      // If an error occurred previously, render the fallback. Otherwise, attempt to load the primary source.
-      source={hasError ? fallbackSource : source}
-      // Catch loading errors (e.g., 404, network timeout) and trigger the fallback state
-      onError={() => setHasError(true)}
+      source={finalSource}
+      onError={(e) => {
+        // Only trigger our error state if the original URI was theoretically valid
+        if (isPrimaryUriValid) {
+          setHasError(true);
+        }
+        // If an onError prop was passed in from the parent, make sure we still call it!
+        if (props.onError) {
+          props.onError(e);
+        }
+      }}
       style={style}
-      // Pass down any remaining standard Image props (like resizeMode, accessibilityLabel, etc.)
       {...props}
     />
   );

--- a/frontend/src/components/ImageFallback.tsx
+++ b/frontend/src/components/ImageFallback.tsx
@@ -1,18 +1,32 @@
 import React, { useState } from 'react';
 import { Image, ImageProps, ImageSourcePropType } from 'react-native';
 
+/**
+ * Props for the ImageFallback component.
+ * Extends standard React Native ImageProps to include a required fallback source.
+ */
 interface ImageFallbackProps extends ImageProps {
+  // The local image asset to display if the primary source fails to load
   fallbackSource: ImageSourcePropType;
 }
 
+/**
+ * A wrapper around the standard React Native Image component.
+ * Gracefully handles broken image URLs or network failures by swapping 
+ * to a provided local fallback image.
+ */
 export const ImageFallback = ({ source, fallbackSource, style, ...props }: ImageFallbackProps) => {
+  // State to track if the primary image source has failed to load
   const [hasError, setHasError] = useState(false);
 
   return (
     <Image
+      // If an error occurred previously, render the fallback. Otherwise, attempt to load the primary source.
       source={hasError ? fallbackSource : source}
+      // Catch loading errors (e.g., 404, network timeout) and trigger the fallback state
       onError={() => setHasError(true)}
       style={style}
+      // Pass down any remaining standard Image props (like resizeMode, accessibilityLabel, etc.)
       {...props}
     />
   );

--- a/frontend/src/components/ImageFallback.tsx
+++ b/frontend/src/components/ImageFallback.tsx
@@ -1,0 +1,19 @@
+import React, { useState } from 'react';
+import { Image, ImageProps, ImageSourcePropType } from 'react-native';
+
+interface ImageFallbackProps extends ImageProps {
+  fallbackSource: ImageSourcePropType;
+}
+
+export const ImageFallback = ({ source, fallbackSource, style, ...props }: ImageFallbackProps) => {
+  const [hasError, setHasError] = useState(false);
+
+  return (
+    <Image
+      source={hasError ? fallbackSource : source}
+      onError={() => setHasError(true)}
+      style={style}
+      {...props}
+    />
+  );
+};


### PR DESCRIPTION
#### PR Description
This PR introduces a reusable <ImageFallback /> component to the React Native frontend to gracefully handle broken image links. If an external image URL fails to load due to network errors or missing assets, this component catches the onError event and smoothly swaps the source to a local placeholder asset (e.g., article_default.jpg), preventing broken layout shifts.

As an initial integration and proof-of-concept, this component has been implemented within src/components/ArticleCard.tsx to protect article thumbnails.

#### Type of Change
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Documentation update

#### Select your work-area
- [x ] Frontend
- [ ] Backend
- [ ] Documentation
- [ ] Others

#### Add your Work Example

Due to local Expo build cache issues preventing the development server from starting, I am unable to provide a local UI snapshot. I am relying on the automated CI/CD checks for visual verification.
<img width="1325" height="862" alt="image" src="https://github.com/user-attachments/assets/6911908d-58f6-442e-86e0-87a10d409ac3" />

#### Related Issue
https://github.com/SB2318/UltimateHealth/issues/1427

#### Fixes (mention the issue number which this fixes) 
Fixes #1427

#### Checklist
- [x] I have updated my branch and synced it with the project's 'develop' branch before making this PR.
- [x] I have optimized the file changes.
- [x] I have added a snapshot of my work example.
- [x] I have made a PR to the project's develop branch.

#### Undertaking
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have checked for plagiarism and assure its authenticity.
- [x] I have read and followed the code of conduct for this repository. I understand that violation of this undertaking may have legal consequences.

- [x] I Agree
