### PR TITLE
#1432 fix: correct broken image path in UltimateHealth App carousel

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -27,7 +27,7 @@ const userScreenshots = [
   { src: "/assets/podcast-recording.jpeg", caption: "Podcast Recorder" },
   { src: "/assets/podcast-upload.jpeg", caption: "Podcast Upload" },
   { src: "/assets/notificaion-screen.jpeg", caption: "Notification" },
-  { src: "/assets/UltimateHealth-about.jpeg", caption: "App Info" },
+  { src: "/assets/ultimate-health-about.jpeg", caption: "App Info" },
   { src: "/assets/terms_cond_page.jpeg", caption: "Terms And Condition" },
 ];
 


### PR DESCRIPTION
## Description

This PR fixes a broken image in the UltimateHealth App carousel.

### Root Cause

The carousel referenced:

`/assets/UltimateHealth-about.jpeg`

while the actual file present in `public/assets` is:

`/assets/ultimate-health-about.jpeg`

This filename mismatch caused image loading failures and generated 400 errors from Next.js image optimization.

### Changes Made

* Updated the image path to use the correct filename:

  * `/assets/ultimate-health-about.jpeg`

### Verification

* Confirmed the image loads correctly in the carousel.
* Confirmed browser console no longer shows 400 errors for this image request.
* Verified carousel rendering after the fix.

