### PR TITLE
fix: resolve syntax errors in FirebaseContext.tsx (#1566)

### DIFF
--- a/frontend/hooks/FirebaseContext.tsx
+++ b/frontend/hooks/FirebaseContext.tsx
@@ -60,13 +60,11 @@ export const FirebaseProvider: React.FC<FirebaseProviderProps> = ({ children }) 
         );
 
         if (missingFields.length > 0) {
-          
-            logger.warn(
-              `Firebase configuration is incomplete. Missing fields: ${missingFields.join(
-                ', '
-              )}. Skipping Firebase initialization.`
-            );
-          }
+          logger.warn(
+            `Firebase configuration is incomplete. Missing fields: ${missingFields.join(
+              ', '
+            )}. Skipping Firebase initialization.`
+          );
           return;
         }
 
@@ -76,12 +74,12 @@ export const FirebaseProvider: React.FC<FirebaseProviderProps> = ({ children }) 
           firebase.app(); // if already initialized, use that one
         }
         const token = await messaging().getToken();
-        if 
+        if (token) {
           logger.log('Firebase Token:', token);
         }
         setFcmToken(token); // Store the token in state
       } catch (error) {
-        
+        if (logger) {
           logger.error('Error getting token:', error);
         }
       }


### PR DESCRIPTION

# PR Description

## Summary

Fixes #1566 — Resolves syntax errors in `frontend/hooks/FirebaseContext.tsx` that prevented TypeScript compilation and blocked Firebase initialization during startup.

## Changes Made

### 1. Restored missing if-block body (Lines 62–69)
The conditional block around Firebase configuration validation had mismatched braces, leaving `logger.warn()` and `return` outside the `if` statement.

**Before:**
```tsx
if (missingFields.length > 0) {

    logger.warn(`Firebase configuration is incomplete...`);
  }
  return;
}
```

**After:**
```tsx
if (missingFields.length > 0) {
  logger.warn(`Firebase configuration is incomplete...`);
  return;
}
```

### 2. Completed malformed if statement (Line 77)
The `if` statement was missing its condition and opening brace.

**Before:**
```tsx
if
  logger.log('Firebase Token:', token);
}
```

**After:**
```tsx
if (token) {
  logger.log('Firebase Token:', token);
}
```

### 3. Fixed catch block structure (Lines 81–85)
The `catch` block had a stray closing brace and was missing an `if (logger)` guard.

**Before:**
```tsx
} catch (error) {

    logger.error('Error getting token:', error);
  }
}
```

**After:**
```tsx
} catch (error) {
  if (logger) {
    logger.error('Error getting token:', error);
  }
}
```

## Impact
- ✅ All braces are now properly balanced
- ✅ All conditional statements are complete and valid
- ✅ TypeScript compiles successfully
- ✅ Firebase initialization flow is unblocked

## File Changed
- `frontend/hooks/FirebaseContext.tsx` — 7 insertions, 9 deletions

## Related Issue
Closes #1566
