### PR TITLE
fix(web): log sanitized CSP reports

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "test": "node --no-warnings --test src/app/admin-agreement/signatureValidation.test.mjs",
+    "test": "node --no-warnings --test src/app/admin-agreement/signatureValidation.test.mjs src/app/api/csp-report/sanitizeCspReport.test.mjs",
     "lint": "eslint",
     "knip": "knip",
     "knip:deps": "knip --dependencies",

--- a/web/src/app/api/csp-report/route.ts
+++ b/web/src/app/api/csp-report/route.ts
@@ -1,22 +1,5 @@
 import { NextResponse } from "next/server";
-
-/**
- * Sanitizes query parameters and tokens from a URL string to prevent
- * sensitive data exposure in logs.
- */
-function sanitizeUrl(url: unknown): string {
-  if (typeof url !== "string") return "";
-  try {
-    const parsed = new URL(url);
-    if (parsed.search) {
-      parsed.search = "?[redacted]";
-    }
-    return parsed.toString();
-  } catch {
-    const qIndex = url.indexOf("?");
-    return qIndex !== -1 ? url.substring(0, qIndex) + "?[redacted]" : url;
-  }
-}
+import { sanitizeCspReport } from "./sanitizeCspReport";
 
 /**
  * CSP Report API Endpoint
@@ -28,31 +11,23 @@ export async function POST(request: Request) {
   try {
     const rawBody = await request.text();
     let report: Record<string, unknown>;
-    
+
     try {
       report = JSON.parse(rawBody);
     } catch (jsonError) {
       console.error("CSP Report: Error parsing JSON body:", jsonError);
       return NextResponse.json({ error: "Invalid JSON format" }, { status: 400 });
     }
-    
-    // Sanitize the report fields to prevent leaking sensitive tokens in logs
-    const cspReport = report?.["csp-report"] as Record<string, unknown> | undefined;
-    if (cspReport) {
-      if (typeof cspReport["document-uri"] === "string") {
-        cspReport["document-uri"] = sanitizeUrl(cspReport["document-uri"]);
-      }
-      if (typeof cspReport["referrer"] === "string") {
-        cspReport["referrer"] = sanitizeUrl(cspReport["referrer"]);
-      }
-      if (typeof cspReport["blocked-uri"] === "string") {
-        cspReport["blocked-uri"] = sanitizeUrl(cspReport["blocked-uri"]);
-      }
-    }
-    
+
+    const cspReport = sanitizeCspReport(report?.["csp-report"]);
+
     // Log the violation report (or forward to monitoring service like Sentry)
-    console.warn("CSP Violation Reported:", report);
-    
+    if (cspReport) {
+      console.warn("CSP Violation Reported:", cspReport);
+    } else {
+      console.warn("CSP Violation Reported: Missing or invalid csp-report payload");
+    }
+
     // Return 204 No Content as recommended to prevent response feedback loops
     return new NextResponse(null, { status: 204 });
   } catch (error) {

--- a/web/src/app/api/csp-report/sanitizeCspReport.js
+++ b/web/src/app/api/csp-report/sanitizeCspReport.js
@@ -1,0 +1,79 @@
+const URL_REPORT_FIELDS = new Set([
+  "blocked-uri",
+  "document-uri",
+  "referrer",
+  "source-file",
+]);
+
+const LOGGED_REPORT_FIELDS = new Set([
+  "blocked-uri",
+  "column-number",
+  "disposition",
+  "document-uri",
+  "effective-directive",
+  "line-number",
+  "original-policy",
+  "referrer",
+  "script-sample",
+  "source-file",
+  "status-code",
+  "violated-directive",
+]);
+
+function isPlainObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function sanitizeLogValue(value) {
+  if (
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean" ||
+    value === null
+  ) {
+    return value;
+  }
+
+  return "";
+}
+
+/**
+ * Sanitizes query parameters, fragments, and tokens from a URL string to
+ * prevent sensitive data exposure in logs.
+ */
+export function sanitizeUrl(url) {
+  if (typeof url !== "string") return "";
+
+  try {
+    const parsed = new URL(url);
+    if (parsed.search) parsed.search = "?[redacted]";
+    if (parsed.hash) parsed.hash = "#[redacted]";
+    return parsed.toString();
+  } catch {
+    const queryIndex = url.indexOf("?");
+    const hashIndex = url.indexOf("#");
+    const sensitiveIndexes = [queryIndex, hashIndex].filter((index) => index !== -1);
+
+    if (sensitiveIndexes.length === 0) return url;
+
+    const firstSensitiveIndex = Math.min(...sensitiveIndexes);
+    const marker = url[firstSensitiveIndex] === "?" ? "?[redacted]" : "#[redacted]";
+    return url.substring(0, firstSensitiveIndex) + marker;
+  }
+}
+
+export function sanitizeCspReport(report) {
+  if (!isPlainObject(report)) return undefined;
+
+  const sanitizedReport = {};
+
+  for (const [field, value] of Object.entries(report)) {
+    if (!LOGGED_REPORT_FIELDS.has(field)) continue;
+
+    sanitizedReport[field] = URL_REPORT_FIELDS.has(field)
+      ? sanitizeUrl(value)
+      : sanitizeLogValue(value);
+  }
+
+  return sanitizedReport;
+}

--- a/web/src/app/api/csp-report/sanitizeCspReport.test.mjs
+++ b/web/src/app/api/csp-report/sanitizeCspReport.test.mjs
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { sanitizeCspReport, sanitizeUrl } from "./sanitizeCspReport.js";
+
+test("sanitizeUrl redacts URL query parameters and fragments", () => {
+  assert.equal(
+    sanitizeUrl("https://example.com/account?token=secret#session=also-secret"),
+    "https://example.com/account?[redacted]#[redacted]",
+  );
+});
+
+test("sanitizeUrl redacts query parameters from non-standard URL strings", () => {
+  assert.equal(sanitizeUrl("/account?token=secret"), "/account?[redacted]");
+});
+
+test("sanitizeCspReport keeps only sanitized CSP report log fields", () => {
+  const sanitizedReport = sanitizeCspReport({
+    "document-uri": "https://health.example/patient?token=secret",
+    referrer: "https://referrer.example/path?session=secret",
+    "blocked-uri": "https://cdn.example/script.js?apiKey=secret",
+    "source-file": "https://health.example/app.js#access-token",
+    "violated-directive": "script-src-elem",
+    "line-number": 42,
+    "status-code": 200,
+    metadata: { authorization: "Bearer secret" },
+  });
+
+  assert.deepEqual(sanitizedReport, {
+    "document-uri": "https://health.example/patient?[redacted]",
+    referrer: "https://referrer.example/path?[redacted]",
+    "blocked-uri": "https://cdn.example/script.js?[redacted]",
+    "source-file": "https://health.example/app.js#[redacted]",
+    "violated-directive": "script-src-elem",
+    "line-number": 42,
+    "status-code": 200,
+  });
+});
+
+test("sanitizeCspReport returns undefined for invalid report payloads", () => {
+  assert.equal(sanitizeCspReport(undefined), undefined);
+  assert.equal(sanitizeCspReport(null), undefined);
+  assert.equal(sanitizeCspReport("not a report"), undefined);
+});

--- a/web/src/app/api/csp-report/sanitizeCspReport.test.mjs
+++ b/web/src/app/api/csp-report/sanitizeCspReport.test.mjs
@@ -1,7 +1,17 @@
 import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
 import test from "node:test";
+import ts from "typescript";
 
-import { sanitizeCspReport, sanitizeUrl } from "./sanitizeCspReport.js";
+const source = await readFile(new URL("./sanitizeCspReport.ts", import.meta.url), "utf8");
+const { outputText } = ts.transpileModule(source, {
+  compilerOptions: {
+    module: ts.ModuleKind.ESNext,
+    target: ts.ScriptTarget.ES2022,
+  },
+});
+const moduleUrl = `data:text/javascript;base64,${Buffer.from(outputText).toString("base64")}`;
+const { sanitizeCspReport, sanitizeUrl } = await import(moduleUrl);
 
 test("sanitizeUrl redacts URL query parameters and fragments", () => {
   assert.equal(

--- a/web/src/app/api/csp-report/sanitizeCspReport.ts
+++ b/web/src/app/api/csp-report/sanitizeCspReport.ts
@@ -1,11 +1,14 @@
-const URL_REPORT_FIELDS = new Set([
+type CspReportLogValue = string | number | boolean | null;
+type SanitizedCspReport = Record<string, CspReportLogValue>;
+
+const URL_REPORT_FIELDS = new Set<string>([
   "blocked-uri",
   "document-uri",
   "referrer",
   "source-file",
 ]);
 
-const LOGGED_REPORT_FIELDS = new Set([
+const LOGGED_REPORT_FIELDS = new Set<string>([
   "blocked-uri",
   "column-number",
   "disposition",
@@ -20,11 +23,11 @@ const LOGGED_REPORT_FIELDS = new Set([
   "violated-directive",
 ]);
 
-function isPlainObject(value) {
+function isPlainObject(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
-function sanitizeLogValue(value) {
+function sanitizeLogValue(value: unknown): CspReportLogValue {
   if (
     typeof value === "string" ||
     typeof value === "number" ||
@@ -41,7 +44,7 @@ function sanitizeLogValue(value) {
  * Sanitizes query parameters, fragments, and tokens from a URL string to
  * prevent sensitive data exposure in logs.
  */
-export function sanitizeUrl(url) {
+export function sanitizeUrl(url: unknown): string {
   if (typeof url !== "string") return "";
 
   try {
@@ -62,10 +65,10 @@ export function sanitizeUrl(url) {
   }
 }
 
-export function sanitizeCspReport(report) {
+export function sanitizeCspReport(report: unknown): SanitizedCspReport | undefined {
   if (!isPlainObject(report)) return undefined;
 
-  const sanitizedReport = {};
+  const sanitizedReport: SanitizedCspReport = {};
 
   for (const [field, value] of Object.entries(report)) {
     if (!LOGGED_REPORT_FIELDS.has(field)) continue;


### PR DESCRIPTION
## Description

This PR fixes the CSP report logging issue where the `/api/csp-report` endpoint was building a sanitized CSP report but still logging the original request payload. That meant sensitive data could still appear in server logs if it was included in unexpected fields, nested metadata, query parameters, or URL fragments.

The endpoint now logs only a sanitized CSP report object. The sanitization logic has been moved into a dedicated helper so the behavior is clearer, reusable, and directly testable.

## What Changed

- Updated `web/src/app/api/csp-report/route.ts` to log the sanitized CSP report instead of the raw `report` object.
- Added `sanitizeCspReport.js` to centralize CSP report sanitization.
- Added an allow-list of expected CSP report fields so unrelated or unexpected payload data is not written to logs.
- Redacted query parameters and URL fragments from URL-based CSP fields:
  - `document-uri`
  - `referrer`
  - `blocked-uri`
  - `source-file`
- Added handling for invalid or malformed CSP report payloads so raw request data is not logged.
- Added `node:test` coverage for CSP sanitization behavior.
- Updated the test script to include the new CSP report sanitization tests.

## Why This Fix Is Needed

Previously, the endpoint sanitized selected fields but logged the original report object afterward. This created a gap between the intended sanitized output and the actual logged data.

Because CSP reports can contain URLs, metadata, and browser-provided violation details, logging the raw payload can expose sensitive information such as tokens, session identifiers, query parameters, or other user-specific data. This PR ensures that only the sanitized and allow-listed CSP report data reaches application logs.

## Validation

The new tests verify that:

- URL query parameters are redacted.
- URL fragments are redacted.
- Only expected CSP report fields are retained.
- Unexpected metadata is excluded from logs.
- Invalid CSP report payloads are handled safely.

## Tests Run

- `npm run test`
- `npm run lint`  
  Passes with one existing unrelated warning: `RelatedArticles.tsx` has an unused `CSSProperties` import.
- `npm run build`

Fixes #1337 