### PR TITLE
fix: encode podcast search parameters

### DIFF
--- a/frontend/src/hooks/useGetSearchPodcasts.ts
+++ b/frontend/src/hooks/useGetSearchPodcasts.ts
@@ -15,7 +15,12 @@ AxiosError
   return useQuery({
     queryKey: ['search-podcasts', page, q],
     queryFn: async () => {
-      const res = await axios.get(`${SEARCH_PODCAST}?q=${q}&page=${page}`);
+      const res = await axios.get(SEARCH_PODCAST, {
+        params: {
+          q,
+          page,
+        },
+      });
 
       return res.data as SearchResponse;
     },


### PR DESCRIPTION
## Summary

- pass podcast search input through Axios `params`
- preserve reserved characters as part of the `q` value
- keep pagination as a separately encoded query parameter

## Root cause

The search hook interpolated raw user input into the URL. Characters such as `&`, `#`, `+`, `%`, and `?` could be interpreted as query-string syntax instead of search text.

## Validation

- `git diff --check`
- verified Axios receives `q` and `page` as separate parameter values
- dependency installation is blocked by the existing Yarn/Windows `EISDIR` package-fetch failure

Fixes #1919