### PR TITLE
fix: use functional state update to eliminate stale closure race in language preference toggling

### DIFF
--- a/frontend/src/contexts/PreferencesContext.tsx
+++ b/frontend/src/contexts/PreferencesContext.tsx
@@ -16,7 +16,7 @@ import { LanguageCode, isValidLanguageCode } from '../constants/languages';
 
 interface PreferencesContextType {
   preferredLanguages: LanguageCode[];
-  setPreferredLanguages: (languages: LanguageCode[]) => Promise<void>;
+  setPreferredLanguages: (languages: LanguageCode[] | ((prev: LanguageCode[]) => LanguageCode[])) => Promise<void>;
   addLanguagePreference: (language: LanguageCode) => Promise<void>;
   removeLanguagePreference: (language: LanguageCode) => Promise<void>;
   isLoading: boolean;
@@ -101,17 +101,18 @@ export const PreferencesProvider: React.FC<PreferencesProviderProps> = ({
   );
 
   const setPreferredLanguages = useCallback(
-    async (languages: LanguageCode[]): Promise<void> => {
-      const validLanguages = languages.filter(lang =>
-        isValidLanguageCode(lang)
-      );
-      setInternalPreferredLanguages(validLanguages);
+    async (updater: LanguageCode[] | ((prev: LanguageCode[]) => LanguageCode[])): Promise<void> => {
+      let validLanguages: LanguageCode[] = [];
+      setInternalPreferredLanguages(prev => {
+        const next = typeof updater === 'function' ? updater(prev) : updater;
+        validLanguages = next.filter(lang => isValidLanguageCode(lang));
+        return validLanguages;
+      });
       await savePreferencesToStorage(validLanguages);
     },
     [savePreferencesToStorage]
   );
 
-  // ✅ FIXED: Refactored to avoid race conditions
   const addLanguagePreference = useCallback(
     async (language: LanguageCode): Promise<void> => {
       if (!isValidLanguageCode(language)) {
@@ -120,25 +121,20 @@ export const PreferencesProvider: React.FC<PreferencesProviderProps> = ({
         );
         return;
       }
-      // Use setPreferredLanguages to avoid race conditions
-      if (!preferredLanguages.includes(language)) {
-        await setPreferredLanguages([...preferredLanguages, language]);
-      }
+      await setPreferredLanguages(prev =>
+        prev.includes(language) ? prev : [...prev, language]
+      );
     },
-    [preferredLanguages, setPreferredLanguages]
+    [setPreferredLanguages]
   );
 
-  // ✅ FIXED: Refactored to avoid race conditions
   const removeLanguagePreference = useCallback(
     async (language: LanguageCode): Promise<void> => {
-      // Use setPreferredLanguages to avoid race conditions
-      if (preferredLanguages.includes(language)) {
-        await setPreferredLanguages(
-          preferredLanguages.filter(lang => lang !== language)
-        );
-      }
+      await setPreferredLanguages(prev =>
+        prev.filter(lang => lang !== language)
+      );
     },
-    [preferredLanguages, setPreferredLanguages]
+    [setPreferredLanguages]
   );
 
   const value: PreferencesContextType = {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -4305,7 +4305,7 @@ asynckit@^0.4.0:
   resolved "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
-"audio-module@file:C:\\Users\\Swara Mishra\\UltimateHealth\\frontend\\modules\\audio-module":
+"audio-module@workspace:*":
   version "1.0.0"
   resolved "file:modules/audio-module"
 


### PR DESCRIPTION
Closes #1538

## Summary
The `addLanguagePreference` and `removeLanguagePreference` functions in `PreferencesContext.tsx` read `preferredLanguages` from a closure that can become stale when toggles happen faster than re-renders. This causes lost updates where the second toggle's computed array overwrites the first.

## Fix
- Changed `setPreferredLanguages` to accept an updater function (like React's `setState(prev => ...)`)
- `addLanguagePreference` and `removeLanguagePreference` now use functional updates, always operating on the latest state
- Removed `preferredLanguages` from dependency arrays of these functions, eliminating stale closure risk