### PR TITLE
fix : add missing url prod_url prefix to article_tags url

### DIFF
--- a/frontend/src/helper/APIUtils.ts
+++ b/frontend/src/helper/APIUtils.ts
@@ -21,7 +21,7 @@ const CONTENT_CHECKER_PROD: string = extra.CONTENT_CHECKER_PROD;
 
 const LOGIN_API = `${PROD_URL}/user/login`;
 const REGISTRATION_API = `${PROD_URL}/user/register`;
-const ARTICLE_TAGS_API = '/articles/tags';
+const ARTICLE_TAGS_API = `${PROD_URL}/articles/tags`;
 const GET_PROFILE_API = `${PROD_URL}/user/getprofile`;
 const VERIFICATION_MAIL_API = `${PROD_URL}/user/verifyEmail`;
 const RESEND_VERIFICATION = `${PROD_URL}/user/resend-verification-mail`;

--- a/frontend/src/helper/APIUtils.ts
+++ b/frontend/src/helper/APIUtils.ts
@@ -22,7 +22,7 @@ const CONTENT_CHECKER_PROD: string = extra.CONTENT_CHECKER_PROD;
 
 const LOGIN_API = `${PROD_URL}/user/login`;
 const REGISTRATION_API = `${PROD_URL}/user/register`;
-const ARTICLE_TAGS_API = '/articles/tags';
+const ARTICLE_TAGS_API = `${PROD_URL}/articles/tags`;
 const GET_PROFILE_API = `${PROD_URL}/user/getprofile`;
 const VERIFICATION_MAIL_API = `${PROD_URL}/user/verifyEmail`;
 const RESEND_VERIFICATION = `${PROD_URL}/user/resend-verification-mail`;

--- a/frontend/src/hooks/useGetArticleTags.ts
+++ b/frontend/src/hooks/useGetArticleTags.ts
@@ -1,13 +1,11 @@
 import {useQuery, UseQueryResult} from '@tanstack/react-query';
 import axios, {AxiosError} from 'axios';
-import {ARTICLE_TAGS_API, PROD_URL} from '../helper/APIUtils';
+import {ARTICLE_TAGS_API} from '../helper/APIUtils';
 import {Category} from '../type';
 
 const categoryFunc = async () => {
   try{
-     const {data: categoryData} = await axios.get(
-    `${PROD_URL + ARTICLE_TAGS_API}`,
-  );
+     const {data: categoryData} = await axios.get(ARTICLE_TAGS_API);
 
   return categoryData as Category[];
   }catch(err){


### PR DESCRIPTION
## Summary
Fixed missing `PROD_URL` base URL prefix in `ARTICLE_TAGS_API` constant in `APIUtils.ts`.

## Problem
`ARTICLE_TAGS_API` was defined as a bare relative path `/articles/tags` while 
every other API constant uses `${PROD_URL}` as the base. This caused all article 
tag requests to fail silently.

## Fix
```ts
// Before
const ARTICLE_TAGS_API = '/articles/tags';

// After
const ARTICLE_TAGS_API = `${PROD_URL}/articles/tags`;
```

## Files Changed
- `frontend/src/helper/APIUtils.ts`

## Related Issue
Closes #1492 