### PR TITLE
feat: improve no articles empty state

### DIFF
--- a/frontend/src/components/EmptyStates.tsx
+++ b/frontend/src/components/EmptyStates.tsx
@@ -184,9 +184,10 @@ export const OfflinePodcastState = () => (
 
 export const NoArticleState = ({ onRefresh }: { onRefresh?: () => void }) => (
   <BaseEmptyState
-    iconEmoji="📭"
-    title="No Articles Available"
-    description="There are no articles to display right now. Check back later for new health insights!"
+    iconEmoji="🔍"
+    title="No Articles Found"
+    description="We couldn't find any articles matching your current search or filter. Try adjusting your keywords, changing filters, or refreshing the article list."
+    infoText="Tip: Use broader health topics or reset filters to discover more articles."
     actionText={onRefresh ? "Refresh Articles" : undefined}
     onAction={onRefresh}
   />


### PR DESCRIPTION
#### PR Description

Fixes #1582 

This PR improves the empty state experience shown when no health articles are available or when search/filter results return no matching articles.

### Changes Made

* Updated the empty state title from **"No Articles Available"** to **"No Articles Found"**
* Added a more descriptive message explaining why no articles are being displayed
* Added a helpful tip encouraging users to broaden their search terms or reset filters
* Retained the existing **Refresh Articles** functionality

These changes improve the user experience by providing clearer guidance and actionable feedback when no articles are found.

#### Type of Change

* [ ] Bug fix (change which fixes an issue)
* [x] New feature (change which adds functionality)
* [ ] Documentation update

#### Select your work-area

* [x] Frontend
* [ ] Backend
* [ ] Documentation
* [ ] Others

#### Related Issue

Issue assigned regarding improving the empty state UI for health articles.

#### Add your Work Example

<img width="1280" height="154" alt="Screenshot 2026-06-17 012752" src="https://github.com/user-attachments/assets/060da02f-6472-4263-899f-80f5a6797fa6" />


Before:

* Title: "No Articles Available"
* Generic empty state message

After:

* Title: "No Articles Found"
* Helpful guidance for users
* Additional tip for finding relevant articles
* Existing refresh functionality preserved

#### Fixes (mention the issue number which this fixes)

#closes 1582

#### Checklist

* [x] I have updated my branch and synced it with the project's 'develop' branch before making this PR.
* [x] I have optimized the file changes.
* [ ] I have added a snapshot of my work example.
* [x] I have made a PR to the project's develop branch.

#### Undertaking

* [x] My code follows the style guidelines of this project.

* [x] I have performed a self-review of my code.

* [ ] I have commented my code, particularly in hard-to-understand areas.

* [ ] I have made corresponding changes to the documentation.

* [x] I have checked for plagiarism and assure its authenticity.

* [x] I have read and followed the code of conduct for this repository. I understand that violation of this undertaking may have legal consequences.

* [x] I Agree
