### PR TITLE
fix: remove duplicate react-native import in LoginScreen.tsx

### DIFF
--- a/frontend/src/screens/auth/LoginScreen.tsx
+++ b/frontend/src/screens/auth/LoginScreen.tsx
@@ -7,7 +7,7 @@ import React, {useEffect, useState} from 'react';
 import { useForm, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
-import {Alert, Image, useColorScheme} from 'react-native';
+import {ActivityIndicator, Alert, Image, useColorScheme} from 'react-native';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import Snackbar from 'react-native-snackbar';
 import {useDispatch} from 'react-redux';
@@ -37,7 +37,6 @@ import {
 } from '../../store/UserSlice';
 
 import { AuthData, LoginScreenProp } from '../../type';
-import {Alert, Image, useColorScheme, ActivityIndicator} from 'react-native';
 
 const loginSchema = z.object({
   email: z.string().email('Please Enter a Valid Email'),


### PR DESCRIPTION
## Description

Line 40 of `LoginScreen.tsx` had a duplicate `import {Alert, Image, useColorScheme, ActivityIndicator} from 'react-native'` that conflicts with the existing import on line 10. Merged `ActivityIndicator` into line 10's import and removed the duplicate.

**Fixes** #1630

## GSSoC
- Closes #1630