### PR TITLE
Improve Health Articles page responsiveness and space utilization

### DIFF
--- a/web/src/app/articles/page.tsx
+++ b/web/src/app/articles/page.tsx
@@ -16,7 +16,7 @@ export default function ArticlesPage() {
     <main className="min-h-screen bg-white">
       {/* ── Header ── */}
       <header className="border-b border-gray-100">
-        <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex items-center justify-between">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex items-center justify-between">
           <Link
             href={withBasePath("/")}
             className="font-extrabold text-lg"
@@ -50,12 +50,12 @@ export default function ArticlesPage() {
       </section>
 
       {/* ── Articles grid ── */}
-      <section className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-14">
+      <section className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-14">
         <p className="text-sm text-slate-500 mb-8">
           {articles.length} articles
         </p>
 
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
           {articles.map((article) => (
             <ArticleCard key={article.id} article={article} />
           ))}


### PR DESCRIPTION
#### PR Description
Improved the Health Articles page layout and responsiveness on large screens by optimizing container width and grid breakpoints.

### Changes Made
- Changed container width from `max-w-6xl` to `max-w-7xl`
- Added `xl:grid-cols-4` for better large-screen utilization
- Maintained responsiveness on mobile and tablet devices

#### Type of Change
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update

#### Select your work-area
- [x] Frontend
- [ ] Backend
- [ ] Documentation
- [ ] Others

#### Related Issue
Fixes #1567

Note

This repository uses the web branch for web application contributions as specified in the contribution guidelines. Therefore, this PR is opened against the web branch instead of develop.

#### Add your Work Example
📷 Before and After screenshots attached.
<img width="1910" height="897" alt="Screenshot 2026-06-14 232305" src="https://github.com/user-attachments/assets/d1bac5ba-fa3a-4164-8d7a-07bded2f0e74" />
<img width="1911" height="1035" alt="Screenshot 2026-06-15 001457" src="https://github.com/user-attachments/assets/d66b8dd2-75af-43db-8c67-b5b8ddc563de" />


#### Fixes (mention the issue number which this fixes)
closes #1567 

#### Checklist
- [ ] I have updated my branch and synced it with the project's 'develop' branch before making this PR.
- [x] I have optimized the file changes.
- [x] I have added a snapshot of my work example.
- [ ] I have made a PR to the project's develop branch.

#### Undertaking
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have checked for plagiarism and assure its authenticity.
- [x] I have read and followed the code of conduct for this repository. I understand that violation of this undertaking may have legal consequences.

- [x] I Agree
