### PR TITLE
feat(web): add print/export-as-pdf button to article detail page

### DIFF
--- a/web/src/components/articles/ArticlePageClient.tsx
+++ b/web/src/components/articles/ArticlePageClient.tsx
@@ -40,7 +40,9 @@ export default function ArticlePageClient({
   return (
     <GlossaryProvider terms={defaultGlossaryTerms}>
       {/* Sticky reading progress indicator */}
+      <div className="print:hidden">
       <ReadingProgressBar />
+      </div>
 
       
 
@@ -53,7 +55,7 @@ export default function ArticlePageClient({
         }
       >
         {/* ── Sticky top navigation bar ── */}
-        <div className="sticky top-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100 shadow-sm flex items-center p-2 border border-gray-200 rounded-full m-3 ">
+        <div className="sticky top-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100 shadow-sm flex items-center p-2 border border-gray-200 rounded-full m-3 print:hidden">
            {/* Back link */}
           <div className="ml-4">
               <Link
@@ -103,7 +105,7 @@ export default function ArticlePageClient({
             </div>
 
             {/* ── Table of Contents Sidebar ── */}
-            <aside className="hidden lg:block lg:w-[250px]">
+            <aside className="hidden lg:block lg:w-[250px] print:hidden">
               <div className="sticky top-[var(--article-sticky-header-height)] max-h-[calc(100vh-var(--article-sticky-header-height))] overflow-y-auto pr-2">
                 <TableOfContents content={article.content} />
               </div>
@@ -112,17 +114,30 @@ export default function ArticlePageClient({
         </main>
 
         {/* ── Related articles ── */}
+        <div className="print:hidden">
         <RelatedArticles articles={relatedArticles} />
-
+        </div>
         {/* ── Platform footer ── */}
+        <div className="print:hidden">
         <ArticlePageFooter />
+        </div>
       </div>
-
+      {/* ── Floating print/export button ── */}
+      <button
+        onClick={() => window.print()}
+        className="fixed bottom-24 right-6 z-50 w-12 h-12 rounded-full bg-white shadow-lg border border-gray-300 flex items-center justify-center text-[#4c51bf] hover:bg-[#4c51bf] hover:text-white transition-colors print:hidden"
+        aria-label="Print or save article as PDF"
+        title="Print / Save as PDF"
+      >
+      <i className="fas fa-print text-lg" aria-hidden="true" />
+      </button>
       {/* ── Floating accessibility controls ── */}
+      <div className="print:hidden">
       <AccessibilityControls
         fontSize={fontSize}
         onFontSizeChange={setFontSize}
       />
+      </div>
     </GlossaryProvider>
   );
 }


### PR DESCRIPTION
#### PR Description
Adds a print/export-as-PDF option to the article detail page. A floating print button (top stack, above the accessibility control, bottom-right of the screen) triggers the browser's native print dialog via `window.print()`. A `print:hidden` Tailwind variant is applied to the sticky nav, reading progress bar, table of contents sidebar, related articles section, page footer, and accessibility controls, so the printed/exported output shows only the article title, author, metadata, and content — no navigation or UI clutter. No new dependencies or backend changes were required.

#### Type of Change
- [x] New feature (change which adds functionality)

#### Select your work-area
- [x] Frontend

#### Related Issue
<!-- paste the issue link here, e.g. https://github.com/SB2318/UltimateHealth/issues/XXX -->

#### Add your Work Example
📷 SCREENSHOTS:
Before
<img width="1366" height="768" alt="before-no-print-feature" src="https://github.com/user-attachments/assets/5e825793-a9a9-4fa8-9ba2-89a3c8e570b8" />
After
<img width="1366" height="768" alt="after-print-button-added" src="https://github.com/user-attachments/assets/c7c63bfb-8d9b-4207-9b3b-a40b9689720a" />
Print Preview
<img width="1366" height="768" alt="print-preview" src="https://github.com/user-attachments/assets/cf71365f-c7dc-40f4-a5cc-0e00184d5962" />

`Fixes #1747`
`Closes #1747`
#### Fixes #1747
closes #1747

#### Checklist
- [x] I have updated my branch and synced it with the project's 'develop' branch before making this PR.
- [x] I have optimized the file changes.
- [x] I have added a snapshot of my work example.
- [x] I have made a PR to the project's develop branch.

#### Undertaking
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have checked for plagiarism and assure its authenticity.
- [x] I have read and followed the code of conduct for this repository. I understand that violation of this undertaking may have legal consequences.
- [x] I Agree