### PR TITLE
Fix: Resolve undefined handleQuickReset crash in HomeScreen

### DIFF
--- a/frontend/src/screens/HomeScreen.tsx
+++ b/frontend/src/screens/HomeScreen.tsx
@@ -551,7 +551,7 @@ const HomeScreen = ({navigation}: HomeScreenProps) => {
           }}
           unreadCount={unreadCount || 0}
           hasActiveFilters={hasActiveFilters}
-          onFilterReset={handleQuickReset}
+          onFilterReset={handleClearAllFilters}
         />
 
         <LoadingState />
@@ -578,7 +578,7 @@ const HomeScreen = ({navigation}: HomeScreenProps) => {
           }}
           unreadCount={unreadCount || 0}
           hasActiveFilters={hasActiveFilters}
-          onFilterReset={handleQuickReset}
+          onFilterReset={handleClearAllFilters}
         />
 
         <ErrorState onRetry={refetch} />
@@ -605,7 +605,7 @@ const HomeScreen = ({navigation}: HomeScreenProps) => {
           }}
           unreadCount={unreadCount || 0}
           hasActiveFilters={hasActiveFilters}
-          onFilterReset={handleQuickReset}
+          onFilterReset={handleClearAllFilters}
         />
 
         <OfflineState />
@@ -629,7 +629,7 @@ const HomeScreen = ({navigation}: HomeScreenProps) => {
           }}
           unreadCount={unreadCount ? unreadCount : 0}
           hasActiveFilters={hasActiveFilters}
-          onFilterReset={handleQuickReset}
+          onFilterReset={handleClearAllFilters}
         />
 
         <View style={styles.buttonContainer}>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "UltimateHealth",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "UltimateHealth",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
### What changed?
Replaced the undefined `handleQuickReset` function calls with the existing `handleClearAllFilters` function in `HomeScreen.tsx`. 

### Why?
The `HomeScreen` component was passing an undefined function to the Quick Filter reset buttons, which caused a `ReferenceError` and crashed the app when interacted with. This fix wires the buttons correctly to clear the filters without crashing.

Fixes #1501