### PR TITLE
fix: use passed prompt parameter in performSendMessage (Fixes #1856)

### DIFF
--- a/frontend/src/screens/ChatbotScreen.tsx
+++ b/frontend/src/screens/ChatbotScreen.tsx
@@ -29,26 +29,6 @@ import {useLoadAIConversations} from '../hooks/useLoadAIChats';
 import Snackbar from 'react-native-snackbar';
 import {verifyChatbotResponse} from '../chatbot-response-verification';
 
-// interface ChatbotResponse {
-//   id: string;
-//   created: number;
-//   model: string;
-//   choices: Choice[];
-//   usage: Usage;
-// }
-
-// interface Usage {
-//   prompt_tokens: number;
-//   completion_tokens: number;
-//   total_tokens: number;
-// }
-
-// interface Choice {
-//   index: number;
-//   message: Message;
-//   finish_reason: string;
-// }
-
 const ChatbotScreen = ({navigation}: ChatBotScreenProps) => {
   const {user_id, user_token} = useSelector((state: any) => state.user);
   const {isConnected} = useSelector((state: any) => state.network);
@@ -59,9 +39,6 @@ const ChatbotScreen = ({navigation}: ChatBotScreenProps) => {
   const isMountedRef = useRef(true);
   const dispatch = useDispatch();
   const {data: user} = useGetProfile();
-  // const token = 'GPMFAQIV2BGXCWYMCVQ3IPVXSOOLI53H5NYA'; //token
-
-  //console.log("User Token", user_token);
 
   const {mutate: sendMessageToAI, isPending: messageProcessPending} =
     useSendMessageToGemini();
@@ -127,114 +104,14 @@ const ChatbotScreen = ({navigation}: ChatBotScreenProps) => {
     }));
   };
 
-
-  const performSendMessage = useCallback((prompt: string) => {
-    if (!isConnected) {
-      const errorId = `error-${Date.now()}`;
-      safeSetMessages(previousMessages =>
-        GiftedChat.append(previousMessages, [
-          {
-            _id: errorId,
-            text: 'Unable to connect. Please check your internet connection and try again.',
-            createdAt: new Date(),
-            user: {
-              _id: 2,
-              avatar:
-                'https://static.vecteezy.com/system/resources/previews/026/309/247/non_2x/robot-chat-or-chat-bot-logo-modern-conversation-automatic-technology-logo-design-template-vector.jpg',
-            },
-            customError: true,
-            originalPrompt: prompt,
-          } as any,
-        ]),
-      );
-      Snackbar.show({
-        text: 'Please check your internet connection and try again!',
-        duration: Snackbar.LENGTH_SHORT,
-      });
-      return;
-    }
-  safeSetMessages(previousMessages =>
-  GiftedChat.append(previousMessages, messages),
-);
-
-const prompt = messages?.[0]?.text ?? 'AI in health within 100 words';
-sendMessageToAI(prompt, {
-     onSuccess: (responseData: Message) => {
-  const verification = verifyChatbotResponse(responseData.text);
-
-  safeSetMessages(previousMessages =>
-    GiftedChat.append(previousMessages, [
-      {
-        _id: responseData._id,
-       text: responseData.text,
-        createdAt: new Date(),
-        user: {
-          _id: 2,
-          avatar:
-            'https://static.vecteezy.com/system/resources/previews/026/309/247/non_2x/robot-chat-or-chat-bot-logo-modern-conversation-automatic-technology-design-template-vector.jpg',
-        },
-metadata: {
-  status: verification.status,
-  confidence: verification.confidence,
-},
-      },
-    ]),
-  );
-},
-      onError: (error: AxiosError) => {
-        setIsLoading(false);
-        if (!isMountedRef.current) {
-          return;
-        }
-        console.log('Error', error);
-        let errorMsg = 'Something went wrong. Please try again.';
-        if (error.response) {
-          const statusCode = error.response.status;
-          switch (statusCode) {
-            case 401:
-              errorMsg = 'Unauthorized access. Please log in again.';
-              break;
-            case 422:
-              errorMsg = 'Invalid request. Please check your input.';
-              break;
-            case 429:
-              errorMsg = 'You’ve reached your daily limit. You can ask up to 5 questions per day';
-              break;
-            case 500:
-              errorMsg = 'An internal server error occurred. Please try again later.';
-              break;
-              case 503:
-  safeSetMessages(previousMessages =>
-    GiftedChat.append(previousMessages, [
-      {
-        _id: Date.now(),
-        text: "⚠️ AI service is temporarily unavailable. Please try again later.",
-        createdAt: new Date(),
-        user: {
-          _id: 2,
-          avatar:
-            'https://static.vecteezy.com/system/resources/previews/026/309/247/non_2x/robot-chat-or-chat-bot-logo-modern-conversation-automatic-technology-logo.jpg',
-        },
-      },
-    ]),
-  );
-  break;
-              
-
-            default:
-              errorMsg = 'An unexpected error occurred. Please try again later.';
-          }
-        } else {
-          if (error.message === 'Network Error') {
-            errorMsg = 'Unable to connect. Please check your internet connection and try again.';
-          }
-        }
-
+  const performSendMessage = useCallback(
+    (prompt: string) => {
+      if (!isConnected) {
         safeSetMessages(previousMessages =>
           GiftedChat.append(previousMessages, [
             {
               _id: `error-${Date.now()}`,
-              text: errorMsg,
+              text: 'Unable to connect. Please check your internet connection and try again.',
               createdAt: new Date(),
               user: {
                 _id: 2,
@@ -246,33 +123,123 @@ metadata: {
             } as any,
           ]),
         );
-      },
-    });
-  }, [isConnected, safeSetMessages, sendMessageToAI, setIsLoading]);
+        Snackbar.show({
+          text: 'Please check your internet connection and try again!',
+          duration: Snackbar.LENGTH_SHORT,
+        });
+        return;
+      }
 
-  const onSend = useCallback((newMessages: IMessage[] = []) => {
-    if (isPending) {
-      return;
-    }
-    const prompt = newMessages[0]?.text ?? 'AI in health within 100 words';
-    
-    safeSetMessages(previousMessages =>
-      GiftedChat.append(previousMessages, newMessages),
-    );
+      sendMessageToAI(prompt, {
+        onSuccess: (responseData: Message) => {
+          const verification = verifyChatbotResponse(responseData.text);
 
-    performSendMessage(prompt);
-  }, [isPending, safeSetMessages, performSendMessage]);
+          safeSetMessages(previousMessages =>
+            GiftedChat.append(previousMessages, [
+              {
+                _id: responseData._id,
+                text: responseData.text,
+                createdAt: new Date(),
+                user: {
+                  _id: 2,
+                  avatar:
+                    'https://static.vecteezy.com/system/resources/previews/026/309/247/non_2x/robot-chat-or-chat-bot-logo-modern-conversation-automatic-technology-logo-design-template-vector.jpg',
+                },
+                metadata: {
+                  status: verification.status,
+                  confidence: verification.confidence,
+                },
+              },
+            ]),
+          );
+        },
+        onError: (error: AxiosError) => {
+          setIsLoading(false);
+          if (!isMountedRef.current) {
+            return;
+          }
+          let errorMsg = 'Something went wrong. Please try again.';
+          if (error.response) {
+            const statusCode = error.response.status;
+            switch (statusCode) {
+              case 401:
+                errorMsg = 'Unauthorized access. Please log in again.';
+                break;
+              case 422:
+                errorMsg = 'Invalid request. Please check your input.';
+                break;
+              case 429:
+                errorMsg =
+                  "You've reached your daily limit. You can ask up to 5 questions per day";
+                break;
+              case 500:
+                errorMsg =
+                  'An internal server error occurred. Please try again later.';
+                break;
+              case 503:
+                errorMsg =
+                  '\u26a0\ufe0f AI service is temporarily unavailable. Please try again later.';
+                break;
+              default:
+                errorMsg =
+                  'An unexpected error occurred. Please try again later.';
+            }
+          } else if (error.message === 'Network Error') {
+            errorMsg =
+              'Unable to connect. Please check your internet connection and try again.';
+          }
 
-  const handleRetry = useCallback((failedMessage: any) => {
-    if (isPending) {
-      return;
-    }
-    safeSetMessages(previousMessages =>
-      previousMessages.filter(m => m._id !== failedMessage._id)
-    );
+          safeSetMessages(previousMessages =>
+            GiftedChat.append(previousMessages, [
+              {
+                _id: `error-${Date.now()}`,
+                text: errorMsg,
+                createdAt: new Date(),
+                user: {
+                  _id: 2,
+                  avatar:
+                    'https://static.vecteezy.com/system/resources/previews/026/309/247/non_2x/robot-chat-or-chat-bot-logo-modern-conversation-automatic-technology-logo-design-template-vector.jpg',
+                },
+                customError: true,
+                originalPrompt: prompt,
+              } as any,
+            ]),
+          );
+        },
+      });
+    },
+    [isConnected, safeSetMessages, sendMessageToAI, setIsLoading],
+  );
 
-    performSendMessage(failedMessage.originalPrompt);
-  }, [isPending, safeSetMessages, performSendMessage]);
+  const onSend = useCallback(
+    (newMessages: IMessage[] = []) => {
+      if (isPending) {
+        return;
+      }
+      const prompt = newMessages[0]?.text ?? 'AI in health within 100 words';
+
+      safeSetMessages(previousMessages =>
+        GiftedChat.append(previousMessages, newMessages),
+      );
+
+      performSendMessage(prompt);
+    },
+    [isPending, safeSetMessages, performSendMessage],
+  );
+
+  const handleRetry = useCallback(
+    (failedMessage: any) => {
+      if (isPending) {
+        return;
+      }
+      safeSetMessages(previousMessages =>
+        previousMessages.filter(m => m._id !== failedMessage._id),
+      );
+
+      performSendMessage(failedMessage.originalPrompt);
+    },
+    [isPending, safeSetMessages, performSendMessage],
+  );
 
   return (
     <SafeAreaView style={{flex: 1, backgroundColor: 'white'}} edges={['top']}>
@@ -339,12 +306,8 @@ metadata: {
                   : 'https://png.pngtree.com/png-clipart/20231019/original/pngtree-user-profile-avatar-png-image_13369988.png',
             }}
             isTyping={isTyping || isPending}
-            //alwaysShowSend={true}
-            //keyboardShouldPersistTaps="handled"
             minInputToolbarHeight={52}
             maxComposerHeight={110}
-            //bottomOffset={Platform.OS === "ios" ? 12 : 0}
-            //messagesContainerStyle={{ paddingTop: 10 }}
             messagesContainerStyle={{
               paddingTop: 10,
               paddingBottom: 20,
@@ -356,23 +319,40 @@ metadata: {
               const currentMessage = props.currentMessage as any;
               if (currentMessage?.customError) {
                 return (
-                  <View style={{
-                    backgroundColor: '#fee2e2',
-                    borderColor: '#fca5a5',
-                    borderWidth: 1,
-                    borderRadius: 12,
-                    padding: 12,
-                    marginVertical: 4,
-                    maxWidth: '85%',
-                    alignSelf: 'flex-start',
-                  }}>
-                    <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
+                  <View
+                    style={{
+                      backgroundColor: '#fee2e2',
+                      borderColor: '#fca5a5',
+                      borderWidth: 1,
+                      borderRadius: 12,
+                      padding: 12,
+                      marginVertical: 4,
+                      maxWidth: '85%',
+                      alignSelf: 'flex-start',
+                    }}>
+                    <View
+                      style={{
+                        flexDirection: 'row',
+                        alignItems: 'center',
+                        gap: 6,
+                      }}>
                       <Ionicons name="alert-circle" size={20} color="#dc2626" />
-                      <Text style={{ color: '#dc2626', fontWeight: '600', fontSize: 15 }}>
+                      <Text
+                        style={{
+                          color: '#dc2626',
+                          fontWeight: '600',
+                          fontSize: 15,
+                        }}>
                         Failed to send message
                       </Text>
                     </View>
-                    <Text style={{ color: '#7f1d1d', fontSize: 15, marginTop: 4, lineHeight: 22 }}>
+                    <Text
+                      style={{
+                        color: '#7f1d1d',
+                        fontSize: 15,
+                        marginTop: 4,
+                        lineHeight: 22,
+                      }}>
                       {currentMessage.text}
                     </Text>
                     {currentMessage.originalPrompt && (
@@ -388,10 +368,14 @@ metadata: {
                           marginTop: 10,
                           alignSelf: 'flex-start',
                           gap: 6,
-                        }}
-                      >
+                        }}>
                         <Ionicons name="refresh" size={16} color="white" />
-                        <Text style={{ color: 'white', fontWeight: '600', fontSize: 14 }}>
+                        <Text
+                          style={{
+                            color: 'white',
+                            fontWeight: '600',
+                            fontSize: 14,
+                          }}>
                           Retry
                         </Text>
                       </TouchableOpacity>
@@ -428,10 +412,7 @@ metadata: {
               />
             )}
             renderSend={props => (
-              <Send
-                {...props}
-                containerStyle={{justifyContent: 'center'}}
-              >
+              <Send {...props} containerStyle={{justifyContent: 'center'}}>
                 <View style={{marginRight: 12, marginBottom: 8}}>
                   <Ionicons
                     name="send"


### PR DESCRIPTION
## Description
`performSendMessage` in `ChatbotScreen.tsx` was ignoring its `prompt` parameter and
instead reading `messages?.[0]?.text` from a stale closure over the component state.
This caused the AI to always receive the wrong input — the last displayed message
rather than what the user had just typed.

Additionally, the stale messages array was being re-appended inside the function,
causing duplicate messages to appear in the chat. The `503` error case also had a
broken structure that skipped the standard retry-bubble path.

## Changes
- Removed the stale `messages` state read inside `performSendMessage`
- Removed the duplicate `safeSetMessages` call that re-appended already-displayed messages
- Removed the variable shadowing (`const prompt = ...` that overwrote the parameter)
- Fixed the `503` switch case to use the same error-bubble-with-retry path as all other errors
- Fixed inconsistent avatar URL in the `onSuccess` handler (had a typo — missing `logo-design`)
- Cleaned up indentation and formatting throughout the function

## Related Issues
Fixes #1856

## Screenshots / Notes
No UI changes — this is a logic-only fix. The chatbot now correctly sends the
user's typed message to the AI.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have tested this change manually
- [x] No new dependencies introduced
