### PR TITLE
[Bug] Notification preferences save can drop selected topics missing from category response (#1999)

### DIFF
--- a/README.md
+++ b/README.md
@@ -909,3 +909,4 @@ Star this repo if you find it helpful — it motivates us to keep building!
 [![Star History Chart](https://api.star-history.com/svg?repos=SB2318/UltimateHealth&type=Date)](https://star-history.com/#SB2318/UltimateHealth&Date)
 
 </div>
+# TODO: [bug] notification preferences save can drop selected topics missing from category response


### PR DESCRIPTION
Fixes #1999