### PR TITLE
fix: broken profile lookup by user handle in UserProfileScreen

### DIFF
--- a/frontend/src/screens/UserProfileScreen.tsx
+++ b/frontend/src/screens/UserProfileScreen.tsx
@@ -54,7 +54,7 @@ const UserProfileScreen = ({navigation, route}: UserProfileScreenProp) => {
 
   // Get the actual authorId string
  // const actualAuthorId = typeof authorId === 'string' ? authorId : authorId?._id || userId || '';
-  const actualAuthorId = routeUserId || user_id; // Prioritize routeUserId, fallback to current user_id
+  const actualAuthorId = routeUserHandle ? '' : (routeUserId || user_id); // Prioritize routeUserId, fallback to current user_id
   const {
     data: user,
     refetch,


### PR DESCRIPTION
## Description

Fixed an issue where clicking on a user mention (@username) opened the logged-in user's profile instead of the mentioned user's profile.

### Changes Made

* Updated the profile lookup logic in UserProfileScreen.
* Prioritized handle-based profile lookup when routeUserHandle is available.
* Preserved existing ID-based profile lookup behavior.

### Issue

Fixes #1288

### Type of Change

* Bug Fix

### Checklist

* [x] Code follows project guidelines
* [x] Tested changes locally
* [x] No unrelated files modified
