### PR TITLE
Fix: clear search state on screen blur

### DIFF
--- a/frontend/src/screens/PodcastSearch.tsx
+++ b/frontend/src/screens/PodcastSearch.tsx
@@ -31,13 +31,13 @@ export default function PodcastSearch({navigation}: PodcastSearchProp) {
 
   useFocusEffect(
     useCallback(() => {
-      // Reset local search state when entering the screen to avoid stale queries.
-      setQuery('');
-      setDebouncedQuery('');
-      setPage(1);
-      setTotalPages(0);
-      setSearchData([]);
       return () => {
+        // Reset local search state when leaving the screen to avoid stale queries.
+        setQuery('');
+        setDebouncedQuery('');
+        setPage(1);
+        setTotalPages(0);
+        setSearchData([]);
         if (debounceTimer.current) clearTimeout(debounceTimer.current);
       };
     }, []),


### PR DESCRIPTION
PR Description
This PR resolves an open bug in the podcast search feature where the search state (query, debounced query, pagination, and search results) persisted in memory when the user navigated away from the screen. 

By relocating the state-clearing functions from the main body of the `useFocusEffect` callback to the returned cleanup function, the search state is now cleared on screen blur (whenever the user leaves the screen/navigates away). This prevents stale queries/results from remaining active in the background and improves the overall user experience.

 Type of Change
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update


 Related Issue
This addresses the open bug regarding search state persistence on screen navigation.
Add your Work Example
📷 Code Difference:
The cleanup behavior has been shifted to screen blur (leaving the screen):
```tsx
  useFocusEffect(
    useCallback(() => {
      return () => {
        // Reset local search state when leaving the screen to avoid stale queries.
        setQuery('');
        setDebouncedQuery('');
        setPage(1);
        setTotalPages(0);
        setSearchData([]);
        if (debounceTimer.current) clearTimeout(debounceTimer.current);
      };
    }, []),
  );
```

#close 1528