### PR TITLE
fix: remove duplicate imports in NotificationScreen.tsx

### DIFF
--- a/frontend/src/screens/NotificationScreen.tsx
+++ b/frontend/src/screens/NotificationScreen.tsx
@@ -1,22 +1,17 @@
 import {AppState, FlatList, StyleSheet, Text, View, Image} from 'react-native';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
-import {ON_PRIMARY_COLOR, PRIMARY_COLOR} from '../helper/Theme';
-import NotificationItem from '../components/NotificationItem';
-import {useDispatch, useSelector} from 'react-redux';
-import {Notification, NotificationType} from '../type';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import Loader from '../components/Loader';
 import Snackbar from 'react-native-snackbar';
-import { useDispatch, useSelector } from 'react-redux';
-import { NoNotificationState } from '../components/EmptyStates';
+import {useDispatch, useSelector} from 'react-redux';
+import {ON_PRIMARY_COLOR, PRIMARY_COLOR} from '../helper/Theme';
+import { hp } from '../helper/Metric';
+import {NoNotificationState} from '../components/EmptyStates';
 import Loader from '../components/Loader';
 import NotificationItem from '../components/NotificationItem';
-import { hp } from '../helper/Metric';
-import { ON_PRIMARY_COLOR, PRIMARY_COLOR } from '../helper/Theme';
+import {Notification, NotificationType} from '../type';
 import { useDeleteNotification } from '../hooks/useDeleteNotification';
 import { useGetAllNotifications } from '../hooks/useGetAllNotifications';
 import { useMarkNotificationAsRead } from '../hooks/useMarkNoticationAsRead';
-import { Notification, NotificationType } from '../type';
 
 type PendingDelete = {
   item: Notification;


### PR DESCRIPTION
Consolidated the three overlapping import blocks (lines 1-19) into a single clean block by removing duplicated imports of react-redux, Loader, NotificationItem, Theme, and type declarations. This resolves the SyntaxError: Identifier has already been declared at build time.

#### PR Description
Consolidated the three overlapping import blocks (lines 1-19) into a single clean block by removing duplicated imports of react-redux, Loader, NotificationItem, Theme, and type declarations. This resolves the SyntaxError: Identifier has already been declared at build time.

#### Type of Change
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update

#### Select your work-area
- [x] Frontend
- [ ] Backend
- [ ] Documentation
- [ ] Others

#### Related Issue
https://github.com/SB2318/UltimateHealth/issues/1628

#### Add your Work Example
N/A — code cleanup, no visual change.

#### Fixes (mention the issue number which this fixes)
Closes #1628

#### Checklist
- [ ] I have updated my branch and synced it with the project's 'develop' branch before making this PR.
- [x] I have optimized the file changes.
- [ ] I have added a snapshot of my work example.
- [ ] I have made a PR to the project's develop branch.

#### Undertaking
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have checked for plagiarism and assure its authenticity.
- [x] I have read and followed the code of conduct for this repository. I understand that violation of this undertaking may have legal consequences.

- [x] I Agree