### PR TITLE
fix: recover podcast playback after network interruptions

### DIFF
--- a/frontend/src/components/NetworkRecoveringBanner.tsx
+++ b/frontend/src/components/NetworkRecoveringBanner.tsx
@@ -1,0 +1,79 @@
+/**
+ * NetworkRecoveringBanner.tsx
+ * 
+ * UI banner component displayed when podcast playback is waiting for network recovery.
+ * Shows a reconnecting message with animated spinner to give user visual feedback
+ * that the app is attempting to restore playback.
+ */
+
+import Ionicons from '@expo/vector-icons/Ionicons';
+import React from 'react';
+import { ActivityIndicator, StyleSheet, View } from 'react-native';
+import { Text, XStack, YStack } from 'tamagui';
+
+interface NetworkRecoveringBannerProps {
+  isVisible: boolean;
+}
+
+/**
+ * Banner displayed when podcast is recovering from network loss.
+ * Animated spinner indicates waiting for network restoration.
+ */
+const NetworkRecoveringBanner: React.FC<NetworkRecoveringBannerProps> = ({
+  isVisible,
+}) => {
+  if (!isVisible) {
+    return null;
+  }
+
+  return (
+    <View style={styles.container}>
+      <YStack
+        width="100%"
+        padding="$3"
+        backgroundColor="#FFA500"
+        borderRadius="$3"
+        justifyContent="center"
+        alignItems="center"
+      >
+        <XStack
+          gap="$2"
+          alignItems="center"
+          justifyContent="center"
+        >
+          <ActivityIndicator 
+            size="small" 
+            color="#FFFFFF"
+            testID="network-recovering-spinner"
+          />
+          <XStack gap="$1" alignItems="center">
+            <Ionicons 
+              name="cloud-offline-outline" 
+              size={16} 
+              color="#FFFFFF"
+              testID="network-recovering-icon"
+            />
+            <Text
+              fontSize={14}
+              fontWeight="600"
+              color="#FFFFFF"
+              testID="network-recovering-text"
+            >
+              Network interrupted. Reconnecting...
+            </Text>
+          </XStack>
+        </XStack>
+      </YStack>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    width: '100%',
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+  },
+});
+
+export default NetworkRecoveringBanner;

--- a/frontend/src/hooks/useNetworkRecovery.ts
+++ b/frontend/src/hooks/useNetworkRecovery.ts
@@ -1,0 +1,253 @@
+/**
+ * useNetworkRecovery.ts
+ * 
+ * Custom hook to handle automatic podcast playback recovery after network interruptions.
+ * 
+ * This hook:
+ * 1. Detects network connectivity changes (loss/restoration)
+ * 2. Saves playback position before pausing on network loss
+ * 3. Automatically restores position and resumes playback on reconnection
+ * 4. Prevents duplicate resume attempts during rapid reconnect events
+ * 5. Distinguishes between network-related and other playback errors
+ * 
+ * Usage:
+ * const { isRecovering, handleNetworkError } = useNetworkRecovery(
+ *   player,
+ *   isConnected,
+ *   currentPosition,
+ *   wasPlaying
+ * );
+ */
+
+import * as Sentry from '@sentry/react-native';
+import { useEffect, useRef, useState } from 'react';
+import { logger } from '../services/monitoring/logger';
+
+interface NetworkRecoveryState {
+  isRecovering: boolean;
+  savedPosition: number;
+  wasPlayingBeforeLoss: boolean;
+}
+
+interface UseNetworkRecoveryReturn {
+  isRecovering: boolean;
+  handleNetworkError: (error: Error, isNetworkRelated: boolean) => void;
+}
+
+/**
+ * Hook for managing podcast playback recovery during network interruptions.
+ * 
+ * @param player - expo-audio player instance
+ * @param isConnected - current network connection status from Redux
+ * @param currentPosition - current playback position in seconds
+ * @param wasPlaying - whether podcast was playing before network loss
+ * @returns Object with recovery state and error handler
+ */
+export const useNetworkRecovery = (
+  player: any,
+  isConnected: boolean,
+  currentPosition: number,
+  wasPlaying: boolean,
+): UseNetworkRecoveryReturn => {
+  const [recoveryState, setRecoveryState] = useState<NetworkRecoveryState>({
+    isRecovering: false,
+    savedPosition: 0,
+    wasPlayingBeforeLoss: false,
+  });
+
+  // Track whether we've attempted resume to prevent duplicates
+  const isResumeAttemptedRef = useRef(false);
+  
+  // Track previous connection state to detect transitions
+  const previousConnectionRef = useRef(isConnected);
+  
+  // Debounce timer for rapid reconnects
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  /**
+   * Handle network loss: pause playback and save state
+   */
+  const handleNetworkLoss = async () => {
+    if (!player) return;
+
+    logger.log('[NetworkRecovery] Network loss detected, saving state and pausing playback');
+
+    try {
+      // Save current state before pausing
+      const position = player.currentTime || 0;
+      const isCurrentlyPlaying = player.playing || false;
+
+      setRecoveryState({
+        isRecovering: true,
+        savedPosition: position,
+        wasPlayingBeforeLoss: isCurrentlyPlaying,
+      });
+
+      // Pause the player gracefully
+      if (isCurrentlyPlaying) {
+        await player.pause();
+        logger.log('[NetworkRecovery] Playback paused, position saved', {
+          position,
+          timestamp: new Date().toISOString(),
+        });
+      }
+
+      // Reset resume attempt flag when network loss occurs
+      isResumeAttemptedRef.current = false;
+
+      // Log to Sentry for offline analytics
+      Sentry.captureMessage('Podcast playback paused due to network loss', 'info');
+    } catch (error) {
+      logger.error('[NetworkRecovery] Error during network loss handling:', error);
+      Sentry.captureException(error, {
+        tags: { context: 'network_loss_pause' },
+      });
+    }
+  };
+
+  /**
+   * Handle network restoration: restore position and resume playback
+   */
+  const handleNetworkRestoration = async () => {
+    if (!player) {
+      logger.warn('[NetworkRecovery] Network restored but player not available');
+      return;
+    }
+
+    // Prevent duplicate resume attempts during rapid reconnect events
+    if (isResumeAttemptedRef.current) {
+      logger.log('[NetworkRecovery] Resume already attempted for this session, skipping duplicate');
+      return;
+    }
+
+    // Mark that we're attempting resume
+    isResumeAttemptedRef.current = true;
+
+    logger.log('[NetworkRecovery] Network restored, attempting playback recovery');
+
+    try {
+      // Small delay to ensure network is stable before resuming
+      await new Promise((resolve: () => void) => setTimeout(resolve, 500));
+
+      // Check network is still available (double-check)
+      if (!isConnected) {
+        logger.warn('[NetworkRecovery] Network connectivity lost again during recovery');
+        isResumeAttemptedRef.current = false;
+        return;
+      }
+
+      // Restore playback position
+      if (recoveryState.savedPosition > 0) {
+        await player.seekTo(recoveryState.savedPosition);
+        logger.log('[NetworkRecovery] Playback position restored');
+      }
+
+      // Resume playback only if it was playing before network loss
+      if (recoveryState.wasPlayingBeforeLoss) {
+        await player.play();
+        logger.log('[NetworkRecovery] Playback resumed after network recovery');
+      }
+
+      // Clear recovery state and UI banner
+      setRecoveryState({
+        isRecovering: false,
+        savedPosition: 0,
+        wasPlayingBeforeLoss: false,
+      });
+
+      // Log successful recovery
+      Sentry.captureMessage('Podcast playback successfully recovered after network loss', 'info');
+    } catch (error) {
+      logger.error('[NetworkRecovery] Error during playback recovery:', error);
+
+      // Reset resume flag on error to allow retry
+      isResumeAttemptedRef.current = false;
+
+      // Distinguish network errors from other errors
+      const isNetworkError = error instanceof Error && (
+        error.message.toLowerCase().indexOf('network') !== -1 ||
+        error.message.toLowerCase().indexOf('timeout') !== -1 ||
+        error.message.toLowerCase().indexOf('fetch') !== -1 ||
+        error.message.toLowerCase().indexOf('offline') !== -1
+      );
+
+      Sentry.captureException(error, {
+        tags: {
+          context: 'network_restoration_recovery',
+          errorType: isNetworkError ? 'network' : 'playback',
+        },
+      });
+
+      // If it's still a network error, keep recovery banner visible
+      if (!isNetworkError) {
+        setRecoveryState((prev: NetworkRecoveryState) => ({
+          ...prev,
+          isRecovering: false,
+        }));
+      }
+    }
+  };
+
+  /**
+   * Public error handler for player errors
+   */
+  const handleNetworkError = (error: Error, isNetworkRelated: boolean = false) => {
+    if (isNetworkRelated) {
+      logger.warn('[NetworkRecovery] Network-related playback error detected:', error.message);
+      handleNetworkLoss();
+    } else {
+      logger.error('[NetworkRecovery] Non-network playback error:', error.message);
+      // Non-network errors should be handled by caller
+    }
+  };
+
+  /**
+   * Watch for network state changes and handle accordingly
+   */
+  useEffect(() => {
+    // Detect transition from connected to disconnected
+    if (previousConnectionRef.current && !isConnected) {
+      logger.log('[NetworkRecovery] Network connection lost');
+      handleNetworkLoss();
+    }
+    // Detect transition from disconnected to connected
+    else if (!previousConnectionRef.current && isConnected) {
+      logger.log('[NetworkRecovery] Network connection restored');
+
+      // Debounce rapid reconnect attempts (ignore within 1 second)
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+      }
+
+      debounceTimerRef.current = setTimeout(() => {
+        void handleNetworkRestoration();
+      }, 1000); // Wait 1 second for network to stabilize
+    }
+
+    previousConnectionRef.current = isConnected;
+
+    // Cleanup debounce timer on unmount
+    return () => {
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+      }
+    };
+  }, [isConnected]);
+
+  /**
+   * Cleanup on unmount
+   */
+  useEffect(() => {
+    return () => {
+      isResumeAttemptedRef.current = false;
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+      }
+    };
+  }, []);
+
+  return {
+    isRecovering: recoveryState.isRecovering,
+    handleNetworkError,
+  };
+};

--- a/frontend/src/screens/PodcastDetail.tsx
+++ b/frontend/src/screens/PodcastDetail.tsx
@@ -1,40 +1,41 @@
-import React, {useEffect, useState} from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import Slider from '@react-native-community/slider';
+import React, { useEffect, useState } from 'react';
 import {
+  Alert,
+  Image,
+  Platform,
   StyleSheet,
   TouchableOpacity,
-  Alert,
-  Platform,
-  View,
-  Image,
   useWindowDimensions,
+  View,
 } from 'react-native';
-import Ionicons from '@expo/vector-icons/Ionicons';
-import {PodcastDetailScreenProp} from '../type';
-import {PRIMARY_COLOR} from '../helper/Theme';
-import Slider from '@react-native-community/slider';
-import {GlassStyles} from '../styles/GlassStyles';
+import { PRIMARY_COLOR } from '../helper/Theme';
+import { GlassStyles } from '../styles/GlassStyles';
+import { PodcastDetailScreenProp } from '../type';
 
-import {useAudioPlayer} from 'expo-audio';
+import { useAudioPlayer } from 'expo-audio';
+import NetworkRecoveringBanner from '../components/NetworkRecoveringBanner';
+import { useNetworkRecovery } from '../hooks/useNetworkRecovery';
 
 // GET_IMAGE is defined as `${PROD_URL}/getfile` (resolves to absolute URL: https://uhsocial.in/api/getfile).
 // This absolute, securely-configured endpoint ensures that relative resource paths cannot access local device files via traversal.
-import {GET_IMAGE} from '../helper/APIUtils';
-import {useSelector} from 'react-redux';
+import { useSelector } from 'react-redux';
+import { GET_IMAGE } from '../helper/APIUtils';
 
-import {downloadAudio, formatCount, StatusEnum} from '../helper/Utils';
-import Snackbar from 'react-native-snackbar';
+import { Feather } from '@expo/vector-icons';
 import AntDesign from '@expo/vector-icons/AntDesign';
 import Share from 'react-native-share';
-import {fp} from '../helper/Metric';
-import {useSocket} from '../contexts/SocketContext';
-import {Feather} from '@expo/vector-icons';
+import Snackbar from 'react-native-snackbar';
+import { ScrollView, Text, Theme, XStack, YStack } from 'tamagui';
+import AudioWaveform from '../components/AudioWaveform';
 import Loader from '../components/Loader';
 import LoadingSpinner from '../components/LoadingSpinner';
-import {Theme, XStack, YStack, Text, ScrollView} from 'tamagui';
-import LottieView from 'lottie-react-native';
-import AudioWaveform from '../components/AudioWaveform';
-import {useGetSinglePodcastDetails} from '../hooks/useGetSinglePodcastDetails';
-import {useLikePodcast} from '../hooks/useLikePodcast';
+import { useSocket } from '../contexts/SocketContext';
+import { fp } from '../helper/Metric';
+import { downloadAudio, formatCount, StatusEnum } from '../helper/Utils';
+import { useGetSinglePodcastDetails } from '../hooks/useGetSinglePodcastDetails';
+import { useLikePodcast } from '../hooks/useLikePodcast';
 
 const isAllowedUrl = (urlStr?: string | null): boolean => {
   if (!urlStr) return false;
@@ -85,6 +86,8 @@ const PodcastDetail = ({navigation, route}: PodcastDetailScreenProp) => {
   const {data: podcast, refetch, isLoading: isPodcastLoading, isError: isPodcastError, error: podcastError} = useGetSinglePodcastDetails(trackId);
   const {mutate: likePodcast, isPending: likePodcastPending} = useLikePodcast();
 
+  // Network recovery: automatically pause, save position, and resume playback on reconnection
+
   const defaultFallback = require('../../assets/sounds/funny-cartoon-sound-397415.mp3');
 
   const getFormattedSource = (url?: string | null) => {
@@ -102,6 +105,14 @@ const PodcastDetail = ({navigation, route}: PodcastDetailScreenProp) => {
   // only initialize once a valid uri exists
   const player = useAudioPlayer(initialSource);
 
+  // Initialize network recovery AFTER player is created to avoid using player before declaration
+  const { isRecovering, handleNetworkError } = useNetworkRecovery(
+    player,
+    isConnected,
+    position,
+    playing,
+  );
+
   useEffect(() => {
     if (podcast?.audio_url) {
       const secureSource = getFormattedSource(podcast.audio_url);
@@ -111,6 +122,38 @@ const PodcastDetail = ({navigation, route}: PodcastDetailScreenProp) => {
       }
     }
   }, [podcast?.audio_url, player, loadedSource]);
+
+  /**
+   * Player error listener: detects playback errors and routes them to network recovery
+   * if they appear to be network-related.
+   */
+  useEffect(() => {
+    if (!player) return;
+
+    // Check if player has an error state (expo-audio may throw or emit errors)
+    const checkPlayerError = () => {
+      try {
+        const status = player.currentStatus;
+        // If status indicates an error and network is down, treat as network error
+        if (status?.error && !isConnected) {
+          handleNetworkError(
+            new Error(status.error || 'Playback error'),
+            true // Mark as network-related
+          );
+        }
+      } catch (error) {
+        // Player may throw if in error state
+        if (error instanceof Error && !isConnected) {
+          handleNetworkError(error, true); // Assume network-related if offline
+        }
+      }
+    };
+
+    // Poll player status every 2 seconds to catch errors early
+    const errorCheckInterval = setInterval(checkPlayerError, 2000);
+
+    return () => clearInterval(errorCheckInterval);
+  }, [player, isConnected, handleNetworkError]);
 
   useEffect(() => {
     const interval = setInterval(() => {
@@ -619,6 +662,8 @@ const PodcastDetail = ({navigation, route}: PodcastDetailScreenProp) => {
           padding="$3"
           paddingTop="$10"
           justifyContent="space-between">
+          {/* Network Recovery Banner: appears when connection is lost during playback */}
+          <NetworkRecoveringBanner isVisible={isRecovering} />
           {content}
         </YStack>
       </Theme>


### PR DESCRIPTION
## Description

This PR fixes the podcast player recovery behavior during temporary network interruptions.

### Changes Made

* Added network interruption detection during podcast playback.
* Preserved playback position when connectivity is lost.
* Added automatic playback recovery when connectivity is restored.
* Prevented duplicate resume attempts during repeated reconnect events.
* Added a reconnecting/waiting UI banner for better user feedback.
* Improved handling of network-related playback failures.

### Testing

* Verified playback pauses when network connectivity is lost.
* Verified playback position is preserved.
* Verified playback resumes from the saved position after reconnection.
* Verified reconnect UI appears during recovery.
* Verified duplicate recovery attempts are prevented.

Fixes #1339

