### PR TITLE
fix: add padding to badgeLight and badgeDark styles #1371

### DIFF
--- a/frontend/src/components/ArticleShareCard.tsx
+++ b/frontend/src/components/ArticleShareCard.tsx
@@ -201,11 +201,15 @@ const styles = StyleSheet.create({
     backgroundColor: 'rgba(255,255,255,0.22)',
     borderWidth: 1,
     borderColor: 'rgba(255,255,255,0.45)',
+    paddingVertical: 4,   
+    paddingHorizontal: 8,  
   },
   badgeDark: {
     backgroundColor: BRAND.badgeBg,
     borderWidth: 1,
     borderColor: BRAND.teal,
+    paddingVertical: 4,    
+    paddingHorizontal: 8,  
   },
   badgeText: {
     fontSize: 10,


### PR DESCRIPTION
#### PR Description
Added paddingVertical and paddingHorizontal to badgeLight and badgeDark 
styles in ArticleShareCard.tsx to fix the badge clipping issue where the 
"Open Source Health Platform" badge was hitting the top edge with no 
breathing room.

#### Type of Change
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update

#### Select your work-area
- [x] Frontend
- [ ] Backend
- [ ] Documentation
- [ ] Others

#### Related Issue
Fixes #1371
https://github.com/SB2318/UltimateHealth/issues/1371

#### Add your Work Example
Added the following to badgeLight and badgeDark styles:
- paddingVertical: 4
- paddingHorizontal: 8

This ensures the badge has consistent padding on all sides and sits 
properly within the header without being clipped.