### PR TITLE
fix: use stable trusted user keys

### DIFF
--- a/frontend/src/components/TrustedUsersModal.tsx
+++ b/frontend/src/components/TrustedUsersModal.tsx
@@ -90,7 +90,7 @@ export default function TrustedUsersModal({
           ) : (
             <FlatList
               data={trustedUsers}
-              keyExtractor={(item, index) => item._id || String(index)}
+              keyExtractor={(item) => item._id || item.user_handle}
               renderItem={renderItem}
               contentContainerStyle={styles.listContent}
             />


### PR DESCRIPTION
#### PR Description
Fixed the unstable array index fallback used in the TrustedUsersModal FlatList keyExtractor.

Updated the keyExtractor to use 'user_handle' instead of the array index whenever '_id' is unavailable. This provides stable keys and prevents incorrect row reuse when the list changes.

Fixes #2002

Instead of using the array index as a fallback key, the component now uses 'user_handle', which provides a stable and unique key when '_id' is unavailable. This prevents incorrect row reuse when the list changes.

#### Type of Change
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update

#### Select your work-area
- [x] Frontend
- [ ] Backend
- [ ] Documentation
- [ ] Others

#### Related Issue
https://github.com/SB2318/UltimateHealth/issues/2002

#### Add your Work Example
Updated the FlatList keyExtractor to use user_handle instead of the array index as the fallback key.

#### Fixes (mention the issue number which this fixes)
Fixes #2002

#### Checklist
- [ ] I have updated my branch and synced it with the project's 'develop' branch before making this PR.
- [x] I have optimized the file changes.
- [ ] I have added a snapshot of my work example.
- [x] I have made a PR to the project's develop branch.

#### Undertaking
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have checked for plagiarism and assure its authenticity.
- [x] I have read and followed the code of conduct for this repository. I understand that violation of this undertaking may have legal consequences.

- [x] I Agree
