### PR TITLE
fix: remove duplicate imports from NotificationScreen

### DIFF
--- a/frontend/src/screens/NotificationScreen.tsx
+++ b/frontend/src/screens/NotificationScreen.tsx
@@ -7,17 +7,11 @@ import {Notification, NotificationType} from '../type';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import Loader from '../components/Loader';
 import Snackbar from 'react-native-snackbar';
-import { useDispatch, useSelector } from 'react-redux';
 import { NoNotificationState } from '../components/EmptyStates';
-import Loader from '../components/Loader';
-import NotificationItem from '../components/NotificationItem';
 import { hp } from '../helper/Metric';
-import { ON_PRIMARY_COLOR, PRIMARY_COLOR } from '../helper/Theme';
 import { useDeleteNotification } from '../hooks/useDeleteNotification';
 import { useGetAllNotifications } from '../hooks/useGetAllNotifications';
 import { useMarkNotificationAsRead } from '../hooks/useMarkNoticationAsRead';
-import { Notification, NotificationType } from '../type';
-
 type PendingDelete = {
   item: Notification;
   index: number;


### PR DESCRIPTION
#### PR Description
This PR removes duplicate import statements from `frontend/src/screens/NotificationScreen.tsx`.

### Changes Made

* Removed duplicate `useDispatch` and `useSelector` imports from `react-redux`
* Removed duplicate `Loader` import
* Removed duplicate `NotificationItem` import
* Removed duplicate `ON_PRIMARY_COLOR` and `PRIMARY_COLOR` imports
* Removed duplicate `Notification` and `NotificationType` imports

These changes resolve the duplicate identifier issues while preserving the existing functionality.

#### Type of Change
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update

#### Select your work-area
- [x] Frontend
- [ ] Backend
- [ ] Documentation
- [ ] Others

#### Related Issue
https://github.com/SB2318/UltimateHealth/issues/1499

#### Add your Work Example
Not applicable.

#### Fixes (mention the issue number which this fixes)
Closes #1499 

#### Checklist
- [ ] I have updated my branch and synced it with the project's 'develop' branch before making this PR.
- [x] I have optimized the file changes.
- [ ] I have added a snapshot of my work example.
- [ ] I have made a PR to the project's develop branch.

#### Undertaking
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have checked for plagiarism and assure its authenticity.
- [x] I have read and followed the code of conduct for this repository. I understand that violation of this undertaking may have legal consequences.

- [x] I Agree
