### PR TITLE
fix: remove duplicate react-native import in LoginScreen.tsx (#1630)

### DIFF
--- a/frontend/src/screens/auth/LoginScreen.tsx
+++ b/frontend/src/screens/auth/LoginScreen.tsx
@@ -7,7 +7,7 @@ import React, {useEffect, useState} from 'react';
 import { useForm, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
-import {Alert, Image, useColorScheme} from 'react-native';
+import {Alert, Image, useColorScheme, ActivityIndicator} from 'react-native';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import Snackbar from 'react-native-snackbar';
 import {useDispatch} from 'react-redux';
@@ -37,7 +37,6 @@ import {
 } from '../../store/UserSlice';
 
 import { AuthData, LoginScreenProp } from '../../type';
-import {Alert, Image, useColorScheme, ActivityIndicator} from 'react-native';
 
 const loginSchema = z.object({
   email: z.string().email('Please Enter a Valid Email'),


### PR DESCRIPTION
## Description
`LoginScreen.tsx` had a duplicate import on line 40 that re-declared `Alert`, `Image`, and `useColorScheme` from `react-native`, all already imported on line 10. This causes a `SyntaxError: Identifier has already been declared` at build time.

## Fix
- Added `ActivityIndicator` (the unique symbol from the duplicate import) to the existing import on line 10
- Removed the duplicate import statement on line 40

Closes #1630