### PR TITLE
fix: resolve web landing page layout overlaps on 280px viewport

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -2956,8 +2956,34 @@ i, svg {
 }
 
 @media (max-width: 480px) {
+  .container {
+    padding: 0 16px;
+  }
+
+  .logo {
+    font-size: 1.25rem;
+    gap: 8px;
+  }
+
+  .logo-icon img {
+    width: 36px;
+    height: 36px;
+    border-radius: 8px;
+  }
+
   .uh-hero-title {
     font-size: 1.75rem;
+  }
+
+  .uh-hero-buttons {
+    flex-direction: column;
+    width: 100%;
+    gap: 10px;
+  }
+
+  .uh-hero-buttons a {
+    width: 100%;
+    justify-content: center;
   }
 
   .uh-stat-card {


### PR DESCRIPTION
### 📝 Description
This Pull Request addresses and resolves the web frontend layout breakages and component overlapping issues on ultra-small device screens (280px - 320px, e.g., Samsung Galaxy Fold) targeting the `web` module.

### 🛠️ Changes Implemented
- **Global Container:** Optimized `.container` structural boundaries to recover horizontal space on mobile.
- **Header & Logo:** Scaled down header logo typography and icon dimensions gracefully.
- **Hero CTA Buttons:** Reconfigured `.uh-hero-buttons` flex layout to stack into a neat full-width column layout for ultra-small mobile displays.

### 🔗 Linked Issues
Closes #1714

---
*Submitted under GirlScript Summer of Code (GSSoC '26)*