### PR TITLE
fix: restore missing opening angle bracket in useSendOtp type signature

### DIFF
--- a/frontend/src/hooks/useSendOtp.ts
+++ b/frontend/src/hooks/useSendOtp.ts
@@ -2,7 +2,7 @@ import { useMutation, UseMutationResult } from "@tanstack/react-query";
 import axios, { AxiosError } from "axios";
 import { SEND_OTP } from "../helper/APIUtils";
 
-export const useSendOtpMutation = ():UseMutationResult
+export const useSendOtpMutation = ():UseMutationResult<
   void,
   AxiosError,
   {email: string}


### PR DESCRIPTION
#### PR Description
Added the missing opening angle bracket `<` in the generic `UseMutationResult` type signature in `useSendOtp.ts`.

#### Type of Change
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update

#### Select your work-area
- [x] Frontend
- [ ] Backend
- [ ] Documentation
- [ ] Others

#### Related Issue
https://github.com/sb2318/ultimatehealth/issues/1565

#### Add your Work Example
Verified type signature compiles correctly using the TypeScript compiler check.

#### Fixes (mention the issue number which this fixes)
Fixes #1565

#### Checklist
- [x] I have optimized the file changes.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I Agree