### PR TITLE
fix: #1570: medical glossary page incorrectly rendering

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -559,10 +559,10 @@ const moveSlider = (ref: RefObject<HTMLDivElement | null>, dir: number) => {
               </Link>
             </li>
             <li>
-              <Link href={withBasePath("/medical-glossary")} className="nav-link-item">
+              <a href={withBasePath("/medical-glossary")} className="nav-link-item">
                 <i className="fas fa-book-medical nav-item-icon" aria-hidden="true"></i>
                 <span className="nav-item-text">Medical Glossary</span>
-              </Link>
+              </a>
             </li>
             <li>
               <Link href="/contribute" className="nav-link-item">


### PR DESCRIPTION
#### PR Description
This PR fixes the rendering issue reported in #1570 where Medical Glossary page appeared broken when accessed through navbar navigation but rendered correctly after a manual page refresh.

Changes Made
Replaced client-side navigation with standard anchor navigation for the affected links.

Ensured a full page reload when navigating to:
NAVBAR > Medical Glossary

Eliminated the inconsistent rendering behavior observed on first navigation.
Testing Performed
Verified Homepage → Medical Glossary navigation.
Confirmed page renders correctly on first navigation.
Confirmed page continues to render correctly after refresh.
Tested that existing navigation functionality remains intact.

#### Type of Change
- [ ✔] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update

#### Select your work-area
- [✔ ] Frontend
- [ ] Backend
- [ ] Documentation
- [ ] Others

#### Related Issue
https://github.com/SB2318/UltimateHealth/issues/1570
#### Add your Work Example
<img width="1512" height="693" alt="image" src="https://github.com/user-attachments/assets/33d3f947-0704-4411-a6f8-028e435ef1a8" />
<img width="1517" height="693" alt="image" src="https://github.com/user-attachments/assets/8a0ce513-ec17-45ab-8582-abf25396cacf" />


#### Fixes (mention the issue number which this fixes)
#1570 

#### Checklist
- [✔ ] I have updated my branch and synced it with the project's 'develop' branch before making this PR.
- [✔ ] I have optimized the file changes.
- [✔ ] I have added a snapshot of my work example.
- [✔ ] I have made a PR to the project's develop branch.

#### Undertaking
- [✔ ] My code follows the style guidelines of this project.
- [✔ ] I have performed a self-review of my code.
- [ ✔] I have commented my code, particularly in hard-to-understand areas.
- [ ✔] I have made corresponding changes to the documentation.
- [ ✔] I have checked for plagiarism and assure its authenticity.
- [ ✔] I have read and followed the code of conduct for this repository. I understand that violation of this undertaking may have legal consequences.

- [✔ ] I Agree
