### PR TITLE
fix: adjust viewport responsiveness down to 280px across multiple screens

### DIFF
--- a/frontend/src/components/CustomAlert.tsx
+++ b/frontend/src/components/CustomAlert.tsx
@@ -26,7 +26,8 @@ export function CustomAlertDialog() {
           animation="bouncy"
           borderRadius={12}
           padded
-          width={300}
+          width="90%"
+          maxWidth={300}
           
         >
           <YStack space="$3">

--- a/frontend/src/components/HomeScreenHeader.tsx
+++ b/frontend/src/components/HomeScreenHeader.tsx
@@ -15,8 +15,8 @@ const HomeScreenHeader = ({
   searchText,
 }: HomeScreenHeaderProps) => {
   return (
-    <YStack backgroundColor="#000A60" width="100%" paddingHorizontal="$3" paddingVertical="$3" elevation={1}>
-      <XStack alignItems="center" justifyContent="space-between" gap="$3">
+    <YStack backgroundColor="#000A60" width="100%" paddingHorizontal="$3" $xs={{ paddingHorizontal: "$2" }} paddingVertical="$3" elevation={1}>
+      <XStack alignItems="center" justifyContent="space-between" gap="$3" $xs={{ gap: "$2" }}>
         
         {/* Left Side Menu Button - Restored! */}
         <Button chromeless onPress={handlePresentModalPress} padding="$0">
@@ -39,9 +39,10 @@ const HomeScreenHeader = ({
           <Input 
             unstyled
             flex={1}
-            placeholder="Search articles..."
+            placeholder="Search..."
             placeholderTextColor="#778599"
             fontSize="$4"
+            $xs={{ fontSize: "$3" }}
             value={searchText}
             onChangeText={onTextInputChange}
             accessibilityLabel="Search articles"
@@ -51,8 +52,8 @@ const HomeScreenHeader = ({
             <Button 
               chromeless 
               onPress={onFilterReset}
-              paddingHorizontal="$3"
-              paddingVertical="$2"
+              paddingHorizontal="$2"
+              paddingVertical="$1"
               marginRight="$1"
               accessibilityLabel="Clear all active filters"
             >
@@ -60,8 +61,9 @@ const HomeScreenHeader = ({
                 color="$color"
                 fontWeight="$fontWeight.semibold"
                 fontSize="$2"
+                $xs={{ fontSize: "$1" }}
               >
-                Clear All
+                Clear
               </Text>
             </Button>
           )}

--- a/frontend/src/screens/auth/LoginScreen.tsx
+++ b/frontend/src/screens/auth/LoginScreen.tsx
@@ -289,7 +289,8 @@ const LoginScreen = ({navigation, route}: LoginScreenProp) => {
               fontSize={16}
               fontWeight="500"
               color={isDarkMode ? '$color' : '$color10'}
-              maxWidth={300}
+              maxWidth="100%"
+              width="100%"
               lineHeight={22}>
               Enter your email and password to securely access your account
             </Text>
@@ -393,7 +394,9 @@ const LoginScreen = ({navigation, route}: LoginScreenProp) => {
               justifyContent="space-between"
               alignItems="center"
               marginTop="$2"
-              paddingHorizontal="$2">
+              paddingHorizontal="$2"
+              flexWrap="wrap"
+              gap="$2">
               <Text
                 color={isDarkMode ? '$gray400' : '$gray700'}
                 fontWeight="500"

--- a/frontend/src/screens/auth/OtpScreen.tsx
+++ b/frontend/src/screens/auth/OtpScreen.tsx
@@ -138,6 +138,7 @@ export default function OtpScreen({navigation, route}: OtpScreenProp) {
 
             <XStack
               gap="$3"
+              $xs={{ gap: "$2" }}
               justifyContent="center"
               marginTop="$7"
               marginBottom="$2">
@@ -171,6 +172,7 @@ export default function OtpScreen({navigation, route}: OtpScreenProp) {
                   br="$5"
                   width={60}
                   height={64}
+                  $xs={{ width: 48, height: 52 }}
                   bg={errorMessages ? '$red1' : digit ? '$blue1' : '$gray1'}
                   color="$color12"
                 />


### PR DESCRIPTION
### 📝 Description
This Pull Request addresses and resolves core viewport layout breakages, overlapping text elements, and rigid spacing bugs on ultra-small device screens (280px - 320px, e.g., Samsung Galaxy Fold). The alignment and sizing constraints have been updated safely using dynamic properties without breaking any existing layout standards.

### 🛠️ Changes Implemented
- **HomeScreenHeader:** Scaled down active layout padding and elements gap using Tamagui's responsive `$xs` utility token. Shortened the dynamic "Clear All" action button label to "Clear" to prevent text truncation inside the search box.
- **LoginScreen:** Implemented `flexWrap="wrap"` on the bottom helper authentication links (`Forgot Password`, `Request Verification`) layout wrapper to avoid horizontal layout collision.
- **OtpScreen (Bonus Fix):** Updated individual input bounds and horizontal grid gaps dynamically under small device viewports.
- **CustomAlert (Bonus Fix):** Replaced hardcoded dimensions with fluid percentages (`width="90%"`, `maxWidth={300}`) to avoid layout bleeding.

### 🔗 Linked Issues
Closes #1714
closes #1715