### PR TITLE
fix: complete logout when offline

### DIFF
--- a/frontend/src/screens/__tests__/LogoutScreen.local.test.tsx
+++ b/frontend/src/screens/__tests__/LogoutScreen.local.test.tsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import {Alert} from 'react-native';
+import {fireEvent, render, waitFor} from '@testing-library/react-native';
+import LogoutScreen from '../auth/LogoutScreen';
+
+const mockDispatch = jest.fn();
+const mockReset = jest.fn();
+const mockClearStorage = jest.fn(() => Promise.resolve());
+const mockLogout = jest.fn();
+
+jest.mock('react-redux', () => ({
+  useDispatch: () => mockDispatch,
+}));
+
+jest.mock('../../hooks/useUserLogout', () => ({
+  useUserLogout: () => ({
+    mutate: mockLogout,
+  }),
+}));
+
+jest.mock('../../helper/Utils', () => ({
+  clearStorage: () => mockClearStorage(),
+}));
+
+jest.mock('../../store/UserSlice', () => ({
+  resetUserState: () => ({type: 'user/resetUserState'}),
+}));
+
+jest.mock('../../helper/APIUtils', () => ({
+  GET_STORAGE_DATA: 'https://storage.example.com',
+}));
+
+jest.mock('../../helper/Theme', () => ({
+  PRIMARY_COLOR: '#000A60',
+}));
+
+jest.mock('tamagui', () => ({
+  useTheme: () => ({
+    background: {val: '#ffffff'},
+    black: {val: '#000000'},
+    color: {val: '#000000'},
+    gray500: {val: '#666666'},
+    white: {val: '#ffffff'},
+  }),
+}));
+
+const renderScreen = () =>
+  render(
+    <LogoutScreen
+      navigation={{reset: mockReset, goBack: jest.fn()} as any}
+      route={{
+        params: {profile_image: '', username: 'Test User'},
+      } as any}
+    />,
+  );
+
+describe('LogoutScreen local logout behavior', () => {
+  let alertSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    alertSpy.mockRestore();
+  });
+
+  const expectLocalLogout = async () => {
+    await waitFor(() => {
+      expect(mockClearStorage).toHaveBeenCalledTimes(1);
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: 'user/resetUserState',
+      });
+      expect(mockReset).toHaveBeenCalledWith({
+        index: 0,
+        routes: [{name: 'LoginScreen'}],
+      });
+    });
+  };
+
+  it('clears local session after confirmed server logout', async () => {
+    mockLogout.mockImplementation((_variables, options) => {
+      void options.onSuccess();
+    });
+
+    const {getByText} = renderScreen();
+    fireEvent.press(getByText('Yes, log me out'));
+
+    await expectLocalLogout();
+    expect(alertSpy).toHaveBeenCalledWith(
+      'Success',
+      'Logged out successfully',
+    );
+  });
+
+  it('clears local session when the server returns an error', async () => {
+    mockLogout.mockImplementation((_variables, options) => {
+      void options.onError({response: {status: 500}});
+    });
+
+    const {getByText} = renderScreen();
+    fireEvent.press(getByText('Yes, log me out'));
+
+    await expectLocalLogout();
+    expect(alertSpy).toHaveBeenCalledWith(
+      'Signed out locally',
+      'The server could not confirm logout, but this device has been signed out.',
+    );
+  });
+
+  it('clears local session when the device is offline', async () => {
+    mockLogout.mockImplementation((_variables, options) => {
+      void options.onError(new Error('Network Error'));
+    });
+
+    const {getByText} = renderScreen();
+    fireEvent.press(getByText('Yes, log me out'));
+
+    await expectLocalLogout();
+    expect(alertSpy).toHaveBeenCalledWith(
+      'Signed out locally',
+      'You are offline, but this device has been signed out.',
+    );
+  });
+});

--- a/frontend/src/screens/auth/LogoutScreen.tsx
+++ b/frontend/src/screens/auth/LogoutScreen.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useCallback} from 'react';
 import {
   StyleSheet,
   View,
@@ -8,10 +8,10 @@ import {
   Alert,
 } from 'react-native';
 import {PRIMARY_COLOR} from '../../helper/Theme';
-import {GET_STORAGE_DATA, USER_LOGOUT} from '../../helper/APIUtils';
-import axios, {AxiosError} from 'axios';
+import {GET_STORAGE_DATA} from '../../helper/APIUtils';
+import {AxiosError} from 'axios';
 import {resetUserState} from '../../store/UserSlice';
-import {useDispatch, useSelector} from 'react-redux';
+import {useDispatch} from 'react-redux';
 import {clearStorage} from '../../helper/Utils';
 import {SafeAreaView} from 'react-native-safe-area-context';
 import {LogoutScreenProp} from '@/src/type';
@@ -28,44 +28,37 @@ const LogoutScreen = ({navigation, route}: LogoutScreenProp) => {
   const theme = useTheme();
   const {mutate: logout} = useUserLogout();  
 
+  const completeLocalLogout = useCallback(async () => {
+    await clearStorage();
+    dispatch(resetUserState());
+    navigation.reset({
+      index: 0,
+      routes: [{name: 'LoginScreen'}],
+    });
+  }, [dispatch, navigation]);
+
   const handleLogout = () => {
     logout(
       {},
       {
         onSuccess: async () => {
-          Alert.alert('Success', 'Logout successfully');
-          await clearStorage();
-          dispatch(resetUserState());
-          navigation.reset({
-            index: 0,
-            routes: [{name: 'LoginScreen'}], 
-          });
+          await completeLocalLogout();
+          Alert.alert('Success', 'Logged out successfully');
         },
 
-        onError: (err: AxiosError) => {
+        onError: async (err: AxiosError) => {
+          console.warn('Remote logout failed; completing local logout.', err);
+          await completeLocalLogout();
+
           if (err.response) {
-            const statusCode = err.response.status;
-            switch (statusCode) {
-              case 500:
-                // Handle internal server errors
-                Alert.alert(
-                  'Logout Failed',
-                  'Internal server error. Please try again later.',
-                );
-                break;
-              default:
-                // Handle any other errors
-                Alert.alert(
-                  'Logout Failed',
-                  'Something went wrong. Please try again later.',
-                );
-            }
-          } else {
-            // Handle network errors
-            console.log('General Update Error', err);
             Alert.alert(
-              'Logout Failed',
-              'Network error. Please check your connection.',
+              'Signed out locally',
+              'The server could not confirm logout, but this device has been signed out.',
+            );
+          } else {
+            Alert.alert(
+              'Signed out locally',
+              'You are offline, but this device has been signed out.',
             );
           }
         },


### PR DESCRIPTION
## Summary

- centralize local logout cleanup and navigation
- execute local logout after both successful and failed remote revocation attempts
- distinguish confirmed server logout from offline/local-only logout feedback
- remove unused authentication imports

## Root cause

Local credentials and Redux state were cleared only from the mutation's success callback. A network or server error therefore prevented users from ending the local session.

## Validation

- `git diff --check`
- reviewed success, HTTP-error, and network-error paths
- dependency installation is blocked by the existing Yarn/Windows `EISDIR` package-fetch failure

Fixes #1921