### PR TITLE
fix: scope article TTS subscriptions

### DIFF
--- a/frontend/src/screens/article/ArticleScreen.tsx
+++ b/frontend/src/screens/article/ArticleScreen.tsx
@@ -71,6 +71,10 @@ import Animated, {
 
 const CHUNK_SIZE = 120;
 
+type TtsSubscription = {
+  remove?: () => void;
+};
+
 const ArticleScreen = ({navigation, route}: ArticleScreenProp) => {
   const {articleId, authorId, recordId} = route.params;
   const getProfileImageUri = (profileImage?: string) => {
@@ -97,6 +101,35 @@ const ArticleScreen = ({navigation, route}: ArticleScreenProp) => {
   const chunkIndexRef = useRef(0);
   const wordsRef = useRef<string[]>([]);
   const readEventFiredRef = useRef(false);
+  const finishSubscriptionRef = useRef<TtsSubscription | null>(null);
+  const errorSubscriptionRef = useRef<TtsSubscription | null>(null);
+  const finishHandlerRef = useRef<(() => void) | null>(null);
+  const errorHandlerRef = useRef<((event: unknown) => void) | null>(null);
+
+  const clearArticleTtsSubscriptions = useCallback(() => {
+    if (finishSubscriptionRef.current?.remove) {
+      finishSubscriptionRef.current.remove();
+    } else if (
+      finishHandlerRef.current &&
+      typeof Tts.removeEventListener === 'function'
+    ) {
+      Tts.removeEventListener('tts-finish', finishHandlerRef.current as any);
+    }
+
+    if (errorSubscriptionRef.current?.remove) {
+      errorSubscriptionRef.current.remove();
+    } else if (
+      errorHandlerRef.current &&
+      typeof Tts.removeEventListener === 'function'
+    ) {
+      Tts.removeEventListener('tts-error', errorHandlerRef.current as any);
+    }
+
+    finishSubscriptionRef.current = null;
+    errorSubscriptionRef.current = null;
+    finishHandlerRef.current = null;
+    errorHandlerRef.current = null;
+  }, []);
 
   // Progress Bar Shared Values
   const scrollY = useSharedValue(0);
@@ -200,10 +233,14 @@ const ArticleScreen = ({navigation, route}: ArticleScreenProp) => {
       setIsPaused(false);
       setPlayerVisible(false);
       Tts.stop();
-      Tts.removeAllListeners('tts-finish');
-      Tts.removeAllListeners('tts-error');
+      clearArticleTtsSubscriptions();
     };
-  }, [articleId, isGuest, updateViewCount]);
+  }, [
+    articleId,
+    clearArticleTtsSubscriptions,
+    isGuest,
+    updateViewCount,
+  ]);
 
   useEffect(() => {
     readEventFiredRef.current = false;
@@ -498,7 +535,14 @@ const ArticleScreen = ({navigation, route}: ArticleScreenProp) => {
     return false;
   };
 
-  const speakNextChunk = () => {
+  const handleTtsError = useCallback((event: unknown) => {
+    console.log('TTS Error:', event);
+    setIsPlaying(false);
+    setIsPaused(false);
+    setPlayerVisible(false);
+  }, []);
+
+  const speakNextChunk = useCallback(() => {
     const words = wordsRef.current;
     const chunkIndex = chunkIndexRef.current;
     if (chunkIndex >= words.length) {
@@ -506,20 +550,36 @@ const ArticleScreen = ({navigation, route}: ArticleScreenProp) => {
       setIsPlaying(false);
       setIsPaused(false);
       setPlayerVisible(false);
-      Tts.removeAllListeners('tts-finish');
-      Tts.removeAllListeners('tts-error');
+      clearArticleTtsSubscriptions();
       return;
     }
     const chunk = words.slice(chunkIndex, chunkIndex + CHUNK_SIZE).join(' ');
     chunkIndexRef.current = chunkIndex + CHUNK_SIZE;
     Tts.speak(chunk);
-  };
+  }, [clearArticleTtsSubscriptions]);
+
+  const attachArticleTtsSubscriptions = useCallback(() => {
+    clearArticleTtsSubscriptions();
+    finishHandlerRef.current = speakNextChunk;
+    errorHandlerRef.current = handleTtsError;
+    finishSubscriptionRef.current = Tts.addEventListener(
+      'tts-finish',
+      speakNextChunk,
+    ) as TtsSubscription;
+    errorSubscriptionRef.current = Tts.addEventListener(
+      'tts-error',
+      handleTtsError,
+    ) as TtsSubscription;
+  }, [
+    clearArticleTtsSubscriptions,
+    handleTtsError,
+    speakNextChunk,
+  ]);
 
   const speakSection = async (_language = 'en-IN', content: string) => {
     try {
       await Tts.stop();
-      Tts.removeAllListeners('tts-finish');
-      Tts.removeAllListeners('tts-error');
+      clearArticleTtsSubscriptions();
 
       const ready = await ensureLanguageInstalled(_language);
       if (!ready) return;
@@ -535,13 +595,7 @@ const ArticleScreen = ({navigation, route}: ArticleScreenProp) => {
       wordsRef.current = words;
       chunkIndexRef.current = 0;
 
-      Tts.addEventListener('tts-finish', speakNextChunk);
-      Tts.addEventListener('tts-error', e => {
-        console.log('TTS Error:', e);
-        setIsPlaying(false);
-        setIsPaused(false);
-        setPlayerVisible(false);
-      });
+      attachArticleTtsSubscriptions();
 
       setIsPlaying(true);
       setIsPaused(false);
@@ -571,20 +625,12 @@ const ArticleScreen = ({navigation, route}: ArticleScreenProp) => {
         // Step back one chunk to resume from the interrupted chunk
         chunkIndexRef.current = Math.max(0, chunkIndexRef.current - CHUNK_SIZE);
 
-        // Re-attach listeners
-        Tts.addEventListener('tts-finish', speakNextChunk);
-        Tts.addEventListener('tts-error', e => {
-          console.log('TTS Error:', e);
-          setIsPlaying(false);
-          setIsPaused(false);
-          setPlayerVisible(false);
-        });
+        attachArticleTtsSubscriptions();
 
         speakNextChunk();
       } else {
         // Pause
-        Tts.removeAllListeners('tts-finish');
-        Tts.removeAllListeners('tts-error');
+        clearArticleTtsSubscriptions();
         await Tts.stop();
         setIsPlaying(false);
         setIsPaused(true);
@@ -597,8 +643,7 @@ const ArticleScreen = ({navigation, route}: ArticleScreenProp) => {
   const handleTtsStop = async () => {
     try {
       await Tts.stop();
-      Tts.removeAllListeners('tts-finish');
-      Tts.removeAllListeners('tts-error');
+      clearArticleTtsSubscriptions();
       wordsRef.current = [];
       chunkIndexRef.current = 0;
       setIsPlaying(false);
@@ -614,19 +659,12 @@ const ArticleScreen = ({navigation, route}: ArticleScreenProp) => {
     Tts.setDefaultRate(selectedSpeed);
     // Restart current position with new speed if currently playing
     if (isPlaying && !isPaused) {
-      Tts.removeAllListeners('tts-finish');
-      Tts.removeAllListeners('tts-error');
+      clearArticleTtsSubscriptions();
       // Step back one chunk so we replay current chunk at new speed
       // Note: Rewind is approximate and might read earlier parts of a smaller previous chunk.
       chunkIndexRef.current = Math.max(0, chunkIndexRef.current - CHUNK_SIZE);
       Tts.stop().then(() => {
-        Tts.addEventListener('tts-finish', speakNextChunk);
-        Tts.addEventListener('tts-error', e => {
-          console.log('TTS Error:', e);
-          setIsPlaying(false);
-          setIsPaused(false);
-          setPlayerVisible(false);
-        });
+        attachArticleTtsSubscriptions();
         speakNextChunk();
       });
     }


### PR DESCRIPTION
## Summary

- track the `tts-finish` and `tts-error` subscriptions owned by `ArticleScreen`
- remove subscriptions through their returned handles, with an exact-handler fallback
- reuse scoped attach/clear helpers for play, pause, resume, speed changes, stop, completion, and unmount
- eliminate every `removeAllListeners` call from the article TTS flow

## Root cause

`ArticleScreen` used global `removeAllListeners` calls for shared native TTS events. Those calls could remove listeners registered by other mounted consumers such as `PodcastPlayer`.

## Validation

- `git diff --check`
- confirmed `ArticleScreen` contains no remaining `removeAllListeners` calls
- reviewed play, pause/resume, speed-change, completion, stop, and unmount paths
- dependency installation is blocked by the existing Yarn/Windows `EISDIR` package-fetch failure

Fixes #1918