### PR TITLE
fix: remove duplicate Reading History row from ProfileScreen (Fixes #1865)

### DIFF
--- a/frontend/src/screens/ProfileScreen.tsx
+++ b/frontend/src/screens/ProfileScreen.tsx
@@ -18,7 +18,6 @@ import {useGetProfile} from '../hooks/useGetProfile';
 import {useUpdateViewCount} from '../hooks/useUpdateViewCount';
 import {useGetReadHistory, ReadHistoryArticle} from '../hooks/useGetReadHistory';
 import { NoArticleState } from '../components/EmptyStates';
-import Ionicon from '@expo/vector-icons/Ionicons';
 
 const ProfileScreen = ({navigation}: ProfileScreenProps) => {
   const theme = useTheme();
@@ -279,14 +278,6 @@ const ProfileScreen = ({navigation}: ProfileScreenProps) => {
       >
         {renderHeader()}
 
-        <TouchableOpacity
-      style={styles.historyRow}
-      onPress={() => navigation.navigate('ReadingHistoryScreen')}>
-      <Ionicon name="time-outline" size={22} color={PRIMARY_COLOR} />
-        <Text style={styles.historyRowText}>Reading History</Text>
-        <Ionicon name="chevron-forward" size={20} color="#9ca3af" />
-      </TouchableOpacity>
-
         {/* Custom Tab Bar */}
         <View style={[styles.tabBarContainer, { backgroundColor: tabColors.background, borderBottomColor: tabColors.border }]}>
           <TouchableOpacity 
@@ -487,22 +478,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
 
-  historyRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 12,
-    paddingHorizontal: 16,
-    paddingVertical: 14,
-    backgroundColor: '#ffffff',
-    borderBottomWidth: 1,
-    borderBottomColor: '#f3f4f6',
-  },
-  historyRowText: {
-    flex: 1,
-    fontSize: 15,
-    fontWeight: '600',
-    color: '#1a1a1a',
-  },
   loadMoreButton: {
     marginTop: 12,
     paddingVertical: 12,


### PR DESCRIPTION
## Description

`ProfileScreen.tsx` exposed reading history in two places at the same time:

1. A `TouchableOpacity` row labelled "Reading History" that navigated away to the separate `ReadingHistoryScreen`.
2. A `History` tab in the inline tab bar that rendered a paginated `FlatList` directly inside the profile `ScrollView`.

Both pointed to the same data, confusing users about which entry to use and breaking the tab-based navigation pattern already established on the screen.

The `History` tab is the more complete implementation — it has pagination, error state with retry, and a load-more footer — so the redundant row shortcut has been removed.

## Changes

`frontend/src/screens/ProfileScreen.tsx`

- Removed the `TouchableOpacity` "Reading History" row and its `onPress` navigation to `ReadingHistoryScreen`
- Removed the `Ionicon` import (`@expo/vector-icons/Ionicons`) which was only used by that row
- Removed the now-dead `historyRow` and `historyRowText` style entries

Fixes #1865

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have verified this change manually
- [x] No new dependencies introduced
