### PR TITLE
fix: resolve text container overflow on small mobile screens (#1876)

### DIFF
--- a/submissions/examples/health-article-fix/README.md
+++ b/submissions/examples/health-article-fix/README.md
@@ -1,0 +1,14 @@
+# 🐛 Bug Fix: Health Article Mobile Content Overflow Container
+
+This patch addresses and fixes Issue #1876 where long medical terms, unbroken vocabulary text runs, and explicit URL hyperlinks break out of their horizontal boundaries on small mobile screens (320px–375px viewports).
+
+## 🧩 Cause of Bug
+Text elements containing long, unbroken character sequences without explicitly declared formatting boundaries default to handling strings as unbroken inline components. This forces parent layout containers to overflow along the X-axis rather than wrapping structural elements naturally.
+
+## 🛠️ The Solution
+Adding proper text wrapping definitions directly onto the content container blocks:
+```css
+.article-content {
+  overflow-wrap: break-word;
+  word-break: break-word;
+}

--- a/submissions/examples/health-article-fix/demo.html
+++ b/submissions/examples/health-article-fix/demo.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Ultimate Health — Mobile Article Overflow Fix Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <div class="app-container">
+    <header class="app-header">
+      <span class="back-btn">←</span>
+      <h2>Health Article</h2>
+      <span class="menu-dots">•••</span>
+    </header>
+
+    <main class="article-view">
+      <section class="demo-box bug-version">
+        <div class="badge badge-error">❌ BEFORE (Buggy Container)</div>
+        <h1 class="article-title">Understanding Rare Respiratory Conditions</h1>
+        
+        <div class="article-content-buggy">
+          <p>Some medical conditions have exceptionally long names. For example, lung disease caused by inhaling fine ash and sand dust is known as <strong>Pneumonoultramicroscopicsilicovolcanoconiosis</strong>.</p>
+          
+          <p>For more research papers, you can visit our medical directory portal at: 
+             <a href="#">https://www.ultimatehealthrepo.org/archive/research/v2/specialized-respiratory-illnesses-and-environmental-triggers-database-fetch?id=992834</a>
+          </p>
+        </div>
+      </section>
+
+      <section class="demo-box fixed-version">
+        <div class="badge badge-success">	
+        <div class="badge badge-success">✅ AFTER (Fixed Container)</div>
+        <h1 class="article-title">Understanding Rare Respiratory Conditions</h1>
+        
+        <div class="article-content-fixed">
+          <p>Some medical conditions have exceptionally long names. For example, lung disease caused by inhaling fine ash and sand dust is known as <strong>Pneumonoultramicroscopicsilicovolcanoconiosis</strong>.</p>
+          
+          <p>For more research papers, you can visit our medical directory portal at: 
+             <a href="#">https://www.ultimatehealthrepo.org/archive/research/v2/specialized-respiratory-illnesses-and-environmental-triggers-database-fetch?id=992834</a>
+          </p>
+        </div>
+      </section>
+    </main>
+
+    <footer class="app-

--- a/submissions/examples/health-article-fix/style.css
+++ b/submissions/examples/health-article-fix/style.css
@@ -1,0 +1,111 @@
+/* ─── Global App Styles ───────────────────────────────── */
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  background: #f4f6f9;
+  color: #1e293b;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  padding: 1rem;
+}
+
+/* Simulated Mobile Frame (320px standard) */
+.app-container {
+  width: 320px;
+  background: #ffffff;
+  border-radius: 24px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+  overflow: hidden;
+  border: 4px solid #000;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-header {
+  background: #10b981;
+  color: white;
+  padding: 1rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.app-header h2 {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.article-view {
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  max-height: 70vh;
+  overflow-y: auto;
+}
+
+.demo-box {
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 1rem;
+}
+
+.badge {
+  display: inline-block;
+  font-size: 0.7rem;
+  font-weight: 700;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  margin-bottom: 0.75rem;
+}
+
+.badge-error { background: #fee2e2; color: #ef4444; }
+.badge-success { background: #d1fae5; color: #10b981; }
+
+.article-title {
+  font-size: 1.2rem;
+  color: #0f172a;
+  margin-bottom: 0.5rem;
+  line-height: 1.4;
+}
+
+p {
+  font-size: 0.9rem;
+  color: #475569;
+  margin-bottom: 0.75rem;
+  line-height: 1.5;
+}
+
+a {
+  color: #3b82f6;
+  text-decoration: none;
+}
+
+/* ─── The Bug Encountered ────────────────────────────── */
+.article-content-buggy {
+  /* Missing handling elements */
+}
+
+/* ─── The Fix Applied ────────────────────────────────── */
+.article-content-fixed {
+  overflow-wrap: break-word;
+  word-wrap: break-word; /* Legacy support */
+  word-break: break-word; /* Modern safe mobile wrap */
+}
+
+.app-footer {
+  background: #f1f5f9;
+  text-align: center;
+  font-size: 0.7rem;
+  color: #64748b;
+  padding: 0.75rem;
+  border-top: 1px solid #e2e8f0;
+}


### PR DESCRIPTION
## Pull Request Description
Fixes #1876. Resolves a critical layout bug where long, unbroken medical terms and raw URL strings overflowed the health article reading container on small mobile viewports (320px–375px wide), causing unwanted horizontal scrolling.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component

## Submission Checklist
- [x] All changes are isolated inside `submissions/examples/health-article-fix/`
- [x] Includes `demo.html` — self-contained comparative viewport demonstration
- [x] Includes `style.css` — custom viewport styles and the CSS layout fix
- [x] Includes `README.md` — documenting the cause, solution, and structural impact
- [x] No changes made to `core/` or global project layout systems
- [x] One feature/fix per PR (no unrelated changes bundled)

## Fix Verification & Details
### What caused the bug?
Text containers lacked native wrapping directives for continuous alphanumeric characters. When encountering long medical nomenclature or dense URL strings, browsers prioritized inline string integrity, stretching the text container past the absolute width limits of small mobile displays.

### How was it resolved?
Applied safe responsive layout containment using CSS properties to enforce string truncation breaking over the bounds of parent containers:
```css
.article-content {
  overflow-wrap: break-word;
  word-break: break-word;
}