### PR TITLE
fix(web): resolve login/register button not responding on downloads page

### DIFF
--- a/web/src/app/contribute/page.tsx
+++ b/web/src/app/contribute/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useRef } from "react";
 import Image from "next/image";
+import { withBasePath } from "@/lib/basePath";
 import { motion, useInView, AnimatePresence, type Variants } from "framer-motion";
 import {
   Code2,
@@ -1526,7 +1527,7 @@ const navLinks = [
   { href: "/#screenshots", label: "Screenshots", icon: "fa-image" },
   { href: "/#programs", label: "Community Programs", icon: "fa-code-branch" },
   { href: "https://uhsocial.in/docs", label: "Read Articles", icon: "fa-file-lines", external: true },
-  { href: "/#downloads", label: "Login / Register", icon: "fa-user" },
+  { href: "/login", label: "Login / Register", icon: "fa-user" },
 ];
 
   return (
@@ -1695,7 +1696,7 @@ const navLinks = [
             {navLinks.map((link) => (
               <a
                 key={link.href}
-                href={link.href}
+                href={withBasePath(link.href)}
                 target={"external" in link && link.external ? "_blank" : undefined}
                 rel={"external" in link && link.external ? "noreferrer" : undefined}
                 onClick={() => setNavOpen(false)}

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -508,7 +508,7 @@ const moveSlider = (ref: RefObject<HTMLDivElement | null>, dir: number) => {
     <>
 
       {/* ── Header ── */}
-      <header className={`header${scrolled ? " scrolled" : ""}bg-white dark:bg-slate-900 transition-colors duration-300 h-[80px]`} id="header">
+      <header className={`header ${scrolled ? "scrolled " : ""}bg-white dark:bg-slate-900 transition-colors duration-300 h-[80px]`} id="header">
         <PageWrapper as="div" className="nav">
           <Link href={withBasePath("/")} className="logo">
             <div className="logo-icon">
@@ -572,10 +572,10 @@ const moveSlider = (ref: RefObject<HTMLDivElement | null>, dir: number) => {
             </li>
             <ModeToggle/>
             <li>
-              <a href="#downloads" className="nav-btn-sm">
+              <Link href={withBasePath("/login")} className="nav-btn-sm">
                 <i className="fas fa-user" aria-hidden="true"></i>
                 <span>Login / Register</span>
-              </a>
+              </Link>
             </li>
           </ul>
 
@@ -591,7 +591,7 @@ const moveSlider = (ref: RefObject<HTMLDivElement | null>, dir: number) => {
           <a href="https://uhsocial.in/docs" target="_blank" rel="noreferrer">Read Articles</a>
           <Link href="/medical-glossary" onClick={() => setMobileMenuOpen(false)}>Medical Glossary</Link>
           <Link href="/contribute" onClick={() => setMobileMenuOpen(false)}>Join Us to Contribute</Link>
-          <a href="#downloads" onClick={() => setMobileMenuOpen(false)}>Login / Register</a>
+          <Link href={withBasePath("/login")} onClick={() => setMobileMenuOpen(false)}>Login / Register</Link>
         </nav>
       </header>
 


### PR DESCRIPTION
Closes #1594

### Description
Changed the "Login / Register" link in the header and mobile navigation to route to `/login` with `withBasePath` instead of referencing the `#downloads` anchor. 

### Files Changed
- `web/src/app/page.tsx`
- `web/src/app/contribute/page.tsx`