### PR TITLE
fix: guard updateReadEvent with ref to prevent duplicate in-flight requests (#1537)

### DIFF
--- a/frontend/src/screens/article/ArticleScreen.tsx
+++ b/frontend/src/screens/article/ArticleScreen.tsx
@@ -595,9 +595,11 @@ const ArticleScreen = ({navigation, route}: ArticleScreenProp) => {
       if (
         article &&
         !readEventSave &&
+        !readEventFiredRef.current &&
         !isGuest &&
         article.status === StatusEnum.PUBLISHED
       ) {
+        readEventFiredRef.current = true;
         updateReadEvent(undefined, {
           onSuccess: () => {
             setReadEventSave(true);
@@ -607,6 +609,7 @@ const ArticleScreen = ({navigation, route}: ArticleScreenProp) => {
             });
           },
           onError: err => {
+            readEventFiredRef.current = false;
             console.log('Update Read Status mutation error', err);
             Snackbar.show({
               text: 'Failed to update your read status.',


### PR DESCRIPTION
Fixes #1537

Problem:
handleReadStatusUpdate guards with !readEventSave (React state), but readEventSave only flips to true in the mutations onSuccess callback. Since onScroll fires many times per second while the user is at the bottom, multiple POST requests for the same article are dispatched before the first response returns.

Fix:
Wire up the existing (previously unused) readEventFiredRef as a synchronous in-flight guard:
- Check !readEventFiredRef.current alongside !readEventSave and !isGuest
- Set readEventFiredRef.current = true immediately before updateReadEvent()
- Reset to false in onError callback to allow retry on failure
- Already reset to false on articleId change (line 182)