### PR TITLE
fix: await notification refresh before stopping loader

### DIFF
--- a/frontend/src/screens/NotificationScreen.tsx
+++ b/frontend/src/screens/NotificationScreen.tsx
@@ -104,11 +104,16 @@ const NotificationScreen = ({navigation}: any) => {
     return () => {};
   }, [notificationsData, isConnected]);
 
-  const onRefresh = () => {
-    setRefreshing(true);
-    refetch();
-    setRefreshing(false);
-  };
+  const onRefresh = async () => {
+  setRefreshing(true);
+
+  try {
+    setPage(1); // Reset pagination
+    await refetch(); // Wait until the request completes
+  } finally {
+    setRefreshing(false); // Hide spinner after refetch finishes
+  }
+};
 
   const restoreDeletedNotification = useCallback((snapshot: PendingDelete) => {
     setNotificationsData(previous => {
@@ -161,15 +166,15 @@ const NotificationScreen = ({navigation}: any) => {
   );
   
   useEffect(() => {
-    const subscription = AppState.addEventListener('change', (state: string) => {
-      if (state === 'active') {
-        setPage(1); // reset pagination
-        refetch(); // fetch fresh data
-      }
-    });
+  const subscription = AppState.addEventListener('change', async (state: string) => {
+    if (state === 'active') {
+      setPage(1);
+      await refetch();
+    }
+  });
 
-    return () => subscription.remove();
-  }, [refetch]);
+  return () => subscription.remove();
+}, [refetch]);
 
   const handleDeleteAction = useCallback(
     (item: Notification) => {


### PR DESCRIPTION
## Summary

- Made `onRefresh` asynchronous.
- Awaited `refetch()` before hiding the refresh indicator.
- Reset pagination to page 1 before refreshing.
- Moved `setRefreshing(false)` into a `finally` block so the indicator stays visible until the request completes.

Fixes #1912