### PR TITLE
fix: stop recorder during screen cleanup

### DIFF
--- a/frontend/src/screens/PodcastRecorder.tsx
+++ b/frontend/src/screens/PodcastRecorder.tsx
@@ -40,6 +40,7 @@ const PodcastRecorder = ({navigation, route}: PodcastRecorderScreenProps) => {
 
   const timerRef = useRef<number | null>(null);
   const recordStartTimeRef = useRef<number | null>(null);
+  const isRecordingRef = useRef(false);
   
   // Stores the latest native duration for use in AppState listener and other effects, preventing stale closures.
   const durationMillisRef = useRef<number>(0);
@@ -84,12 +85,14 @@ const PodcastRecorder = ({navigation, route}: PodcastRecorderScreenProps) => {
   const record = async () => {
     await audioRecorder.prepareToRecordAsync();
     audioRecorder.record();
+    isRecordingRef.current = true;
     startTimer();
   };
 
   const stopRecording = async () => {
     // The recording will be available on `audioRecorder.uri`.
     await audioRecorder.stop();
+    isRecordingRef.current = false;
     setRecording(false);
     stopTimer();
     setFilePath(audioModule.uri);
@@ -267,8 +270,14 @@ const PodcastRecorder = ({navigation, route}: PodcastRecorderScreenProps) => {
   useEffect(() => {
     return () => {
       stopTimer();
+      if (isRecordingRef.current) {
+        isRecordingRef.current = false;
+        void audioRecorder.stop().catch(error => {
+          console.warn('Failed to stop recording during cleanup:', error);
+        });
+      }
     };
-  }, []);
+  }, [audioRecorder]);
 
   return (
     <Theme name="dark">


### PR DESCRIPTION
## Summary

- track whether the native recorder is actively recording
- clear the active flag after a normal stop
- stop the recorder during screen cleanup when recording is still active
- retain timer cleanup and report cleanup failures without crashing navigation

## Root cause

The screen only cleared its JavaScript elapsed-time interval on unmount. It did not stop the native Expo audio recorder, so microphone and file resources could remain active after navigation.

## Validation

- `git diff --check`
- reviewed normal stop, re-record, upload, and unmount paths
- dependency installation is blocked by the existing Yarn/Windows `EISDIR` package-fetch failure

Fixes #1914