### PR TITLE
feat: implement skeleton loading states for articles and podcasts

### DIFF
--- a/frontend/src/components/SkeletonArticleCard.tsx
+++ b/frontend/src/components/SkeletonArticleCard.tsx
@@ -1,0 +1,135 @@
+import React, { useEffect } from 'react';
+import { View, StyleSheet } from 'react-native';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withRepeat,
+  withTiming,
+  withSequence,
+  Easing,
+} from 'react-native-reanimated';
+
+const SkeletonArticleCard = () => {
+  const opacity = useSharedValue(0.3);
+
+  useEffect(() => {
+    opacity.value = withRepeat(
+      withSequence(
+        withTiming(0.7, { duration: 800, easing: Easing.inOut(Easing.ease) }),
+        withTiming(0.3, { duration: 800, easing: Easing.inOut(Easing.ease) })
+      ),
+      -1,
+      true
+    );
+  }, []);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    opacity: opacity.value,
+  }));
+
+  return (
+    <View style={styles.cardContainer}>
+      <Animated.View style={[styles.imageSkeleton, animatedStyle]} />
+
+      <View style={styles.contentContainer}>
+        <View style={styles.badgeRow}>
+          <Animated.View style={[styles.skeletonLine, styles.badgeSkeleton, animatedStyle]} />
+          <Animated.View style={[styles.skeletonLine, styles.badgeSkeleton, animatedStyle, { width: 50 }]} />
+        </View>
+
+        <Animated.View style={[styles.skeletonLine, styles.titleSkeleton, animatedStyle]} />
+        <Animated.View style={[styles.skeletonLine, styles.titleSkeleton, animatedStyle, { width: '60%' }]} />
+
+        <View style={styles.metaRow}>
+          <Animated.View style={[styles.skeletonLine, styles.metaSkeleton, animatedStyle]} />
+          <Animated.View style={[styles.skeletonLine, styles.metaSkeleton, animatedStyle, { width: 40 }]} />
+          <Animated.View style={[styles.skeletonLine, styles.metaSkeleton, animatedStyle, { width: 60 }]} />
+        </View>
+
+        <Animated.View style={[styles.skeletonLine, styles.readTimeSkeleton, animatedStyle]} />
+
+        <View style={styles.actionBar}>
+          {[1, 2, 3, 4, 5, 6].map((i) => (
+            <Animated.View key={i} style={[styles.iconSkeleton, animatedStyle]} />
+          ))}
+        </View>
+      </View>
+    </View>
+  );
+};
+
+export default SkeletonArticleCard;
+
+const styles = StyleSheet.create({
+  cardContainer: {
+    backgroundColor: '#fff',
+    borderRadius: 16,
+    marginVertical: 10,
+    marginHorizontal: 16,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+    elevation: 3,
+    overflow: 'hidden',
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+  },
+  imageSkeleton: {
+    width: '100%',
+    height: 200,
+    backgroundColor: '#E5E7EB',
+  },
+  contentContainer: {
+    padding: 16,
+  },
+  skeletonLine: {
+    backgroundColor: '#E5E7EB',
+    borderRadius: 4,
+    marginBottom: 8,
+  },
+  badgeRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 12,
+  },
+  badgeSkeleton: {
+    width: 80,
+    height: 20,
+    borderRadius: 10,
+  },
+  titleSkeleton: {
+    width: '100%',
+    height: 24,
+    marginBottom: 8,
+  },
+  metaRow: {
+    flexDirection: 'row',
+    gap: 8,
+    marginTop: 8,
+    marginBottom: 12,
+  },
+  metaSkeleton: {
+    width: 80,
+    height: 14,
+  },
+  readTimeSkeleton: {
+    width: 60,
+    height: 14,
+    marginBottom: 16,
+  },
+  actionBar: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingTop: 12,
+    borderTopWidth: 1,
+    borderTopColor: '#F3F4F6',
+  },
+  iconSkeleton: {
+    width: 28,
+    height: 28,
+    borderRadius: 14,
+    backgroundColor: '#E5E7EB',
+  },
+});

--- a/frontend/src/components/SkeletonPodcastCard.tsx
+++ b/frontend/src/components/SkeletonPodcastCard.tsx
@@ -1,0 +1,154 @@
+import React, { useEffect } from 'react';
+import { View, StyleSheet } from 'react-native';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withRepeat,
+  withTiming,
+  withSequence,
+  Easing,
+} from 'react-native-reanimated';
+import { ProfessionalColors, BorderRadius } from '../styles/GlassStyles';
+import { PODCAST_CARD } from '../constants/podcastCard';
+
+const SkeletonPodcastCard = () => {
+  const opacity = useSharedValue(0.3);
+
+  useEffect(() => {
+    opacity.value = withRepeat(
+      withSequence(
+        withTiming(0.7, { duration: 800, easing: Easing.inOut(Easing.ease) }),
+        withTiming(0.3, { duration: 800, easing: Easing.inOut(Easing.ease) })
+      ),
+      -1,
+      true
+    );
+  }, []);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    opacity: opacity.value,
+  }));
+
+  return (
+    <View style={styles.cardWrapper}>
+      <View style={styles.cardContainer}>
+        {/* Image Container */}
+        <Animated.View style={[styles.imageSkeleton, animatedStyle]}>
+          <View style={styles.playButtonSkeleton} />
+        </Animated.View>
+
+        <View style={styles.contentContainer}>
+          {/* Title */}
+          <Animated.View style={[styles.skeletonLine, styles.titleSkeleton, animatedStyle]} />
+          <Animated.View style={[styles.skeletonLine, styles.titleSkeleton, animatedStyle, { width: '70%' }]} />
+
+          {/* Author/Host */}
+          <View style={styles.row}>
+            <Animated.View style={[styles.iconSkeleton, animatedStyle]} />
+            <Animated.View style={[styles.skeletonLine, styles.hostSkeleton, animatedStyle]} />
+          </View>
+
+          {/* Tags */}
+          <View style={styles.tagsRow}>
+            <Animated.View style={[styles.tagSkeleton, animatedStyle]} />
+            <Animated.View style={[styles.tagSkeleton, animatedStyle, { width: 60 }]} />
+            <Animated.View style={[styles.tagSkeleton, animatedStyle, { width: 70 }]} />
+          </View>
+
+          {/* Footer (Views & Duration) */}
+          <View style={styles.footerRow}>
+            <View style={styles.row}>
+              <Animated.View style={[styles.iconSkeleton, animatedStyle]} />
+              <Animated.View style={[styles.skeletonLine, styles.metaSkeleton, animatedStyle]} />
+            </View>
+            <View style={styles.row}>
+              <Animated.View style={[styles.iconSkeleton, animatedStyle]} />
+              <Animated.View style={[styles.skeletonLine, styles.metaSkeleton, animatedStyle]} />
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+  );
+};
+
+export default SkeletonPodcastCard;
+
+const styles = StyleSheet.create({
+  cardWrapper: {
+    marginVertical: 8,
+    width: '100%',
+  },
+  cardContainer: {
+    backgroundColor: '#fff',
+    borderRadius: BorderRadius.lg,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+    elevation: 3,
+    overflow: 'hidden',
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+  },
+  imageSkeleton: {
+    width: '100%',
+    height: PODCAST_CARD.imageHeight,
+    backgroundColor: '#E5E7EB',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  playButtonSkeleton: {
+    width: 56,
+    height: 56,
+    borderRadius: 28,
+    backgroundColor: '#D1D5DB',
+  },
+  contentContainer: {
+    padding: 12,
+  },
+  skeletonLine: {
+    backgroundColor: '#E5E7EB',
+    borderRadius: 4,
+  },
+  titleSkeleton: {
+    height: 20,
+    marginBottom: 8,
+    width: '100%',
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  iconSkeleton: {
+    width: 16,
+    height: 16,
+    borderRadius: 8,
+    backgroundColor: '#E5E7EB',
+  },
+  hostSkeleton: {
+    width: 100,
+    height: 14,
+  },
+  tagsRow: {
+    flexDirection: 'row',
+    gap: 8,
+    marginTop: 12,
+  },
+  tagSkeleton: {
+    width: 50,
+    height: 24,
+    borderRadius: BorderRadius.lg,
+    backgroundColor: '#E5E7EB',
+  },
+  footerRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginTop: 16,
+  },
+  metaSkeleton: {
+    width: 50,
+    height: 14,
+  },
+});

--- a/frontend/src/screens/HomeScreen.tsx
+++ b/frontend/src/screens/HomeScreen.tsx
@@ -7,8 +7,8 @@ import {
   FlatList,
   ScrollView,
 } from 'react-native';
-import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
-import {SafeAreaView} from 'react-native-safe-area-context';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import {
   ON_PRIMARY_COLOR,
   PRIMARY_COLOR,
@@ -23,12 +23,12 @@ import AddIcon from '../components/AddIcon';
 import ArticleCard from '../components/ArticleCard';
 
 import HomeScreenHeader from '../components/HomeScreenHeader';
-import {ArticleData, Category, HomeScreenProps} from '../type';
+import { ArticleData, Category, HomeScreenProps } from '../type';
 import FilterModal from '../components/FilterModal';
-import {BottomSheetModal} from '@gorhom/bottom-sheet';
-import {useSelector, useDispatch} from 'react-redux';
+import { BottomSheetModal } from '@gorhom/bottom-sheet';
+import { useSelector, useDispatch } from 'react-redux';
 import Loader from '../components/Loader';
-import {usePreferences} from '../contexts/PreferencesContext';
+import { usePreferences } from '../contexts/PreferencesContext';
 
 import {
   setFilteredArticles,
@@ -39,15 +39,15 @@ import {
   setTags,
 } from '../store/dataSlice';
 import Snackbar from 'react-native-snackbar';
-import {useFocusEffect} from '@react-navigation/native';
+import { useFocusEffect } from '@react-navigation/native';
 import InactiveUserModal from '../components/InactiveUserModal';
-import {StatusBar} from 'expo-status-bar';
-import {wp} from '../helper/Metric';
-import {useGetCategories} from '../hooks/useGetArticleTags';
-import {useGetProfile} from '../hooks/useGetProfile';
-import {useRequestArticleEdit} from '../hooks/useRequestArticleEdit';
-import {useGetUnreadNotificationCount} from '../hooks/useGetUnreadNotificationCount';
-import {useGetPaginatedArticle} from '../hooks/useGetPaginatedArticles';
+import { StatusBar } from 'expo-status-bar';
+import { wp } from '../helper/Metric';
+import { useGetCategories } from '../hooks/useGetArticleTags';
+import { useGetProfile } from '../hooks/useGetProfile';
+import { useRequestArticleEdit } from '../hooks/useRequestArticleEdit';
+import { useGetUnreadNotificationCount } from '../hooks/useGetUnreadNotificationCount';
+import { useGetPaginatedArticle } from '../hooks/useGetPaginatedArticles';
 import {
   OfflineArticleState,
   NoArticleState,
@@ -67,7 +67,7 @@ const LoadingState = () => {
 };
 
 // Error State Component
-const ErrorState = ({onRetry}: {onRetry: () => void}) => {
+const ErrorState = ({ onRetry }: { onRetry: () => void }) => {
   return (
     <NoArticleState onRefresh={onRetry} />
   );
@@ -97,13 +97,13 @@ const SavedArticleEmptyState = () => (
 );
 
 // Here The purpose of using Redux is to maintain filter state throughout the app session. globally
-const HomeScreen = ({navigation}: HomeScreenProps) => {
+const HomeScreen = ({ navigation }: HomeScreenProps) => {
   const dispatch = useDispatch();
   const [articleCategories, setArticleCategories] = useState<Category[]>([]);
   const [selectedCategory, setSelectedCategory] = useState<Category>();
   const [sortingType, setSortingType] = useState<string>('');
   const [searchText, setSearchText] = useState('');
-  const {isConnected} = useSelector((state: any) => state.network);
+  const { isConnected } = useSelector((state: any) => state.network);
   const [selectedCardId, setSelectedCardId] = useState<string>('');
   // const [repostItem, setRepostItem] = useState<ArticleData | null>(null);
   const [selectCategoryList, setSelectCategoryList] = useState<Category[]>([]);
@@ -111,8 +111,8 @@ const HomeScreen = ({navigation}: HomeScreenProps) => {
   const [filterLoading, setFilterLoading] = useState<boolean>(false);
   // Session-level language filter (can override preferences per session)
   const [sessionSelectedLanguages, setSessionSelectedLanguages] = useState<string[]>([]);
-  const {preferredLanguages, isLoading: preferencesLoading} = usePreferences();
-  const {mutate: requestEdit, isPending: requestEditPending} =
+  const { preferredLanguages, isLoading: preferencesLoading } = usePreferences();
+  const { mutate: requestEdit, isPending: requestEditPending } =
     useRequestArticleEdit();
   const handleClearAllFilters = () => {
     // 1. Local state categories reset
@@ -133,7 +133,7 @@ const HomeScreen = ({navigation}: HomeScreenProps) => {
     sortType,
   } = useSelector((state: any) => state.data);
 
-  const {user_token, isGuest} = useSelector(
+  const { user_token, isGuest } = useSelector(
     (state: any) => state.user,
   );
 
@@ -147,8 +147,8 @@ const HomeScreen = ({navigation}: HomeScreenProps) => {
   // keep fetching pages when a niche category yields no new articles per page.
   const lastCategoryFilteredCountRef = useRef<number>(-1);
   const prevSelectedCategoryNameRef = useRef<string | undefined>(undefined);
-  const {data: user, refetch: refetchUser} = useGetProfile();
-  const {data: categoryData, isSuccess} = useGetCategories(isConnected);
+  const { data: user, refetch: refetchUser } = useGetProfile();
+  const { data: categoryData, isSuccess } = useGetCategories(isConnected);
 
   useEffect(() => {
     if (!isSuccess || !categoryData) return;
@@ -165,13 +165,13 @@ const HomeScreen = ({navigation}: HomeScreenProps) => {
     }
 
     setArticleCategories(categoryData);
-    dispatch(setTags({tags: categoryData}));
+    dispatch(setTags({ tags: categoryData }));
   }, [categoryData, dispatch, isSuccess, selectedTags]);
 
   const handleCategorySelection = (category: Category) => {
     // Update Redux State
     setSelectCategoryList(prevList => {
-       const isAlreadySelected = prevList.some(p => p._id === category._id);
+      const isAlreadySelected = prevList.some(p => p._id === category._id);
       const updatedList = isAlreadySelected
         ? prevList.filter(item => item._id !== category._id)
         : [...prevList, category];
@@ -184,7 +184,7 @@ const HomeScreen = ({navigation}: HomeScreenProps) => {
     bottomSheetModalRef.current?.present();
   }, []);
 
-  const {data: unreadCount, refetch: refetchUnreadCount} =
+  const { data: unreadCount, refetch: refetchUnreadCount } =
     useGetUnreadNotificationCount(isConnected);
 
   useFocusEffect(
@@ -250,7 +250,7 @@ const HomeScreen = ({navigation}: HomeScreenProps) => {
       podcastId: null,
     });
   };
-  const renderItem = ({item}: {item: ArticleData}) => {
+  const renderItem = ({ item }: { item: ArticleData }) => {
     return (
       <ArticleCard
         item={item}
@@ -258,7 +258,7 @@ const HomeScreen = ({navigation}: HomeScreenProps) => {
         setSelectedCardId={setSelectedCardId}
         navigation={navigation}
         success={onRefresh}
-        handleRepostAction={()=>{}}
+        handleRepostAction={() => { }}
         handleReportAction={handleReportAction}
         handleEditRequestAction={(item, index, reason) => {
           // submitRequest
@@ -300,15 +300,15 @@ const HomeScreen = ({navigation}: HomeScreenProps) => {
         selectedTags: articleCategories,
       }),
     );
-    dispatch(setSortType({sortType: ''}));
-    dispatch(setFilteredArticles({filteredArticles: allArticlesRef.current}));
+    dispatch(setSortType({ sortType: '' }));
+    dispatch(setFilteredArticles({ filteredArticles: allArticlesRef.current }));
   };
 
   const handleFilterApply = () => {
     // Update Redux State Variables
     if (selectCategoryList.length > 0) {
       //   console.log("enter")
-      dispatch(setSelectedTags({selectedTags: selectCategoryList}));
+      dispatch(setSelectedTags({ selectedTags: selectCategoryList }));
     } else {
       //console.log("enter ele", articleCategories);
 
@@ -321,7 +321,7 @@ const HomeScreen = ({navigation}: HomeScreenProps) => {
 
     if (sortingType && sortingType !== '') {
       if (__DEV__) console.log('Sort type', sortType);
-      dispatch(setSortType({sortType: sortingType}));
+      dispatch(setSortType({ sortType: sortingType }));
     }
 
     updateArticles(allArticlesRef.current);
@@ -347,10 +347,10 @@ const HomeScreen = ({navigation}: HomeScreenProps) => {
 
     // Filter by language preference
     // Priority: session-selected languages > preferred languages
-    const effectiveLanguages = sessionSelectedLanguages.length > 0 
-      ? sessionSelectedLanguages 
+    const effectiveLanguages = sessionSelectedLanguages.length > 0
+      ? sessionSelectedLanguages
       : preferredLanguages;
-    
+
     if (effectiveLanguages.length > 0) {
       filtered = filtered.filter(article =>
         effectiveLanguages.includes(article.language || 'en-IN'),
@@ -371,7 +371,7 @@ const HomeScreen = ({navigation}: HomeScreenProps) => {
     } else if (sortType && sortType === 'popular' && filtered.length > 1) {
       filtered.sort((a, b) => b.viewCount - a.viewCount);
     }
-    dispatch(setFilteredArticles({filteredArticles: filtered}));
+    dispatch(setFilteredArticles({ filteredArticles: filtered }));
     setFilterLoading(false);
   };
 
@@ -439,7 +439,7 @@ const HomeScreen = ({navigation}: HomeScreenProps) => {
       currentFiltered.length < 5 &&
       currentFiltered.length > lastCategoryFilteredCountRef.current
     ) {
-       prevSelectedCategoryNameRef.current = selectedCategory.name; 
+      prevSelectedCategoryNameRef.current = selectedCategory.name;
       lastCategoryFilteredCountRef.current = currentFiltered.length;
       setPage(prev => prev + 1);
     }
@@ -480,29 +480,29 @@ const HomeScreen = ({navigation}: HomeScreenProps) => {
   }, [isFetching, refreshing]);
 
   const handleSearch = (textInput: string) => {
-  if (textInput === '' || allArticlesRef.current.length === 0) {
-    dispatch(setSearchedArticles({ searchedArticles: [] }));
-    dispatch(setSearchMode({ searchMode: false }));
-  } else {
-    dispatch(setSearchMode({ searchMode: true }));
-    const matchesSearch = allArticlesRef.current.filter(article => {  // ✅ use full accumulated list
-      const matchesTitle =
-        article.title && typeof article.title === 'string'
-          ? article.title.toLowerCase().includes((textInput || '').toLowerCase())
-          : false;
-      const matchesTags =
-        article.tags && Array.isArray(article.tags)
-          ? article.tags.some(
+    if (textInput === '' || allArticlesRef.current.length === 0) {
+      dispatch(setSearchedArticles({ searchedArticles: [] }));
+      dispatch(setSearchMode({ searchMode: false }));
+    } else {
+      dispatch(setSearchMode({ searchMode: true }));
+      const matchesSearch = allArticlesRef.current.filter(article => {  // ✅ use full accumulated list
+        const matchesTitle =
+          article.title && typeof article.title === 'string'
+            ? article.title.toLowerCase().includes((textInput || '').toLowerCase())
+            : false;
+        const matchesTags =
+          article.tags && Array.isArray(article.tags)
+            ? article.tags.some(
               tag =>
                 tag && tag.name && typeof tag.name === 'string' &&
                 tag.name.toLowerCase().includes((textInput || '').toLowerCase()),
             )
-          : false;
-      return matchesTitle || matchesTags;
-    });
-    dispatch(setSearchedArticles({ searchedArticles: matchesSearch }));
-  }
-};
+            : false;
+        return matchesTitle || matchesTags;
+      });
+      dispatch(setSearchedArticles({ searchedArticles: matchesSearch }));
+    }
+  };
 
   const listData = useMemo(() => {
     if (showSavedOnly) {
@@ -532,7 +532,7 @@ const HomeScreen = ({navigation}: HomeScreenProps) => {
     const hasSorting = sortType !== '';
     return hasCustomCategories || hasSorting;
   }, [selectedTags, sortType, articleCategories]);
-  if (!articleData || articleData.articles?.length === 0) {
+  if (isLoading && (!articleData || articleData.articles?.length === 0)) {
     return (
       <SafeAreaView style={styles.container}>
         <HomeScreenHeader
@@ -636,7 +636,7 @@ const HomeScreen = ({navigation}: HomeScreenProps) => {
           <ScrollView
             horizontal={true}
             showsHorizontalScrollIndicator={false}
-            //contentContainerStyle={{flex:1}}
+          //contentContainerStyle={{flex:1}}
           >
             {selectedTags &&
               selectedTags.length > 0 &&
@@ -685,27 +685,27 @@ const HomeScreen = ({navigation}: HomeScreenProps) => {
   return (
     <SafeAreaView style={styles.container}>
       <HomeScreenHeader
-            handlePresentModalPress={handlePresentModalPress}
-            onTextInputChange={(text) => {
-              setSearchText(text);
-              handleSearch(text);
-            }}
-            onNotificationClick={() => {
-              if (isGuest) {
-                navigation.navigate('GuestPlaceholderScreen', {
-                  title: 'Notifications',
-                  description: 'Sign in to see your notifications.',
-                  iconName: 'bell',
-                });
-              } else {
-                navigation.navigate('NotificationScreen');
-              }
-            }}
-            unreadCount={unreadCount ? unreadCount : 0}
-            hasActiveFilters={selectedCategory !== '' || sortingType !== '' || searchText !== ''}
-            onFilterReset={handleClearAllFilters}
-            searchText={searchText}
-          />
+        handlePresentModalPress={handlePresentModalPress}
+        onTextInputChange={(text) => {
+          setSearchText(text);
+          handleSearch(text);
+        }}
+        onNotificationClick={() => {
+          if (isGuest) {
+            navigation.navigate('GuestPlaceholderScreen', {
+              title: 'Notifications',
+              description: 'Sign in to see your notifications.',
+              iconName: 'bell',
+            });
+          } else {
+            navigation.navigate('NotificationScreen');
+          }
+        }}
+        unreadCount={unreadCount ? unreadCount : 0}
+        hasActiveFilters={selectedCategory !== '' || sortingType !== '' || searchText !== ''}
+        onFilterReset={handleClearAllFilters}
+        searchText={searchText}
+      />
       <FilterModal
         bottomSheetModalRef={bottomSheetModalRef}
         categories={articleCategories}
@@ -722,7 +722,7 @@ const HomeScreen = ({navigation}: HomeScreenProps) => {
         <ScrollView
           horizontal={true}
           showsHorizontalScrollIndicator={false}
-          //contentContainerStyle={{flex:1}}
+        //contentContainerStyle={{flex:1}}
         >
           {!isGuest && (
             <TouchableOpacity
@@ -770,9 +770,8 @@ const HomeScreen = ({navigation}: HomeScreenProps) => {
                   }}
                   onPress={() => handleCategoryClick(item)}
                   accessibilityRole="button"
-                  accessibilityLabel={`Filter by ${item.name}${
-                    isActive ? ', currently active' : ''
-                  }`}>
+                  accessibilityLabel={`Filter by ${item.name}${isActive ? ', currently active' : ''
+                    }`}>
                   <Text
                     style={{
                       ...styles.labelStyle,
@@ -908,7 +907,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     marginBottom: 24,
     shadowColor: PRIMARY_COLOR,
-    shadowOffset: {width: 0, height: 4},
+    shadowOffset: { width: 0, height: 4 },
     shadowOpacity: 0.15,
     shadowRadius: 12,
     elevation: 8,
@@ -957,7 +956,7 @@ const styles = StyleSheet.create({
     borderRadius: 25,
     marginTop: 8,
     shadowColor: PRIMARY_COLOR,
-    shadowOffset: {width: 0, height: 4},
+    shadowOffset: { width: 0, height: 4 },
     shadowOpacity: 0.3,
     shadowRadius: 8,
     elevation: 6,
@@ -987,7 +986,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     marginBottom: 20,
     shadowColor: '#9C27B0',
-    shadowOffset: {width: 0, height: 3},
+    shadowOffset: { width: 0, height: 3 },
     shadowOpacity: 0.12,
     shadowRadius: 10,
     elevation: 5,

--- a/frontend/src/screens/PodcastsScreen.tsx
+++ b/frontend/src/screens/PodcastsScreen.tsx
@@ -9,6 +9,7 @@ import {
 
 import {YStack, View, XStack} from 'tamagui';
 import PodcastCard from '../components/PodcastCard';
+import SkeletonPodcastCard from '../components/SkeletonPodcastCard';
 import {hp} from '../helper/Metric';
 import {PodcastData, PodcastScreenProps} from '../type';
 import {useDispatch, useSelector} from 'react-redux';
@@ -177,9 +178,13 @@ const PodcastsScreen = ({navigation}: PodcastScreenProps) => {
   );
 
   const renderLoadingState = () => (
-    <View style={styles.loadingContainer}>
-     <PodcastLoadingState/>
-    </View>
+    <FlatList
+      data={[1, 2, 3]}
+      keyExtractor={item => item.toString()}
+      renderItem={() => <SkeletonPodcastCard />}
+      contentContainerStyle={styles.flatListContentContainer}
+      showsVerticalScrollIndicator={false}
+    />
   );
 
   const renderEmptyState = () => (


### PR DESCRIPTION
Resolves #1782

### Description
This PR implements skeleton loading states for both the **Article feed** and **Podcast feed**, providing a seamless visual transition from loading to loaded state. This vastly improves the perceived performance and user experience by reducing abrupt content rendering.

### Changes Made
1. Created \SkeletonArticleCard.tsx\ that mimics the layout of the Article feed using \eact-native-reanimated\.
2. Created \SkeletonPodcastCard.tsx\ that mimics the layout of the Podcast feed.
3. Updated \HomeScreen.tsx\ to use a \FlatList\ of skeleton cards while \isLoading\ is true.
4. Updated \PodcastsScreen.tsx\ to use the skeleton cards during the initial fetch.
5. Fixed a minor bug in \HomeScreen\ where an empty state would never be reachable on the initial fetch.