### PR TITLE
feat(web): implement infinite circular carousel for App Screenshots section

### DIFF
--- a/web/src/app/medical-glossary/page.tsx
+++ b/web/src/app/medical-glossary/page.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import Navbar from "@/components/layout/Navbar";
 import { withBasePath } from "@/lib/basePath";
 import { MedicalGlossaryExplorer } from "./MedicalGlossaryExplorer";
 import { Navbar, PageWrapper, Section } from "@/components/layout";

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -57,7 +57,20 @@ const TERMS_OF_USE_URL = process.env.NEXT_PUBLIC_TERMS_OF_USE_URL || "#";
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const SLIDER_SCROLL_AMOUNT = 324;
 const DNA_TRAIL_MAX_POINTS = 38;
+const CLONE_COUNT = 8; // needs to be >= viewport_width / itemWidth for clone zone to be reachable
 const isValidEmail = (email: string) => EMAIL_PATTERN.test(email.trim());
+
+// Infinite carousel: clone first/last CLONE_COUNT items on each side for seamless looping
+const extendedUserScreenshots = [
+  ...userScreenshots.slice(-CLONE_COUNT),
+  ...userScreenshots,
+  ...userScreenshots.slice(0, CLONE_COUNT),
+];
+const extendedAdminScreenshots = [
+  ...adminScreenshots.slice(-CLONE_COUNT),
+  ...adminScreenshots,
+  ...adminScreenshots.slice(0, CLONE_COUNT),
+];
 
 const getCursorGlowSnapshot = () => {
   if (typeof window === "undefined") return false;
@@ -310,52 +323,42 @@ export default function Home() {
     }
   };
 
-  const moveSlider = (ref: RefObject<HTMLDivElement | null>, dir: number) => {
+  // Infinite carousel using the clone trick:
+  // The rendered list is [...lastN clones, ...real items, ...firstN clones]
+  // moveSlider only triggers the smooth scroll; the scroll-event listeners below
+  // handle the silent reset once the animation actually finishes.
+  const moveSlider = (
+    ref: RefObject<HTMLDivElement | null>,
+    dir: number,
+    _realCount: number,
+  ) => {
     const slider = ref.current;
     if (!slider) return;
-
-    const maxScroll = slider.scrollWidth - slider.clientWidth;
+    const maxScrollLeft = slider.scrollWidth - slider.clientWidth;
     const currentScroll = slider.scrollLeft;
-    const targetScroll = currentScroll + dir * SLIDER_SCROLL_AMOUNT;
-
-    if (dir === 1) {
-      if (currentScroll >= maxScroll) {
-        slider.scrollTo({ left: 0, behavior: "auto" });
-        return;
-      }
-
-      if (targetScroll > maxScroll) {
-        slider.scrollTo({ left: maxScroll, behavior: "smooth" });
-        return;
-      }
-    }
-
-    if (dir === -1) {
-      if (currentScroll <= 0 || targetScroll < 0) {
-        slider.scrollTo({ left: maxScroll, behavior: "auto" });
-        return;
-      }
-    }
-
-    slider.scrollTo({
-      left: Math.max(0, Math.min(targetScroll, maxScroll)),
-      behavior: "smooth",
-    });
+    const targetScroll = Math.max(
+      0,
+      Math.min(currentScroll + dir * SLIDER_SCROLL_AMOUNT, maxScrollLeft),
+    );
+    slider.scrollTo({ left: targetScroll, behavior: "smooth" });
   };
 
   const startAutoSlide = useCallback(() => {
     if (autoSlideTimerRef.current) clearInterval(autoSlideTimerRef.current);
     autoSlideTimerRef.current = setInterval(() => {
-      moveSlider(userSliderRef, 1);
-      if (adminSliderOpen) moveSlider(adminSliderRef, 1);
+      moveSlider(userSliderRef, 1, userScreenshots.length);
+      if (adminSliderOpen) moveSlider(adminSliderRef, 1, adminScreenshots.length);
     }, 3000);
   }, [adminSliderOpen]);
 
-  const handleManualSlide = useCallback((ref: RefObject<HTMLDivElement | null>, direction: number) => {
-    if (autoSlideTimerRef.current) clearInterval(autoSlideTimerRef.current);
-    moveSlider(ref, direction);
-    setTimeout(startAutoSlide, 5000);
-  }, [startAutoSlide]);
+  const handleManualSlide = useCallback(
+    (ref: RefObject<HTMLDivElement | null>, direction: number, realCount: number) => {
+      if (autoSlideTimerRef.current) clearInterval(autoSlideTimerRef.current);
+      moveSlider(ref, direction, realCount);
+      setTimeout(startAutoSlide, 5000);
+    },
+    [startAutoSlide],
+  );
 
   useEffect(() => {
     startAutoSlide();
@@ -363,6 +366,83 @@ export default function Home() {
       if (autoSlideTimerRef.current) clearInterval(autoSlideTimerRef.current);
     };
   }, [startAutoSlide]);
+
+  // Initialise slider scroll positions to show the first REAL item (skip start clones)
+  useEffect(() => {
+    if (!userSliderOpen) return;
+    const timer = setTimeout(() => {
+      const slider = userSliderRef.current;
+      if (!slider) return;
+      const itemWidth = slider.scrollWidth / (userScreenshots.length + CLONE_COUNT * 2);
+      slider.scrollLeft = CLONE_COUNT * itemWidth;
+    }, 50);
+    return () => clearTimeout(timer);
+  }, [userSliderOpen]);
+
+  useEffect(() => {
+    if (!adminSliderOpen) return;
+    const timer = setTimeout(() => {
+      const slider = adminSliderRef.current;
+      if (!slider) return;
+      const itemWidth = slider.scrollWidth / (adminScreenshots.length + CLONE_COUNT * 2);
+      slider.scrollLeft = CLONE_COUNT * itemWidth;
+    }, 50);
+    return () => clearTimeout(timer);
+  }, [adminSliderOpen]);
+
+  // Scroll-event debounce: fires 150ms after scrolling stops (works for any scroll duration)
+  // Silently resets position when the slider lands in the clone zone.
+  useEffect(() => {
+    const slider = userSliderRef.current;
+    if (!slider || !userSliderOpen) return;
+    let debounce: ReturnType<typeof setTimeout> | null = null;
+    const onScroll = () => {
+      if (debounce) clearTimeout(debounce);
+      debounce = setTimeout(() => {
+        const totalItems = userScreenshots.length + CLONE_COUNT * 2;
+        const itemWidth = slider.scrollWidth / totalItems;
+        const startOffset = CLONE_COUNT * itemWidth;
+        const realScrollWidth = userScreenshots.length * itemWidth;
+        const scroll = slider.scrollLeft;
+        if (scroll >= startOffset + realScrollWidth) {
+          slider.scrollTo({ left: startOffset + (scroll - startOffset - realScrollWidth), behavior: "instant" as ScrollBehavior });
+        } else if (scroll < startOffset) {
+          slider.scrollTo({ left: startOffset + realScrollWidth + (scroll - startOffset), behavior: "instant" as ScrollBehavior });
+        }
+      }, 150);
+    };
+    slider.addEventListener("scroll", onScroll, { passive: true });
+    return () => {
+      slider.removeEventListener("scroll", onScroll);
+      if (debounce) clearTimeout(debounce);
+    };
+  }, [userSliderOpen]);
+
+  useEffect(() => {
+    const slider = adminSliderRef.current;
+    if (!slider || !adminSliderOpen) return;
+    let debounce: ReturnType<typeof setTimeout> | null = null;
+    const onScroll = () => {
+      if (debounce) clearTimeout(debounce);
+      debounce = setTimeout(() => {
+        const totalItems = adminScreenshots.length + CLONE_COUNT * 2;
+        const itemWidth = slider.scrollWidth / totalItems;
+        const startOffset = CLONE_COUNT * itemWidth;
+        const realScrollWidth = adminScreenshots.length * itemWidth;
+        const scroll = slider.scrollLeft;
+        if (scroll >= startOffset + realScrollWidth) {
+          slider.scrollTo({ left: startOffset + (scroll - startOffset - realScrollWidth), behavior: "instant" as ScrollBehavior });
+        } else if (scroll < startOffset) {
+          slider.scrollTo({ left: startOffset + realScrollWidth + (scroll - startOffset), behavior: "instant" as ScrollBehavior });
+        }
+      }, 150);
+    };
+    slider.addEventListener("scroll", onScroll, { passive: true });
+    return () => {
+      slider.removeEventListener("scroll", onScroll);
+      if (debounce) clearTimeout(debounce);
+    };
+  }, [adminSliderOpen]);
 
   // ── TestFlight invite ──
   const sendTesterEmail = async () => {
@@ -499,9 +579,9 @@ export default function Home() {
             {userSliderOpen && (
               <div className="screenshot-slider-container">
                 <div className="screenshots-wrapper" ref={userSliderRef}>
-                  {userScreenshots.map((s) => (
+                  {extendedUserScreenshots.map((s, i) => (
                     <div
-                      key={s.src}
+                      key={`user-${i}`}
                       className="screenshot-box"
                       onClick={() => openScreenshotModal(s.src)}
                       onKeyDown={(e) => handleScreenshotCardKeyDown(e, s.src)}
@@ -518,16 +598,10 @@ export default function Home() {
                       />
                     </div>
                   ))}
-                  <div className="screenshot-box">
-                    <div className="screenshot-empty">
-                      <i className="fas fa-mobile-alt" style={{ fontSize: "4rem", color: "#cbd5e1" }}></i>
-                      <p style={{ marginTop: "20px", color: "#718096", fontWeight: 600 }}>More Screens Coming Soon</p>
-                    </div>
-                  </div>
                 </div>
                 <div className="slider-nav">
-                  <button className="nav-btn" type="button" aria-label="Previous UltimateHealth screenshot" onClick={() => handleManualSlide(userSliderRef, -1)}><i className="fas fa-chevron-left"></i></button>
-                  <button className="nav-btn" type="button" aria-label="Next UltimateHealth screenshot" onClick={() => handleManualSlide(userSliderRef, 1)}><i className="fas fa-chevron-right"></i></button>
+                  <button className="nav-btn" type="button" aria-label="Previous UltimateHealth screenshot" onClick={() => handleManualSlide(userSliderRef, -1, userScreenshots.length)}><i className="fas fa-chevron-left"></i></button>
+                  <button className="nav-btn" type="button" aria-label="Next UltimateHealth screenshot" onClick={() => handleManualSlide(userSliderRef, 1, userScreenshots.length)}><i className="fas fa-chevron-right"></i></button>
                 </div>
               </div>
             )}
@@ -541,9 +615,9 @@ export default function Home() {
             {adminSliderOpen && (
               <div className="screenshot-slider-container">
                 <div className="screenshots-wrapper" ref={adminSliderRef}>
-                  {adminScreenshots.map((s) => (
+                  {extendedAdminScreenshots.map((s, i) => (
                     <div
-                      key={s.src}
+                      key={`admin-${i}`}
                       className="screenshot-box"
                       onClick={() => openScreenshotModal(s.src)}
                       onKeyDown={(e) => handleScreenshotCardKeyDown(e, s.src)}
@@ -560,16 +634,10 @@ export default function Home() {
                       />
                     </div>
                   ))}
-                  <div className="screenshot-box">
-                    <div className="screenshot-empty">
-                      <i className="fas fa-mobile-alt" style={{ fontSize: "4rem", color: "#cbd5e1" }}></i>
-                      <p style={{ marginTop: "20px", color: "#718096", fontWeight: 600 }}>More Screens Coming Soon</p>
-                    </div>
-                  </div>
                 </div>
                 <div className="slider-nav">
-                  <button className="nav-btn" type="button" aria-label="Previous UHealth Admin screenshot" onClick={() => handleManualSlide(adminSliderRef, -1)}><i className="fas fa-chevron-left"></i></button>
-                  <button className="nav-btn" type="button" aria-label="Next UHealth Admin screenshot" onClick={() => handleManualSlide(adminSliderRef, 1)}><i className="fas fa-chevron-right"></i></button>
+                  <button className="nav-btn" type="button" aria-label="Previous UHealth Admin screenshot" onClick={() => handleManualSlide(adminSliderRef, -1, adminScreenshots.length)}><i className="fas fa-chevron-left"></i></button>
+                  <button className="nav-btn" type="button" aria-label="Next UHealth Admin screenshot" onClick={() => handleManualSlide(adminSliderRef, 1, adminScreenshots.length)}><i className="fas fa-chevron-right"></i></button>
                 </div>
               </div>
             )}


### PR DESCRIPTION
## What problem does this solve?
Closes #2017 

The App Screenshots carousel on the landing page had a dead-end — 
clicking `›` at the last image stopped scrolling instead of wrapping 
to the first image. Clicking `‹` at the first image also stopped.

## What changed?
- Implemented infinite/circular carousel using the **clone trick**:
  - The rendered list is `[...last8 clones, ...real items, ...first8 clones]`
  - Clicking `›` at the last image smoothly scrolls into the end-clones 
    (image 1 appears from the right), then silently resets to the real position
  - Clicking `‹` at the first image works symmetrically
- Used a **scroll-event debounce** (150ms) for reliable clone-zone detection 
  across all browser speeds and screen sizes
- `CLONE_COUNT = 8` ensures the clone zone is reachable on screens up to ~2592px wide
- Also fixed a pre-existing **duplicate `Navbar` import** in `medical-glossary/page.tsx` 
  that caused a build error

## How did you test it?
- Tested on `localhost:3001` with `npm run dev`
- Verified `›` wraps seamlessly from last → first image (appears from right)
- Verified `‹` wraps seamlessly from first → last image (appears from left)
- Auto-slide also wraps correctly
- Both UltimateHealth App and UHealth Admin App carousels work

## Videos
[[attach a short screen recording of the carousel looping]](https://github.com/user-attachments/assets/9e6f2c15-23aa-44c1-ac72-7d3700280e2a)
