### PR TITLE
fix: password verify stage

### DIFF
--- a/frontend/src/screens/auth/NewPasswordScreen.tsx
+++ b/frontend/src/screens/auth/NewPasswordScreen.tsx
@@ -101,8 +101,6 @@ export default function NewPasswordScreen({
     );
   };
 
-    );
-  };
 
   const insets = useSafeAreaInsets();
   if (isPending) {
@@ -241,13 +239,6 @@ export default function NewPasswordScreen({
                   </XStack>
                 )}
               />
-                  <Icon
-                    name={secureTextEntry ? 'eye-off' : 'eye'}
-                    size={20}
-                    color={theme.gray700.val}
-                  />
-                </Button>
-              </XStack>
 
               {/* Password Requirements */}
               <XStack gap="$2" alignItems="center" paddingLeft="$2">
@@ -354,13 +345,6 @@ export default function NewPasswordScreen({
                   </XStack>
                 )}
               />
-                  <Icon
-                    name={secureNewTextEntry ? 'eye-off' : 'eye'}
-                    size={20}
-                    color={theme.gray600.val}
-                  />
-                </Button>
-              </XStack>
 
               {/* Confirmation Status */}
               {confirmPassword && (
@@ -446,15 +430,3 @@ export default function NewPasswordScreen({
     </YStack>
   );
 }
-function setErrorMessage(arg0: null) {
-  throw new Error('Function not implemented.');
-}
-
-function setPassword(pass: string) {
-  throw new Error('Function not implemented.');
-}
-
-function setPasswordVerify(arg0: boolean) {
-  throw new Error('Function not implemented.');
-}
-

--- a/frontend/src/screens/auth/NewPasswordScreen.tsx
+++ b/frontend/src/screens/auth/NewPasswordScreen.tsx
@@ -430,3 +430,4 @@ export default function NewPasswordScreen({
     </YStack>
   );
 }
+


### PR DESCRIPTION
#### PR Description
This PR cleans up `frontend/src/screens/auth/NewPasswordScreen.tsx`, which contained leftover dead code that broke the build:
- Removed a stray duplicated `);` / `};` block
- Removed two duplicated `<Icon>`/`</Button>`/`</XStack>` JSX blocks (leftovers from the password/confirm-password fields)
- Removed unused dead functions `setErrorMessage`, `setPassword`, and `setPasswordVerify`

Regarding the original issue: the `passwordVerify` state described in #1128 (shared between `handlePassword` and `handleConfirmPassword`) no longer exists in the current code. `passwordVerify` is already correctly derived only from `password`/`errors.password` via react-hook-form + zod, and `confirmPassword` is never read by it. The shared-state bug doesn't reproduce in this version — the real blocker was the leftover dead/duplicated code causing build errors, which this PR fixes.

#### Type of Change
- [x] Bug fix (change which fixes an issue)

#### Select your work-area
- [x] Frontend


#### Fixes #1128 

#### Checklist
- [x] I have updated my branch and synced it with the project's 'develop' branch before making this PR.
- [x] I have optimized the file changes.
- [ ] I have added a snapshot of my work example.
- [x] I have made a PR to the project's develop branch.

#### Undertaking
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have checked for plagiarism and assure its authenticity.
- [x] I have read and followed the code of conduct for this repository. I understand that violation of this undertaking may have legal consequences.

- [x] I Agree