### PR TITLE
fix(web): correct contact form API endpoint from /api/contact/send to…

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -476,8 +476,7 @@ export default function Home() {
   }
 
   // ── Contact form submit → uhsocial.in API ──
-  // Backend route needed: POST /api/contact/send on NEXT_PUBLIC_API_BASE_URL
-  // See /contact_newsletter_guide.md for the Express route implementation
+  // Contact form submits to POST /api/contact on NEXT_PUBLIC_API_BASE_URL
   const handleContactSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     const trimmedName = contactName.trim()
@@ -495,7 +494,7 @@ export default function Home() {
     }
     setContactStatus('sending')
     try {
-      const res = await fetch(`${API_BASE_URL}/api/contact/send`, {
+      const res = await fetch(`${API_BASE_URL}/api/contact`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({


### PR DESCRIPTION
#### PR Description
The contact form on the landing page was calling the wrong backend API endpoint (`/api/contact/send`), which does not exist on the server. This caused every form submission to fall through to the `mailto:` fallback instead of actually hitting the API. Fixed by updating the fetch URL to the correct endpoint `/api/contact` as confirmed by @SB2318 in the issue thread.

#### Type of Change
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update

#### Select your work-area
- [x] Frontend
- [ ] Backend
- [ ] Documentation
- [ ] Others

#### Related Issue
closes #1440 

#### Add your Work Example
Before: `fetch(`${API_BASE_URL}/api/contact/send`, ...)` → always fell back to mailto
After: `fetch(`${API_BASE_URL}/api/contact`, ...)` → correctly hits the backend endpoint

#### Fixes (mention the issue number which this fixes)
#1440 

#### Checklist
- [x] I have updated my branch and synced it with the project's 'develop' branch before making this PR.
- [x] I have optimized the file changes.
- [x] I have added a snapshot of my work example.
- [x] I have made a PR to the project's develop branch.

#### Undertaking
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have checked for plagiarism and assure its authenticity.
- [ ] I have read and followed the code of conduct for this repository. I understand that violation of this undertaking may have legal consequences.

- [x] I Agree
