### PR TITLE
fix: encode podcast search parameters

### DIFF
--- a/frontend/src/hooks/useGetSearchPodcasts.ts
+++ b/frontend/src/hooks/useGetSearchPodcasts.ts
@@ -15,7 +15,13 @@ AxiosError
   return useQuery({
     queryKey: ['search-podcasts', page, q],
     queryFn: async () => {
-      const res = await axios.get(`${SEARCH_PODCAST}?q=${q}&page=${page}`);
+      const res = await axios.get(SEARCH_PODCAST,{
+        params:{
+          q,
+          page,
+        },
+      });
+      
 
       return res.data as SearchResponse;
     },


### PR DESCRIPTION
#### PR Description
This PR fixes the podcast search query parameter encoding issue in `useGetSearchPodcasts.ts`.

Changes made:
- Replaced manual query string construction with Axios `params`.
- Ensured reserved URL characters such as `&`, `#`, `+`, `%`, and `?` are handled correctly.
- Preserved the complete search query during API requests.

#### Type of Change
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update

#### Select your work-area
- [x] Frontend
- [ ] Backend
- [ ] Documentation
- [ ] Others

#### Related Issue
#1919

#### Add your Work Example
No visible UI changes. This update improves API request handling for podcast search queries.

#### Fixes (mention the issue number which this fixes)
closes #1919

#### Checklist
- [x] I have optimized the file changes.
- [x] I have made a PR to the project's develop branch.

#### Undertaking
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have checked for plagiarism and assure its authenticity.
- [x] I have read and followed the code of conduct for this repository.
- [x] I Agree