### PR TITLE
fix: pass article param in ArticleCommentLike notification navigation

### DIFF
--- a/frontend/src/screens/NotificationScreen.tsx
+++ b/frontend/src/screens/NotificationScreen.tsx
@@ -331,6 +331,7 @@ const NotificationScreen = ({navigation}: any) => {
         navigation.navigate('CommentScreen', {
           articleId: item.articleId._id,
           mentionedUsers: item.articleId.mentionedUsers,
+          article: item.articleId,
         });
       }
     } else if (item.type === NotificationType.ArticleReview) {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -4305,7 +4305,7 @@ asynckit@^0.4.0:
   resolved "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
-"audio-module@file:C:\\Users\\Swara Mishra\\UltimateHealth\\frontend\\modules\\audio-module":
+"audio-module@workspace:*":
   version "1.0.0"
   resolved "file:modules/audio-module"
 


### PR DESCRIPTION
Closes #1531

## Summary
When tapping an `ArticleCommentLike` notification, the `CommentScreen` was missing the `article` parameter, causing a crash. This fix adds `article: item.articleId` to the navigation params.

## Changes
- `frontend/src/screens/NotificationScreen.tsx`: Added `article: item.articleId` to `ArticleCommentLike` navigation call