### PR TITLE
fix: remove unused VULTR_CHAT_URL dead code

### DIFF
--- a/frontend/src/helper/APIUtils.ts
+++ b/frontend/src/helper/APIUtils.ts
@@ -62,7 +62,6 @@ const GET_YEARLY_READ_REPORT = `${PROD_URL}/analytics/yearly-reads/`;
 const GET_MONTHLY_WRITES_REPORT = `${PROD_URL}/analytics/monthly-writes/`;
 const GET_YEARLY_WRITES_REPORT = `${PROD_URL}/analytics/yearly-writes/`;
 
-const VULTR_CHAT_URL = 'https://api.vultrinference.com/v1/chat/completions';
 const GET_ARTICLE_CONTENT = `${PROD_URL}/articles/get-article-content`;
 const GET_IMPROVEMENT_CONTENT = `${PROD_URL}/article/get-improve-content`;
 
@@ -154,7 +153,6 @@ export {
   GET_MONTHLY_WRITES_REPORT,
   GET_YEARLY_READ_REPORT,
   GET_YEARLY_WRITES_REPORT,
-  VULTR_CHAT_URL,
   CHAT_URL,
   REPOST_ARTICLE,
   CHECK_USER_HANDLE,


### PR DESCRIPTION
### Summary

Removes `VULTR_CHAT_URL` constant and its export from `APIUtils.ts`. This was leftover from the old Vultr chatbot implementation — unused after Gemini migration.

- Delete `const VULTR_CHAT_URL` declaration (line 64)
- Remove `VULTR_CHAT_URL` from the export list (line 156)

Closes #1908