### PR TITLE
feat: add reading history feature (Fixes #1523)

### DIFF
--- a/frontend/src/navigations/StackNavigation.tsx
+++ b/frontend/src/navigations/StackNavigation.tsx
@@ -14,6 +14,7 @@ import NotificationScreen from '../screens/NotificationScreen';
 import EditorScreen from '../screens/article/EditorScreen';
 import PreviewScreen from '../screens/article/PreviewScreen';
 import ArticleScreen from '../screens/article/ArticleScreen';
+import ReadingHistoryScreen from '../screens/ReadingHistoryScreen';
 import {
   TouchableOpacity,
   StyleSheet,
@@ -555,6 +556,32 @@ const StackNavigation = () => {
               onPress={() => {
                 navigation.goBack();
               }}>
+              <FontAwesome6 size={25} name="arrow-left" color={'white'} />
+            </TouchableOpacity>
+          ),
+        })}
+      />
+      <Stack.Screen
+        name="ReadingHistoryScreen"
+        component={ReadingHistoryScreen}
+        options={({navigation}) => ({
+          headerShown: true,
+          headerTitle: 'Reading History',
+          headerTitleAlign: 'center',
+          headerBackTitleVisible: false,
+          headerTintColor: 'white',
+          headerStyle: {
+            elevation: 4,
+            backgroundColor: '#000A60',
+            shadowColor: '#000',
+            shadowOffset: {width: 0, height: 2},
+            shadowOpacity: 0.25,
+            shadowRadius: 3.5,
+          },
+          headerLeft: () => (
+            <TouchableOpacity
+              style={styles.headerLeftButtonCommentScreen}
+              onPress={() => navigation.goBack()}>
               <FontAwesome6 size={25} name="arrow-left" color={'white'} />
             </TouchableOpacity>
           ),

--- a/frontend/src/screens/ProfileScreen.tsx
+++ b/frontend/src/screens/ProfileScreen.tsx
@@ -7,7 +7,7 @@ import ArticleCard from '../components/ArticleCard';
 import {useDispatch, useSelector} from 'react-redux';
 import { useTheme } from 'tamagui';
 import {useBottomTabBarHeight} from '@react-navigation/bottom-tabs';
-import {SafeAreaView} from 'react-native-safe-area-context';
+import {SafeAreaView} from 'react-native';
 import ProfileHeader from '../components/ProfileHeader';
 import {ArticleData, ProfileScreenProps} from '../type';
 import Loader from '../components/Loader';
@@ -17,6 +17,7 @@ import {setUserHandle} from '../store/UserSlice';
 import {useGetProfile} from '../hooks/useGetProfile';
 import {useUpdateViewCount} from '../hooks/useUpdateViewCount';
 import { NoArticleState } from '../components/EmptyStates';
+import Ionicon from '@expo/vector-icons/Ionicons';
 
 const ProfileScreen = ({navigation}: ProfileScreenProps) => {
   const theme = useTheme();
@@ -247,6 +248,14 @@ const ProfileScreen = ({navigation}: ProfileScreenProps) => {
       >
         {renderHeader()}
 
+        <TouchableOpacity
+      style={styles.historyRow}
+      onPress={() => navigation.navigate('ReadingHistoryScreen')}>
+      <Ionicon name="time-outline" size={22} color={PRIMARY_COLOR} />
+        <Text style={styles.historyRowText}>Reading History</Text>
+        <Ionicon name="chevron-forward" size={20} color="#9ca3af" />
+      </TouchableOpacity>
+
         {/* Custom Tab Bar */}
         <View style={[styles.tabBarContainer, { backgroundColor: tabColors.background, borderBottomColor: tabColors.border }]}>
           <TouchableOpacity 
@@ -385,5 +394,21 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
+  },
+  historyRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    backgroundColor: '#ffffff',
+    borderBottomWidth: 1,
+    borderBottomColor: '#f3f4f6',
+  },
+  historyRowText: {
+    flex: 1,
+    fontSize: 15,
+    fontWeight: '600',
+    color: '#1a1a1a',
   },
 });

--- a/frontend/src/screens/ProfileScreen.tsx
+++ b/frontend/src/screens/ProfileScreen.tsx
@@ -7,7 +7,7 @@ import ArticleCard from '../components/ArticleCard';
 import {useDispatch, useSelector} from 'react-redux';
 import { useTheme } from 'tamagui';
 import {useBottomTabBarHeight} from '@react-navigation/bottom-tabs';
-import {SafeAreaView} from 'react-native';
+import {SafeAreaView} from 'react-native-safe-area-context';
 import ProfileHeader from '../components/ProfileHeader';
 import {ArticleData, ProfileScreenProps} from '../type';
 import Loader from '../components/Loader';

--- a/frontend/src/screens/ReadingHistoryScreen.tsx
+++ b/frontend/src/screens/ReadingHistoryScreen.tsx
@@ -1,0 +1,253 @@
+import React, {useCallback, useState} from 'react';
+import {
+  FlatList,
+  StyleSheet,
+  Text,
+  View,
+  Image,
+  TouchableOpacity,
+  Alert,
+} from 'react-native';
+import {SafeAreaView} from 'react-native';
+import {useFocusEffect} from '@react-navigation/native';
+import {StackScreenProps} from '@react-navigation/stack';
+import Ionicon from '@expo/vector-icons/Ionicons';
+import {RootStackParamList} from '../type';
+import {PRIMARY_COLOR, ON_PRIMARY_COLOR} from '../helper/Theme';
+import {
+  ReadingHistoryItem,
+  getReadingHistory,
+  clearReadingHistory,
+} from '../services/ReadingHistoryService';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type Props = StackScreenProps<RootStackParamList, 'ReadingHistoryScreen'>;
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function timeAgo(timestamp: number): string {
+  const diffMs = Date.now() - timestamp;
+  const diffSec = Math.floor(diffMs / 1000);
+  if (diffSec < 60) return 'Just now';
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) return `${diffHr}h ago`;
+  const diffDay = Math.floor(diffHr / 24);
+  if (diffDay < 7) return `${diffDay}d ago`;
+  return new Date(timestamp).toLocaleDateString();
+}
+
+// ─── Empty State ──────────────────────────────────────────────────────────────
+
+const EmptyHistory = () => (
+  <View style={styles.emptyContainer}>
+    <Ionicon name="time-outline" size={64} color="#c0c0c0" />
+    <Text style={styles.emptyTitle}>No reading history yet</Text>
+    <Text style={styles.emptySubtitle}>
+      Articles you open will appear here.
+    </Text>
+  </View>
+);
+
+// ─── Row Item ─────────────────────────────────────────────────────────────────
+
+type RowProps = {
+  item: ReadingHistoryItem;
+  onPress: (item: ReadingHistoryItem) => void;
+};
+
+const HistoryRow = React.memo(({item, onPress}: RowProps) => (
+  <TouchableOpacity
+    style={styles.row}
+    onPress={() => onPress(item)}
+    activeOpacity={0.7}>
+    {item.coverImage ? (
+      <Image source={{uri: item.coverImage}} style={styles.thumbnail} />
+    ) : (
+      <View style={[styles.thumbnail, styles.thumbnailPlaceholder]}>
+        <Ionicon name="document-text-outline" size={28} color="#aaa" />
+      </View>
+    )}
+    <View style={styles.rowContent}>
+      <Text style={styles.rowTitle} numberOfLines={2}>
+        {item.title}
+      </Text>
+      <Text style={styles.rowMeta} numberOfLines={1}>
+        {item.authorName}
+        {item.category ? ` · ${item.category}` : ''}
+      </Text>
+      <Text style={styles.rowTime}>{timeAgo(item.viewedAt)}</Text>
+    </View>
+    <Ionicon name="chevron-forward" size={20} color="#c0c0c0" />
+  </TouchableOpacity>
+));
+HistoryRow.displayName = 'HistoryRow';
+// ─── Screen ───────────────────────────────────────────────────────────────────
+
+const ReadingHistoryScreen = ({navigation}: Props) => {
+  const [history, setHistory] = useState<ReadingHistoryItem[]>([]);
+
+  // Reload each time screen is focused so it reflects newly viewed articles
+  useFocusEffect(
+    useCallback(() => {
+      setHistory(getReadingHistory());
+    }, []),
+  );
+
+  const handleClear = () => {
+    Alert.alert(
+      'Clear History',
+      'This will permanently remove all reading history. Continue?',
+      [
+        {text: 'Cancel', style: 'cancel'},
+        {
+          text: 'Clear',
+          style: 'destructive',
+          onPress: () => {
+            clearReadingHistory();
+            setHistory([]);
+          },
+        },
+      ],
+    );
+  };
+
+  const handleRowPress = (item: ReadingHistoryItem) => {
+    // ArticleScreen expects articleId as number
+    navigation.navigate('ArticleScreen', {
+      articleId: Number(item.articleId),
+    });
+  };
+
+  const renderItem = useCallback(
+    ({item}: {item: ReadingHistoryItem}) => (
+      <HistoryRow item={item} onPress={handleRowPress} />
+    ),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
+
+  const keyExtractor = useCallback(
+    (item: ReadingHistoryItem) => item.articleId,
+    [],
+  );
+
+  return (
+    <SafeAreaView style={styles.container}>
+      {history.length > 0 && (
+        <TouchableOpacity style={styles.clearButton} onPress={handleClear}>
+          <Ionicon name="trash-outline" size={18} color="#EF4444" />
+          <Text style={styles.clearText}>Clear History</Text>
+        </TouchableOpacity>
+      )}
+      <FlatList
+        data={history}
+        renderItem={renderItem}
+        keyExtractor={keyExtractor}
+        contentContainerStyle={[
+          styles.listContent,
+          history.length === 0 && styles.listContentEmpty,
+        ]}
+        ListEmptyComponent={<EmptyHistory />}
+        showsVerticalScrollIndicator={false}
+      />
+    </SafeAreaView>
+  );
+};
+
+export default ReadingHistoryScreen;
+
+// ─── Styles ───────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: ON_PRIMARY_COLOR,
+  },
+  clearButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    alignSelf: 'flex-end',
+    gap: 6,
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+  },
+  clearText: {
+    color: '#EF4444',
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  listContent: {
+    paddingHorizontal: 16,
+    paddingBottom: 120,
+  },
+  listContentEmpty: {
+    flexGrow: 1,
+    justifyContent: 'center',
+  },
+  // Row
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#fff',
+    borderRadius: 12,
+    padding: 12,
+    marginBottom: 10,
+    shadowColor: '#000',
+    shadowOffset: {width: 0, height: 1},
+    shadowOpacity: 0.06,
+    shadowRadius: 4,
+    elevation: 2,
+    gap: 12,
+  },
+  thumbnail: {
+    width: 64,
+    height: 64,
+    borderRadius: 8,
+    resizeMode: 'cover',
+  },
+  thumbnailPlaceholder: {
+    backgroundColor: '#f3f4f6',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  rowContent: {
+    flex: 1,
+    gap: 3,
+  },
+  rowTitle: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: '#1a1a1a',
+    lineHeight: 20,
+  },
+  rowMeta: {
+    fontSize: 13,
+    color: '#6b7280',
+  },
+  rowTime: {
+    fontSize: 12,
+    color: '#9ca3af',
+    marginTop: 2,
+  },
+  // Empty
+  emptyContainer: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 10,
+    paddingVertical: 40,
+  },
+  emptyTitle: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: '#374151',
+  },
+  emptySubtitle: {
+    fontSize: 14,
+    color: '#9ca3af',
+    textAlign: 'center',
+    paddingHorizontal: 32,
+  },
+});

--- a/frontend/src/screens/ReadingHistoryScreen.tsx
+++ b/frontend/src/screens/ReadingHistoryScreen.tsx
@@ -8,7 +8,7 @@ import {
   TouchableOpacity,
   Alert,
 } from 'react-native';
-import {SafeAreaView} from 'react-native';
+import {SafeAreaView} from 'react-native-safe-area-context';
 import {useFocusEffect} from '@react-navigation/native';
 import {StackScreenProps} from '@react-navigation/stack';
 import Ionicon from '@expo/vector-icons/Ionicons';

--- a/frontend/src/screens/article/ArticleScreen.tsx
+++ b/frontend/src/screens/article/ArticleScreen.tsx
@@ -24,6 +24,7 @@ import Snackbar from 'react-native-snackbar';
 import ResearchSummaryCard from '../../components/ResearchSummaryCard';
 import StructuredPodcastCard from '../../components/StructuredPodcastCard';
 import { generateArticleSummary, ArticleSummary } from '../../services/SummaryService';
+import {recordArticleView} from '../../services/ReadingHistoryService';
 
 import {
   formatCount,
@@ -159,6 +160,17 @@ const ArticleScreen = ({navigation, route}: ArticleScreenProp) => {
     setFontScale(nextValue);
     debouncedPersistFontScale(nextValue);
   };
+
+  useEffect(() => {
+    if (!article) return;
+    recordArticleView({
+      articleId: String(article._id),
+      title: article.title ?? '',
+      authorName: article.authorName ?? '',
+      category: article.tags?.[0]?.name ?? '',
+      coverImage: article.imageUtils?.[0] ?? '',
+    });
+  }, [article]);
 
   useEffect(() => {
     if (!isGuest) {

--- a/frontend/src/services/ReadingHistoryService.ts
+++ b/frontend/src/services/ReadingHistoryService.ts
@@ -1,0 +1,112 @@
+import {createMMKV} from 'react-native-mmkv';
+import type {MMKV} from 'react-native-mmkv';
+
+let _storage: MMKV | null = null;
+let _initialized = false;
+
+function getStorage(): MMKV | null {
+  if (_initialized) return _storage;
+  _initialized = true;
+  try {
+    _storage = createMMKV({id: 'reading-history-storage'});
+  } catch {
+    _storage = null;
+  }
+  return _storage;
+}
+
+const HISTORY_KEY = 'reading_history';
+const MAX_HISTORY = 50;
+const DEBOUNCE_MS = 60_000; // 60 seconds
+
+export type ReadingHistoryItem = {
+  articleId: string;
+  title: string;
+  authorName: string;
+  category: string; // first tag name, or '' if none
+  coverImage: string;
+  viewedAt: number; // Date.now()
+};
+
+/**
+ * Load the history array from MMKV.
+ * Returns [] on missing key, MMKV unavailable, or corrupted JSON.
+ */
+export function getReadingHistory(): ReadingHistoryItem[] {
+  try {
+    const storage = getStorage();
+    if (!storage) return [];
+    const raw = storage.getString(HISTORY_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed as ReadingHistoryItem[];
+  } catch {
+    // Corrupted data — wipe and start fresh
+    try { getStorage()?.remove(HISTORY_KEY); } catch {}
+    return [];
+  }
+}
+
+/**
+ * Persist history array to MMKV.
+ */
+function saveHistory(history: ReadingHistoryItem[]): void {
+  try {
+    const storage = getStorage();
+    if (!storage) return;
+    storage.set(HISTORY_KEY, JSON.stringify(history));
+  } catch {
+    // Storage write failure — silent; don't crash the article view
+  }
+}
+
+/**
+ * Record an article view.
+ *
+ * Rules:
+ *  - If same article viewed within last 60 s → skip (debounce).
+ *  - If already in history → lift to index 0, refresh timestamp.
+ *  - New entry → prepend, trim to MAX_HISTORY.
+ */
+export function recordArticleView(
+  item: Omit<ReadingHistoryItem, 'viewedAt'>,
+): void {
+  try {
+    const now = Date.now();
+    const history = getReadingHistory();
+
+    const existingIndex = history.findIndex(
+      h => h.articleId === item.articleId,
+    );
+
+    if (existingIndex !== -1) {
+      const existing = history[existingIndex];
+      // Debounce: same article opened again within 60 s → skip
+      if (now - existing.viewedAt < DEBOUNCE_MS) return;
+      // Lift to top with fresh timestamp
+      history.splice(existingIndex, 1);
+      history.unshift({...item, viewedAt: now});
+    } else {
+      history.unshift({...item, viewedAt: now});
+    }
+
+    // Cap at 50
+    if (history.length > MAX_HISTORY) {
+      history.splice(MAX_HISTORY);
+    }
+
+    saveHistory(history);
+  } catch {
+    // Never crash an article screen due to history logic
+  }
+}
+
+/**
+ * Wipe all reading history.
+ */
+export function clearReadingHistory(): void {
+  try {
+    getStorage()?.remove(HISTORY_KEY)
+  } catch {}
+}

--- a/frontend/src/type.ts
+++ b/frontend/src/type.ts
@@ -133,6 +133,7 @@ export type RootStackParamList = {
   CommunityGuidelines: undefined;
   ContributorPage: undefined;
   OpenSourcePage: undefined;
+  ReadingHistoryScreen: undefined;
 };
 
 export type RedirectTo = {


### PR DESCRIPTION
Fixes #1523

## What this PR does
Adds a "Reading History" screen that automatically tracks and displays the last 50 articles a user has read, accessible from the Profile screen.

## Changes
- `src/services/ReadingHistoryService.ts` (new) — MMKV-backed storage service with recordArticleView, getReadingHistory, clearReadingHistory
- `src/screens/ReadingHistoryScreen.tsx` (new) — FlatList screen showing history entries with "Viewed X ago" timestamps and Clear History button
- `src/screens/article/ArticleScreen.tsx` — added useEffect to record article view when article data loads
- `src/screens/ProfileScreen.tsx` — added "Reading History" navigation row
- `src/navigations/StackNavigation.tsx` — registered ReadingHistoryScreen
- `src/type.ts` — added ReadingHistoryScreen to RootStackParamList

## Implementation highlights
- 60s debounce prevents duplicate saves if user reopens same article quickly
- Deduplication on re-read — lifts existing entry to top with fresh timestamp
- Capped at 50 entries, newest first
- All storage operations wrapped in try/catch — never crashes article screen
- Used createMMKV pattern consistent with existing MMKVUtils.ts in codebase
- Tracking placed in ArticleScreen (where users read) not ArticleDescriptionScreen (article creation form)

## Testing note
App could not be run locally due to a pre-existing Metro bundler error (resolveConfig version conflict between expo ~54 and @expo/metro-config) unrelated to this PR. Implementation verified through TypeScript checking against existing codebase patterns.