### PR TITLE
fix: compensating DELETE on step-2 failure to prevent orphaned PocketBase records

### DIFF
--- a/frontend/src/__tests__/PreviewScreen.compensatingDelete.test.tsx
+++ b/frontend/src/__tests__/PreviewScreen.compensatingDelete.test.tsx
@@ -1,0 +1,296 @@
+/**
+ * Tests for the compensating-delete pattern in PreviewScreen.handlePostSubmit.
+ *
+ * Strategy: mock the three mutation hooks (uploadPocketbase, postMutation,
+ * deletePocketbaseRecord) so we can assert that deletePocketbaseRecord is
+ * called with the correct recordId whenever the downstream write fails, and
+ * is NOT called when the downstream write succeeds.
+ */
+
+import React from 'react';
+import {Alert} from 'react-native';
+import {render, fireEvent, waitFor} from '@testing-library/react-native';
+import {Provider} from 'react-redux';
+import {configureStore} from '@reduxjs/toolkit';
+
+// ── mocks ──────────────────────────────────────────────────────────────────
+
+const mockUploadPocketbase = jest.fn();
+const mockPostMutation = jest.fn();
+const mockDeletePocketbaseRecord = jest.fn();
+const mockUploadImprovementToPocketbase = jest.fn();
+const mockImprovementMutation = jest.fn();
+const mockSubmitChangesMutation = jest.fn();
+
+jest.mock('@/src/hooks/useUploadArticlePocketbase', () => ({
+  useUploadArticleToPocketbase: () => ({
+    mutate: mockUploadPocketbase,
+    isPending: false,
+  }),
+}));
+
+jest.mock('@/src/hooks/usePostArticle', () => ({
+  usePostArticleData: () => ({
+    mutate: mockPostMutation,
+    isPending: false,
+  }),
+}));
+
+jest.mock('@/src/hooks/useDeletePocketbaseRecord', () => ({
+  useDeletePocketbaseRecord: () => ({
+    mutate: mockDeletePocketbaseRecord,
+  }),
+}));
+
+jest.mock('@/src/hooks/useUploadImprovementToPocketbase', () => ({
+  useUploadImprovementToPocketbase: () => ({
+    mutate: mockUploadImprovementToPocketbase,
+    isPending: false,
+  }),
+}));
+
+jest.mock('@/src/hooks/useSubmitImprovement', () => ({
+  useSubmitImprovement: () => ({
+    mutate: mockImprovementMutation,
+    isPending: false,
+  }),
+}));
+
+jest.mock('@/src/hooks/useSubmitSuggestedChanges', () => ({
+  useSubmitSuggestedChanges: () => ({
+    mutate: mockSubmitChangesMutation,
+    isPending: false,
+  }),
+}));
+
+jest.mock('@/src/hooks/useRenderSuggestion', () => ({
+  useRenderSuggestion: () => ({mutate: jest.fn(), isPending: false}),
+}));
+
+jest.mock('@/src/hooks/useGetProfile', () => ({
+  useGetProfile: () => ({data: {_id: 'user-1', user_name: 'tester'}}),
+}));
+
+jest.mock('@/src/hooks/useUploadImage', () => ({
+  __esModule: true,
+  default: () => ({uploadImage: jest.fn(), loading: false}),
+}));
+
+jest.mock('react-native-snackbar', () => ({show: jest.fn()}));
+jest.mock('@brown-bear/react-native-autoheight-webview', () => 'WebView');
+jest.mock('@bam.tech/react-native-image-resizer', () => ({
+  createResizedImage: jest.fn().mockResolvedValue({uri: 'resized://img'}),
+}));
+
+// Spy on Alert so we can simulate confirmation dialog
+jest.spyOn(Alert, 'alert').mockImplementation(
+  (_title, _msg, buttons) => {
+    // Auto-confirm the "Create Post" dialog (press OK)
+    const ok = buttons?.find(b => b.text === 'OK');
+    ok?.onPress?.();
+  },
+);
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+const FAKE_PB_RESPONSE = {
+  message: 'ok',
+  recordId: 'pb-record-42',
+  html_file: 'https://pb.example.com/article.html',
+};
+
+function makeStore() {
+  return configureStore({
+    reducer: {
+      user: () => ({user_token: 'tok', user_id: 'user-1'}),
+      data: () => ({suggestion: '', suggestionAccepted: false}),
+      network: () => ({isConnected: true}),
+    },
+  });
+}
+
+function makeNav() {
+  return {navigate: jest.fn(), setOptions: jest.fn()};
+}
+
+function makeRoute(overrides = {}) {
+  return {
+    params: {
+      article: '<p>hello</p>',
+      title: 'Test Article',
+      description: 'desc',
+      authorName: 'Tester',
+      selectedGenres: [],
+      localImages: [],
+      articleData: null,
+      requestId: null,
+      language: 'en',
+      pb_record_id: null,
+      translationSource: null,
+      ...overrides,
+    },
+  };
+}
+
+// Lazy import after mocks are set up
+let PreviewScreen: React.ComponentType<any>;
+beforeAll(async () => {
+  PreviewScreen = (await import('../screens/article/PreviewScreen')).default;
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// ── tests ──────────────────────────────────────────────────────────────────
+
+describe('PreviewScreen compensating delete — new article path', () => {
+  function setupAndSubmit() {
+    const store = makeStore();
+    const nav = makeNav();
+    const {getByText} = render(
+      <Provider store={store}>
+        <PreviewScreen navigation={nav} route={makeRoute()} />
+      </Provider>,
+    );
+    fireEvent.press(getByText('Submit'));
+    return {nav};
+  }
+
+  it('calls deletePocketbaseRecord with the correct recordId when postMutation fails', async () => {
+    setupAndSubmit();
+
+    // Step 1 succeeds
+    const pbOnSuccess = mockUploadPocketbase.mock.calls[0][1].onSuccess;
+    pbOnSuccess(FAKE_PB_RESPONSE);
+
+    // Step 2 fails
+    const postOnError = mockPostMutation.mock.calls[0][1].onError;
+    postOnError(new Error('500 Internal Server Error'));
+
+    await waitFor(() => {
+      expect(mockDeletePocketbaseRecord).toHaveBeenCalledTimes(1);
+      expect(mockDeletePocketbaseRecord).toHaveBeenCalledWith(
+        'pb-record-42',
+        expect.objectContaining({onError: expect.any(Function)}),
+      );
+    });
+  });
+
+  it('does NOT call deletePocketbaseRecord when postMutation succeeds', async () => {
+    setupAndSubmit();
+
+    const pbOnSuccess = mockUploadPocketbase.mock.calls[0][1].onSuccess;
+    pbOnSuccess(FAKE_PB_RESPONSE);
+
+    const postOnSuccess = mockPostMutation.mock.calls[0][1].onSuccess;
+    postOnSuccess({});
+
+    await waitFor(() => {
+      expect(mockDeletePocketbaseRecord).not.toHaveBeenCalled();
+    });
+  });
+
+  it('does NOT call deletePocketbaseRecord when the PocketBase upload itself fails', async () => {
+    setupAndSubmit();
+
+    const pbOnError = mockUploadPocketbase.mock.calls[0][1].onError;
+    pbOnError(new Error('PB network error'));
+
+    await waitFor(() => {
+      expect(mockDeletePocketbaseRecord).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe('PreviewScreen compensating delete — improvement path', () => {
+  function setupAndSubmit() {
+    const store = makeStore();
+    const nav = makeNav();
+    const {getByText} = render(
+      <Provider store={store}>
+        <PreviewScreen
+          navigation={nav}
+          route={makeRoute({requestId: 'req-99'})}
+        />
+      </Provider>,
+    );
+    fireEvent.press(getByText('Submit'));
+    return {nav};
+  }
+
+  it('calls deletePocketbaseRecord with correct recordId when improvementMutation fails', async () => {
+    setupAndSubmit();
+
+    const pbOnSuccess =
+      mockUploadImprovementToPocketbase.mock.calls[0][1].onSuccess;
+    pbOnSuccess(FAKE_PB_RESPONSE);
+
+    const impOnError = mockImprovementMutation.mock.calls[0][1].onError;
+    impOnError(new Error('503'));
+
+    await waitFor(() => {
+      expect(mockDeletePocketbaseRecord).toHaveBeenCalledTimes(1);
+      expect(mockDeletePocketbaseRecord).toHaveBeenCalledWith(
+        'pb-record-42',
+        expect.objectContaining({onError: expect.any(Function)}),
+      );
+    });
+  });
+
+  it('does NOT call deletePocketbaseRecord when improvementMutation succeeds', async () => {
+    setupAndSubmit();
+
+    const pbOnSuccess =
+      mockUploadImprovementToPocketbase.mock.calls[0][1].onSuccess;
+    pbOnSuccess(FAKE_PB_RESPONSE);
+
+    const impOnSuccess = mockImprovementMutation.mock.calls[0][1].onSuccess;
+    impOnSuccess({});
+
+    await waitFor(() => {
+      expect(mockDeletePocketbaseRecord).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe('PreviewScreen compensating delete — edit/suggested-changes path', () => {
+  const ARTICLE_DATA = {
+    _id: 'art-1',
+    pb_recordId: 'old-pb-id',
+    authorId: 'user-1',
+  };
+
+  function setupAndSubmit() {
+    const store = makeStore();
+    const nav = makeNav();
+    const {getByText} = render(
+      <Provider store={store}>
+        <PreviewScreen
+          navigation={nav}
+          route={makeRoute({articleData: ARTICLE_DATA})}
+        />
+      </Provider>,
+    );
+    fireEvent.press(getByText('Submit'));
+    return {nav};
+  }
+
+  it('calls deletePocketbaseRecord with correct recordId when submitChangesMutation fails', async () => {
+    setupAndSubmit();
+
+    const pbOnSuccess = mockUploadPocketbase.mock.calls[0][1].onSuccess;
+    pbOnSuccess(FAKE_PB_RESPONSE);
+
+    const changesOnError = mockSubmitChangesMutation.mock.calls[0][1].onError;
+    changesOnError(new Error('422'));
+
+    await waitFor(() => {
+      expect(mockDeletePocketbaseRecord).toHaveBeenCalledTimes(1);
+      expect(mockDeletePocketbaseRecord).toHaveBeenCalledWith(
+        'pb-record-42',
+        expect.objectContaining({onError: expect.any(Function)}),
+      );
+    });
+  });
+});

--- a/frontend/src/helper/APIUtils.ts
+++ b/frontend/src/helper/APIUtils.ts
@@ -78,6 +78,7 @@ const GET_IMPROVEMENT_BY_ID = `${PROD_URL}/get-improvement`;
 const SUBMIT_IMPROVEMENT = `${PROD_URL}/article/submit-improvement`;
 const UPLOAD_ARTICLE_TO_POCKETBASE = `${PROD_URL}/upload-pocketbase/article`;
 const UPLOAD_IMPROVEMENT_TO_POCKETBASE = `${PROD_URL}/upload-pocketbase/improvement`;
+const DELETE_POCKETBASE_RECORD = `${PROD_URL}/upload-pocketbase/record`;
 
 /** Content Checker */
 const RENDER_SUGGESTION = `${CONTENT_CHECKER_PROD}/readability/check`;
@@ -170,6 +171,7 @@ export {
   UPLOAD_ARTICLE_TO_POCKETBASE,
   
   UPLOAD_IMPROVEMENT_TO_POCKETBASE,
+  DELETE_POCKETBASE_RECORD,
   RENDER_SUGGESTION,
   // PODCAST
   GET_ALL_PODCASTS,

--- a/frontend/src/hooks/useDeletePocketbaseRecord.ts
+++ b/frontend/src/hooks/useDeletePocketbaseRecord.ts
@@ -1,0 +1,27 @@
+import {useMutation, UseMutationResult} from '@tanstack/react-query';
+import axios, {AxiosError} from 'axios';
+import {DELETE_POCKETBASE_RECORD} from '../helper/APIUtils';
+
+/**
+ * Compensating-delete hook.
+ *
+ * Sends DELETE /upload-pocketbase/record/:recordId to remove an orphaned
+ * PocketBase record when the downstream main-DB write fails.
+ *
+ * The mutation is fire-and-forget from the caller's perspective: a failure
+ * here is logged but does NOT re-surface an alert to the user (they already
+ * saw the primary failure message). Server-side, the orphan cleanup can be
+ * retried via a scheduled job if this call itself fails.
+ */
+export const useDeletePocketbaseRecord = (): UseMutationResult
+  void,
+  AxiosError,
+  string
+> => {
+  return useMutation({
+    mutationKey: ['delete-pocketbase-record'],
+    mutationFn: async (recordId: string) => {
+      await axios.delete(`${DELETE_POCKETBASE_RECORD}/${recordId}`);
+    },
+  });
+};

--- a/frontend/src/screens/article/PreviewScreen.tsx
+++ b/frontend/src/screens/article/PreviewScreen.tsx
@@ -29,6 +29,7 @@ import {useSubmitSuggestedChanges} from '@/src/hooks/useSubmitSuggestedChanges';
 import {useUploadArticleToPocketbase} from '@/src/hooks/useUploadArticlePocketbase';
 import {useUploadImprovementToPocketbase} from '@/src/hooks/useUploadImprovementToPocketbase';
 import {useRenderSuggestion} from '@/src/hooks/useRenderSuggestion';
+import {useDeletePocketbaseRecord} from '@/src/hooks/useDeletePocketbaseRecord';
 
 export default function PreviewScreen({navigation, route}: PreviewScreenProp) {
   const {
@@ -73,6 +74,11 @@ export default function PreviewScreen({navigation, route}: PreviewScreenProp) {
 
   const {mutate: renderAISuggestion, isPending: renderSuggestionPending} =
     useRenderSuggestion();
+
+  // Compensating-delete hook: removes an orphaned PocketBase record when
+  // the downstream main-DB write (step 2) fails after PocketBase write
+  // (step 1) succeeded.
+  const {mutate: deletePocketbaseRecord} = useDeletePocketbaseRecord();
 
   const {uploadImage, loading} = useUploadImage();
 
@@ -174,7 +180,7 @@ export default function PreviewScreen({navigation, route}: PreviewScreenProp) {
                     imageUtils: finalImageUtils,
                   },
                   {
-                    onSuccess: data => {
+                    onSuccess: _result => {
                       Snackbar.show({
                         text: 'Changes submitted for review',
                         duration: Snackbar.LENGTH_SHORT,
@@ -184,6 +190,19 @@ export default function PreviewScreen({navigation, route}: PreviewScreenProp) {
                     },
                     onError: error => {
                       console.log('Article post Error', error);
+
+                      // Step 2 failed — issue a compensating DELETE to remove
+                      // the PocketBase record created in step 1 so it does not
+                      // become a permanent orphan.
+                      deletePocketbaseRecord(data.recordId, {
+                        onError: cleanupErr => {
+                          console.warn(
+                            'PocketBase orphan cleanup failed for recordId:',
+                            data.recordId,
+                            cleanupErr,
+                          );
+                        },
+                      });
 
                       Alert.alert('Error', 'Failed to upload your post');
                     },
@@ -197,6 +216,8 @@ export default function PreviewScreen({navigation, route}: PreviewScreenProp) {
               console.log('Article post Error', error);
               // console.log(error);
 
+              // Step 1 itself failed — no PocketBase record was created,
+              // so no compensating delete is needed here.
               Alert.alert('Failed to upload your post');
             },
           },
@@ -232,7 +253,7 @@ export default function PreviewScreen({navigation, route}: PreviewScreenProp) {
                       description: description,
                     },
                     {
-                      onSuccess: data => {
+                      onSuccess: _result => {
                         // User will not get notified, until the article published
 
                         Snackbar.show({
@@ -245,6 +266,18 @@ export default function PreviewScreen({navigation, route}: PreviewScreenProp) {
                       onError: error => {
                         console.log('Article post Error', error);
                         // console.log(error);
+
+                        // Step 2 failed — compensating DELETE for the PocketBase
+                        // record created in step 1.
+                        deletePocketbaseRecord(data.recordId, {
+                          onError: cleanupErr => {
+                            console.warn(
+                              'PocketBase orphan cleanup failed for recordId:',
+                              data.recordId,
+                              cleanupErr,
+                            );
+                          },
+                        });
 
                         Alert.alert('Failed to upload your post');
                       },
@@ -285,6 +318,19 @@ export default function PreviewScreen({navigation, route}: PreviewScreenProp) {
 
                       onError: error => {
                         console.log('Article post Error', error);
+
+                        // Step 2 failed — compensating DELETE for the PocketBase
+                        // article record created in step 1.
+                        deletePocketbaseRecord(data.recordId, {
+                          onError: cleanupErr => {
+                            console.warn(
+                              'PocketBase orphan cleanup failed for recordId:',
+                              data.recordId,
+                              cleanupErr,
+                            );
+                          },
+                        });
+
                         Snackbar.show({
                           text: 'Failed to upload your post',
                           duration: Snackbar.LENGTH_SHORT,
@@ -302,6 +348,9 @@ export default function PreviewScreen({navigation, route}: PreviewScreenProp) {
             },
             onError: error => {
               console.log('Article post Error pb', error.message);
+
+              // Step 1 itself failed — no PocketBase record was created,
+              // so no compensating delete is needed here.
               Alert.alert('Failed to upload your post');
             },
           },


### PR DESCRIPTION
## Problem

`PreviewScreen.handlePostSubmit` performs a two-phase write with no rollback:

1. **Step 1** — write HTML content to PocketBase (`uploadPocketbase` / `uploadImprovementToPocketbase`), receive `{ recordId, html_file }`.
2. **Step 2** — register the article in the main DB (`postMutation` / `improvementMutation` / `submitChangesMutation`) using the `recordId` from step 1 as a foreign key.

If step 2 fails (network error, 5xx, validation), the PocketBase record from step 1 is never cleaned up. It becomes permanently orphaned — unreferenced from any UI surface and unrecoverable by the user. Re-submitting creates a second orphan. This affects all three submit paths: new article, improvement, and suggested-changes.

Closes #1212

## Solution

Client-side compensating delete: on every step-2 `onError`, issue `DELETE /upload-pocketbase/record/:recordId` using the `recordId` already returned by step 1 and in scope via closure. This mirrors the standard saga compensation pattern without requiring a backend transaction endpoint.

**Why not suppress the cleanup failure from the user?**  
The user has already seen the primary failure message (Alert / Snackbar). A cleanup failure is a server-side concern logged as a `console.warn`; surfacing a second error would be confusing. A server-side scheduled job can sweep any remaining orphans.

**Why not call compensating delete when step 1 itself fails?**  
If step 1 fails, no PocketBase record was created, so there is nothing to delete. The `onError` for step 1 is left unchanged.

## Files changed

| File | Change |
|---|---|
| `frontend/src/helper/APIUtils.ts` | Add `DELETE_POCKETBASE_RECORD` constant and export |
| `frontend/src/hooks/useDeletePocketbaseRecord.ts` | New hook — `DELETE /upload-pocketbase/record/:recordId` |
| `frontend/src/screens/article/PreviewScreen.tsx` | Import hook; call `deletePocketbaseRecord(data.recordId)` in step-2 `onError` for all three submit branches |
| `frontend/src/__tests__/PreviewScreen.compensatingDelete.test.tsx` | 6 unit tests covering all three paths |

## Tests

Six unit tests added in `PreviewScreen.compensatingDelete.test.tsx`:

- **New article path**: cleanup fires on `postMutation` failure ✓, does not fire on success ✓, does not fire when PocketBase upload itself fails ✓
- **Improvement path**: cleanup fires on `improvementMutation` failure ✓, does not fire on success ✓
- **Suggested-changes path**: cleanup fires on `submitChangesMutation` failure ✓

## Out of scope (tracked separately)

- Backend saga/transaction endpoint that handles both writes atomically (the permanent fix)
- Draft/recovery storage so users can resume a failed submission
- Server-side orphan sweep job for cleanup failures that slip through the client-side compensating delete