### PR TITLE
fix: merge notification pages safely

### DIFF
--- a/frontend/src/helper/notificationUtils.test.ts
+++ b/frontend/src/helper/notificationUtils.test.ts
@@ -1,0 +1,40 @@
+import {mergeNotificationsById} from './notificationUtils';
+
+const notification = (id: string, title = id) =>
+  ({_id: id, title}) as any;
+
+describe('mergeNotificationsById', () => {
+  it('returns an empty list when both pages are empty', () => {
+    expect(mergeNotificationsById([], [])).toEqual([]);
+  });
+
+  it('preserves the order of unique notifications', () => {
+    expect(
+      mergeNotificationsById(
+        [notification('1'), notification('2')],
+        [notification('3')],
+      ).map(item => item._id),
+    ).toEqual(['1', '2', '3']);
+  });
+
+  it('deduplicates IDs and keeps the latest server value', () => {
+    expect(
+      mergeNotificationsById(
+        [notification('1', 'old title'), notification('2')],
+        [notification('1', 'updated title')],
+      ),
+    ).toEqual([
+      notification('1', 'updated title'),
+      notification('2'),
+    ]);
+  });
+
+  it('deduplicates repeated entries within the incoming page', () => {
+    expect(
+      mergeNotificationsById(
+        [],
+        [notification('1', 'first'), notification('1', 'second')],
+      ),
+    ).toEqual([notification('1', 'second')]);
+  });
+});

--- a/frontend/src/helper/notificationUtils.ts
+++ b/frontend/src/helper/notificationUtils.ts
@@ -1,0 +1,17 @@
+import type {Notification} from '../type';
+
+export const mergeNotificationsById = (
+  current: Notification[],
+  incoming: Notification[],
+): Notification[] => {
+  const notifications = new Map<string, Notification>();
+
+  current.forEach(notification => {
+    notifications.set(notification._id, notification);
+  });
+  incoming.forEach(notification => {
+    notifications.set(notification._id, notification);
+  });
+
+  return Array.from(notifications.values());
+};

--- a/frontend/src/screens/NotificationScreen.tsx
+++ b/frontend/src/screens/NotificationScreen.tsx
@@ -22,6 +22,22 @@ type PendingDelete = {
 
 const UNDO_TIMEOUT_MS = 3500;
 
+const mergeNotificationsById = (
+  current: Notification[],
+  incoming: Notification[],
+): Notification[] => {
+  const notifications = new Map<string, Notification>();
+
+  current.forEach(notification => {
+    notifications.set(notification._id, notification);
+  });
+  incoming.forEach(notification => {
+    notifications.set(notification._id, notification);
+  });
+
+  return Array.from(notifications.values());
+};
+
 const NotificationScreen = ({navigation}: any) => {
   const {user_token} = useSelector((state: any) => state.user);
   const [refreshing, setRefreshing] = React.useState(false);
@@ -53,8 +69,12 @@ const NotificationScreen = ({navigation}: any) => {
         setNotificationsData(notificationsRes.notifications);
       } else {
         if (notificationsRes.notifications) {
-          const oldNotif = notificationsData ?? [];
-          setNotificationsData([...oldNotif, ...notificationsRes.notifications]);
+          setNotificationsData(previous =>
+            mergeNotificationsById(
+              previous ?? [],
+              notificationsRes.notifications,
+            ),
+          );
         }
       }
     }

--- a/frontend/src/screens/NotificationScreen.tsx
+++ b/frontend/src/screens/NotificationScreen.tsx
@@ -13,6 +13,7 @@ import {Notification, NotificationType} from '../type';
 import { useDeleteNotification } from '../hooks/useDeleteNotification';
 import { useGetAllNotifications } from '../hooks/useGetAllNotifications';
 import { useMarkNotificationAsRead } from '../hooks/useMarkNoticationAsRead';
+import {mergeNotificationsById} from '../helper/notificationUtils';
 
 type PendingDelete = {
   item: Notification;
@@ -21,22 +22,6 @@ type PendingDelete = {
 };
 
 const UNDO_TIMEOUT_MS = 3500;
-
-const mergeNotificationsById = (
-  current: Notification[],
-  incoming: Notification[],
-): Notification[] => {
-  const notifications = new Map<string, Notification>();
-
-  current.forEach(notification => {
-    notifications.set(notification._id, notification);
-  });
-  incoming.forEach(notification => {
-    notifications.set(notification._id, notification);
-  });
-
-  return Array.from(notifications.values());
-};
 
 const NotificationScreen = ({navigation}: any) => {
   const {user_token} = useSelector((state: any) => state.user);


### PR DESCRIPTION
## Summary

- append notification pages with a functional state update
- merge pages by notification ID to prevent duplicate rows
- preserve already loaded pages when responses complete close together

## Root cause

Later pages were appended from the `notificationsData` array captured by the effect closure. A response could therefore merge into an older snapshot and overwrite notifications added by another response.

## Validation

- `git diff --check`
- verified page one still replaces the list while later pages merge into the latest state
- dependency installation is blocked by the existing Yarn/Windows `EISDIR` package-fetch failure

Fixes #1915