### PR TITLE
fiX: correct useSendOtp generic type signature

### DIFF
--- a/frontend/src/hooks/useSendOtp.ts
+++ b/frontend/src/hooks/useSendOtp.ts
@@ -2,7 +2,7 @@ import { useMutation, UseMutationResult } from "@tanstack/react-query";
 import axios, { AxiosError } from "axios";
 import { SEND_OTP } from "../helper/APIUtils";
 
-export const useSendOtpMutation = ():UseMutationResult
+export const useSendOtpMutation = ():UseMutationResult<
   void,
   AxiosError,
   {email: string}


### PR DESCRIPTION
#### PR Description

This PR fixes the TypeScript generic type signature error in `frontend/src/hooks/useSendOtp.ts`.

### Changes Made

* Added the missing `<` after `UseMutationResult` in the hook return type declaration.
* Corrected the generic type syntax so that TypeScript can properly parse the hook signature.
* No functional behavior was changed.

### Type of Change

* [x] Bug fix

### Work Area

* [x] Frontend

### Related Issue

* #1565

### Work Example

* Fixed the malformed generic declaration
* This resolves the syntax error that prevented successful TypeScript compilation.

### Fixes

Closes #1565

### Checklist

* [x] I have optimized the file changes.
* [x] I have made a PR to the project's main branch.
* [x] I have performed a self-review of my code.
* [x] I have checked for plagiarism and assure its authenticity.
* [x] I have read and followed the code of conduct.

### Undertaking

* [x] I Agree
