### PR TITLE
fix(web): use consistent navbar across Medical Glossary & Articles pages

### DIFF
--- a/web/src/app/articles/page.tsx
+++ b/web/src/app/articles/page.tsx
@@ -4,6 +4,7 @@ import { format, parseISO } from "date-fns";
 import { withBasePath } from "@/lib/basePath";
 import { articles } from "@/lib/article-data";
 import type { Article } from "@/types/article";
+import Navbar from "@/components/layout/Navbar";
 
 export const metadata: Metadata = {
   title: "Health Articles | UltimateHealth",
@@ -13,25 +14,8 @@ export const metadata: Metadata = {
 
 export default function ArticlesPage() {
   return (
-    <main className="min-h-screen bg-white">
-      {/* ── Header ── */}
-      <header className="border-b border-gray-100">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex items-center justify-between">
-          <Link
-            href={withBasePath("/")}
-            className="font-extrabold text-lg"
-            style={{ background: "linear-gradient(135deg,#667eea,#764ba2)", WebkitBackgroundClip: "text", WebkitTextFillColor: "transparent" }}
-          >
-            UltimateHealth
-          </Link>
-          <Link
-            href={withBasePath("/medical-glossary")}
-            className="text-sm font-semibold text-slate-600 hover:text-[#667eea] transition-colors"
-          >
-            Medical Glossary
-          </Link>
-        </div>
-      </header>
+    <main className="min-h-screen bg-white pt-20">
+      <Navbar />
 
       {/* ── Hero ── */}
       <section className="bg-gradient-to-br from-[#667eea] to-[#764ba2] py-16 px-4">

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 import { Inter, DM_Sans } from "next/font/google";
 // DO NOT remove the globals2.css import, it contains important global styles for the application
 import "./globals2.css";
+import "./globals2.css";
+import "./globals.css";
 import "@fortawesome/fontawesome-free/css/all.min.css";
 import { cn } from "@/lib/utils";
 import { TooltipProvider } from "@/components/ui/tooltip";

--- a/web/src/app/medical-glossary/page.tsx
+++ b/web/src/app/medical-glossary/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-
+import Navbar from "@/components/layout/Navbar";
 import { withBasePath } from "@/lib/basePath";
 import { MedicalGlossaryExplorer } from "./MedicalGlossaryExplorer";
 
@@ -12,21 +12,8 @@ export const metadata: Metadata = {
 
 export default function MedicalGlossaryPage() {
   return (
-    <main className="min-h-screen bg-[linear-gradient(180deg,#f8fafc_0%,#ecfdf5_55%,#f8fafc_100%)] text-slate-950">
-      <header className="mx-auto flex w-full max-w-6xl items-center justify-between px-4 py-6 sm:px-6 lg:px-8">
-        <Link
-          href={withBasePath("/")}
-          className="text-sm font-semibold text-slate-600 transition hover:text-emerald-700"
-        >
-          UltimateHealth
-        </Link>
-        <Link
-          href={withBasePath("/contribute")}
-          className="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:border-emerald-200 hover:text-emerald-700"
-        >
-          Contribute
-        </Link>
-      </header>
+    <main className="min-h-screen bg-[linear-gradient(180deg,#f8fafc_0%,#ecfdf5_55%,#f8fafc_100%)] text-slate-950 pt-20">
+      <Navbar />
 
       <section className="mx-auto w-full max-w-6xl px-4 pb-8 pt-8 text-center sm:px-6 lg:px-8 lg:pt-14">
         <p className="text-sm font-semibold uppercase tracking-[0.28em] text-emerald-700">

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -2,7 +2,6 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import "./globals.css";
 
 import { type RefObject, useCallback, useEffect, useRef, useState, useSyncExternalStore } from "react";
 import HeroAndDownload from "../components/HeroAndDownload";

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -9,6 +9,7 @@ import HeroAndDownload from "../components/HeroAndDownload";
 import ScrollToTop from "../components/ScrollToTop";
 
 import { PageWrapper, Section } from "../components/layout";
+import Navbar from "../components/layout/Navbar";
 
 import { withBasePath } from "@/lib/basePath";
 import { Skeleton } from "../components/ui";
@@ -86,8 +87,7 @@ const subscribeToCursorGlow = (callback: () => void) => {
 const TRACKED_SECTION_IDS = ["screenshots", "features", "programs", "contact"];
 
 export default function Home() {
-  const [scrolled, setScrolled] = useState(false);
-  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+
   const [comingSoonModal, setComingSoonModal] = useState(false);
   const [appleModal, setAppleModal] = useState(false);
   const [testerEmail, setTesterEmail] = useState("");
@@ -222,13 +222,6 @@ export default function Home() {
       canvas.remove();
       dnaCanvasRef.current = null;
     };
-  }, []);
-
-  // ── Scroll header ──
-  useEffect(() => {
-    const handleScroll = () => setScrolled(window.scrollY > 50);
-    window.addEventListener("scroll", handleScroll);
-    return () => window.removeEventListener("scroll", handleScroll);
   }, []);
 
   // ── Scroll reveal ──
@@ -504,92 +497,7 @@ const moveSlider = (ref: RefObject<HTMLDivElement | null>, dir: number) => {
   return (
     <>
 
-      {/* ── Header ── */}
-      <header className={`header${scrolled ? " scrolled" : ""}`} id="header">
-        <PageWrapper as="div" className="nav">
-          <Link href={withBasePath("/")} className="logo">
-            <div className="logo-icon">
-              <Image
-                src="https://raw.githubusercontent.com/SB2318/UltimateHealth/refs/heads/main/frontend/src/assets/images/adaptive-icon.png"
-                alt="UltimateHealth Logo" width={48} height={48}
-                priority
-              />
-            </div>
-            Ultimate-Health
-          </Link>
-
-          <ul className="nav-links">
-            <li>
-              <a
-                href="#features"
-                className={`nav-link-item${activeSection === "features" ? " active" : ""}`}
-                aria-current={activeSection === "features" ? "location" : undefined}
-              >
-                <i className="fas fa-star nav-item-icon" aria-hidden="true"></i>
-                <span className="nav-item-text">Platform Highlights</span>
-              </a>
-            </li>
-            <li>
-              <a
-                href="#screenshots"
-                className={`nav-link-item${activeSection === "screenshots" ? " active" : ""}`}
-                aria-current={activeSection === "screenshots" ? "location" : undefined}
-              >
-                <i className="fas fa-image nav-item-icon" aria-hidden="true"></i>
-                <span className="nav-item-text">Screenshots</span>
-              </a>
-            </li>
-            <li>
-              <a
-                href="#programs"
-                className={`nav-link-item${activeSection === "programs" ? " active" : ""}`}
-                aria-current={activeSection === "programs" ? "location" : undefined}
-              >
-                <i className="fas fa-code-branch nav-item-icon" aria-hidden="true"></i>
-                <span className="nav-item-text">Community Programs</span>
-              </a>
-            </li>
-            <li>
-              <Link href={withBasePath("/articles")} className="nav-link-item">
-                <i className="fas fa-file-lines nav-item-icon" aria-hidden="true"></i>
-                <span className="nav-item-text">Read Articles</span>
-              </Link>
-            </li>
-            <li>
-              <Link href={withBasePath("/medical-glossary")} className="nav-link-item">
-                <i className="fas fa-book-medical nav-item-icon" aria-hidden="true"></i>
-                <span className="nav-item-text">Medical Glossary</span>
-              </Link>
-            </li>
-            <li>
-              <Link href={withBasePath("/contribute")} className="nav-link-item">
-                <i className="fas fa-users nav-item-icon" aria-hidden="true"></i>
-                <span className="nav-item-text">Join Us to Contribute</span>
-              </Link>
-            </li>
-            <li style={{ display: "flex", alignItems: "center" }}>
-              <a href="#downloads" className="nav-btn-sm">
-                <i className="fas fa-user" aria-hidden="true"></i>
-                <span>Login / Register</span>
-              </a>
-            </li>
-          </ul>
-
-          <button className="mobile-menu-toggle" onClick={() => setMobileMenuOpen((o) => !o)} aria-label={mobileMenuOpen ? "Close navigation menu" : "Open navigation menu"} aria-expanded={mobileMenuOpen}>
-            <i className={`fas fa-${mobileMenuOpen ? "times" : "bars"}`}></i>
-          </button>
-        </PageWrapper>
-
-        <nav className={`mobile-nav${mobileMenuOpen ? " open" : ""}`}>
-          <a href="#screenshots" onClick={() => setMobileMenuOpen(false)}>Screenshots</a>
-          <a href="#features" onClick={() => setMobileMenuOpen(false)}>Platform Highlights</a>
-          <a href="#programs" onClick={() => setMobileMenuOpen(false)}>Community Programs</a>
-          <Link href={withBasePath("/articles")} onClick={() => setMobileMenuOpen(false)}>Read Articles</Link>
-          <Link href={withBasePath("/medical-glossary")} onClick={() => setMobileMenuOpen(false)}>Medical Glossary</Link>
-          <Link href={withBasePath("/contribute")} onClick={() => setMobileMenuOpen(false)}>Join Us to Contribute</Link>
-          <a href="#downloads" onClick={() => setMobileMenuOpen(false)}>Login / Register</a>
-        </nav>
-      </header>
+      <Navbar activeSection={activeSection} />
 
       {/* ── Hero ── */}
       <HeroAndDownload

--- a/web/src/components/layout/Navbar.tsx
+++ b/web/src/components/layout/Navbar.tsx
@@ -2,7 +2,6 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import "../../app/globals.css";
 import { useEffect, useState } from "react";
 
 import { PageWrapper } from "./index";

--- a/web/src/components/layout/Navbar.tsx
+++ b/web/src/components/layout/Navbar.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import "../../app/globals.css";
+import { useEffect, useState } from "react";
+
+import { PageWrapper } from "./index";
+import { withBasePath } from "@/lib/basePath";
+
+interface NavbarProps {
+  /**
+   * Id of the in-page section currently in view, used only on the homepage
+   * to highlight the matching anchor link (e.g. "features", "screenshots",
+   * "programs"). Leave undefined on pages that don't have these sections —
+   * no link will be marked active, which is correct there.
+   */
+  activeSection?: string;
+}
+
+export default function Navbar({ activeSection }: NavbarProps) {
+  const [scrolled, setScrolled] = useState(false);
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => setScrolled(window.scrollY > 50);
+    window.addEventListener("scroll", handleScroll);
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
+
+  return (
+    <header className={`header${scrolled ? " scrolled" : ""}`} id="header">
+      <PageWrapper as="div" className="nav">
+        <Link href={withBasePath("/")} className="logo">
+          <div className="logo-icon">
+            <Image
+              src="https://raw.githubusercontent.com/SB2318/UltimateHealth/refs/heads/main/frontend/src/assets/images/adaptive-icon.png"
+              alt="UltimateHealth Logo"
+              width={48}
+              height={48}
+              priority
+            />
+          </div>
+          Ultimate-Health
+        </Link>
+
+        <ul className="nav-links">
+          <li>
+            <a
+              href={withBasePath("/#features")}
+              className={`nav-link-item${activeSection === "features" ? " active" : ""}`}
+              aria-current={activeSection === "features" ? "location" : undefined}
+            >
+              <i className="fas fa-star nav-item-icon" aria-hidden="true"></i>
+              <span className="nav-item-text">Platform Highlights</span>
+            </a>
+          </li>
+          <li>
+            <a
+              href={withBasePath("/#screenshots")}
+              className={`nav-link-item${activeSection === "screenshots" ? " active" : ""}`}
+              aria-current={activeSection === "screenshots" ? "location" : undefined}
+            >
+              <i className="fas fa-image nav-item-icon" aria-hidden="true"></i>
+              <span className="nav-item-text">Screenshots</span>
+            </a>
+          </li>
+          <li>
+            <a
+              href={withBasePath("/#programs")}
+              className={`nav-link-item${activeSection === "programs" ? " active" : ""}`}
+              aria-current={activeSection === "programs" ? "location" : undefined}
+            >
+              <i className="fas fa-code-branch nav-item-icon" aria-hidden="true"></i>
+              <span className="nav-item-text">Community Programs</span>
+            </a>
+          </li>
+          <li>
+            <Link href={withBasePath("/articles")} className="nav-link-item">
+              <i className="fas fa-file-lines nav-item-icon" aria-hidden="true"></i>
+              <span className="nav-item-text">Read Articles</span>
+            </Link>
+          </li>
+          <li>
+            <Link href={withBasePath("/medical-glossary")} className="nav-link-item">
+              <i className="fas fa-book-medical nav-item-icon" aria-hidden="true"></i>
+              <span className="nav-item-text">Medical Glossary</span>
+            </Link>
+          </li>
+          <li>
+            <Link href={withBasePath("/contribute")} className="nav-link-item">
+              <i className="fas fa-users nav-item-icon" aria-hidden="true"></i>
+              <span className="nav-item-text">Join Us to Contribute</span>
+            </Link>
+          </li>
+          <li style={{ display: "flex", alignItems: "center" }}>
+            <a href={withBasePath("/#downloads")} className="nav-btn-sm">
+              <i className="fas fa-user" aria-hidden="true"></i>
+              <span>Login / Register</span>
+            </a>
+          </li>
+        </ul>
+
+        <button
+          className="mobile-menu-toggle"
+          onClick={() => setMobileMenuOpen((o) => !o)}
+          aria-label={mobileMenuOpen ? "Close navigation menu" : "Open navigation menu"}
+          aria-expanded={mobileMenuOpen}
+        >
+          <i className={`fas fa-${mobileMenuOpen ? "times" : "bars"}`}></i>
+        </button>
+      </PageWrapper>
+
+      <nav className={`mobile-nav${mobileMenuOpen ? " open" : ""}`}>
+        <a href={withBasePath("/#screenshots")} onClick={() => setMobileMenuOpen(false)}>Screenshots</a>
+        <a href={withBasePath("/#features")} onClick={() => setMobileMenuOpen(false)}>Platform Highlights</a>
+        <a href={withBasePath("/#programs")} onClick={() => setMobileMenuOpen(false)}>Community Programs</a>
+        <Link href={withBasePath("/articles")} onClick={() => setMobileMenuOpen(false)}>Read Articles</Link>
+        <Link href={withBasePath("/medical-glossary")} onClick={() => setMobileMenuOpen(false)}>Medical Glossary</Link>
+        <Link href={withBasePath("/contribute")} onClick={() => setMobileMenuOpen(false)}>Join Us to Contribute</Link>
+        <a href={withBasePath("/#downloads")} onClick={() => setMobileMenuOpen(false)}>Login / Register</a>
+      </nav>
+    </header>
+  );
+}


### PR DESCRIPTION
#### PR Description
Fixes the inconsistent navbar issue described in #1752. The homepage uses a full-featured navbar (logo + branding, all nav links, scroll-spy active states, mobile menu, and a Login/Register button), but the Articles and Medical Glossary pages each rendered their own minimal, hardcoded `<header>` with just a text logo and a single link.

I extracted the homepage's navbar into a new shared `Navbar` component (`web/src/components/layout/Navbar.tsx`) and reused it on both pages, so navigation is now visually and functionally consistent across the site.

**Changes:**
- Created `web/src/components/layout/Navbar.tsx` , a self-contained client component with its own scroll-detection state (for the `scrolled` style) and mobile menu toggle, extracted from `page.tsx`.
- Added an optional `activeSection` prop so the homepage can still highlight the active in-page section (Platform Highlights / Screenshots / Community Programs); it's simply omitted on other pages, which correctly results in no link being marked active.
- Fixed in-page anchor links (`#features`, `#screenshots`, `#programs`, `#downloads`) to use `withBasePath("/#...")` instead of bare `#...`, so they correctly navigate back to the homepage and scroll to the right section when clicked from Articles or Medical Glossary, previously these would have done nothing on non-homepage pages.
- Updated `web/src/app/page.tsx` to use the new `Navbar` component instead of inline header markup, removing the now-duplicated `scrolled`/`mobileMenuOpen` state and scroll listener.
- Updated `web/src/app/articles/page.tsx` and `web/src/app/medical-glossary/page.tsx` to replace their minimal headers with `<Navbar />`, and added top padding to their `<main>` to account for the fixed-position header.

#### Type of Change
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update

#### Select your work-area
- [x] Frontend
- [ ] Backend
- [ ] Documentation
- [ ] Others

#### Related Issue
#1752

#### Add your Work Example

Before:
<img width="1918" height="962" alt="Screenshot 2026-06-20 125653" src="https://github.com/user-attachments/assets/5199ea63-0a52-437b-9b8a-e99624a06df2" />

<img width="1918" height="956" alt="Screenshot 2026-06-20 125620" src="https://github.com/user-attachments/assets/4eedb536-399d-4bd1-b9de-8d3ff1b527bc" />

---

After:
<img width="1897" height="910" alt="image" src="https://github.com/user-attachments/assets/33877349-ead5-4610-b027-eed462d436b3" />

<img width="1907" height="906" alt="image" src="https://github.com/user-attachments/assets/4e7778bb-d89a-4da9-afcc-f78d528b4fc2" />


#### Fixes (mention the issue number which this fixes)
Closes #1752

#### Checklist
- [x] I have updated my branch and synced it with the project's base branch (`web`) before making this PR.
- [x] I have optimized the file changes.
- [x] I have added a snapshot of my work example.
- [x] I have made a PR to the project's `web` branch.

#### Undertaking
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have checked for plagiarism and assure its authenticity.
- [x] I have read and followed the code of conduct for this repository. I understand that violation of this undertaking may have legal consequences.
- [x] I Agree