### PR TITLE
fix(frontend): normalize API base URL composition to prevent malformed request endpoints

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "test": "node --no-warnings --test src/app/admin-agreement/signatureValidation.test.mjs src/app/api/csp-report/sanitizeCspReport.test.mjs src/components/articles/article-layout.test.mjs",
+    "test": "node --no-warnings --test src/app/admin-agreement/signatureValidation.test.mjs src/app/api/csp-report/sanitizeCspReport.test.mjs src/components/articles/article-layout.test.mjs src/lib/api.test.mjs",
     "lint": "eslint",
     "knip": "knip",
     "knip:deps": "knip --dependencies",

--- a/web/src/lib/api-url.mjs
+++ b/web/src/lib/api-url.mjs
@@ -1,0 +1,18 @@
+/**
+ * Build a consistent API URL from a configured base URL and request path.
+ *
+ * @param {string} baseUrl
+ * @param {string} path
+ */
+export function normalizeApiUrl(baseUrl, path) {
+  const normalizedBaseUrl = baseUrl.trim().replace(/\/+$/, "");
+  const apiBaseUrl = normalizedBaseUrl.endsWith("/api")
+    ? normalizedBaseUrl
+    : `${normalizedBaseUrl}/api`;
+  const normalizedPath = path
+    .trim()
+    .replace(/^\/+/, "")
+    .replace(/^api(?:\/+|$)/, "");
+
+  return normalizedPath ? `${apiBaseUrl}/${normalizedPath}` : apiBaseUrl;
+}

--- a/web/src/lib/api.test.mjs
+++ b/web/src/lib/api.test.mjs
@@ -1,21 +1,6 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
 import test from "node:test";
-import ts from "typescript";
-
-const source = readFileSync(new URL("./api.ts", import.meta.url), "utf8");
-const compiled = ts.transpileModule(source, {
-  compilerOptions: { module: ts.ModuleKind.CommonJS },
-}).outputText;
-const apiModule = { exports: {} };
-
-new Function("module", "exports", "process", compiled)(
-  apiModule,
-  apiModule.exports,
-  process
-);
-
-const { normalizeApiUrl } = apiModule.exports;
+import { normalizeApiUrl } from "./api-url.mjs";
 
 const baseUrls = [
   "https://example.com",

--- a/web/src/lib/api.test.mjs
+++ b/web/src/lib/api.test.mjs
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import ts from "typescript";
+
+const source = readFileSync(new URL("./api.ts", import.meta.url), "utf8");
+const compiled = ts.transpileModule(source, {
+  compilerOptions: { module: ts.ModuleKind.CommonJS },
+}).outputText;
+const apiModule = { exports: {} };
+
+new Function("module", "exports", "process", compiled)(
+  apiModule,
+  apiModule.exports,
+  process
+);
+
+const { normalizeApiUrl } = apiModule.exports;
+
+const baseUrls = [
+  "https://example.com",
+  "https://example.com/",
+  "https://example.com/api",
+  "https://example.com/api/",
+];
+const paths = ["user/login", "/user/login", "api/user/login", "/api/user/login"];
+
+test("normalizes API base URLs and request paths", () => {
+  for (const baseUrl of baseUrls) {
+    for (const path of paths) {
+      assert.equal(
+        normalizeApiUrl(baseUrl, path),
+        "https://example.com/api/user/login",
+        `${baseUrl} with ${path}`
+      );
+    }
+  }
+});
+
+test("collapses extra boundary slashes without changing nested paths", () => {
+  assert.equal(
+    normalizeApiUrl("https://example.com///", "///api///admin/login"),
+    "https://example.com/api/admin/login"
+  );
+});
+
+test("returns the API root when the request path is empty or api", () => {
+  assert.equal(normalizeApiUrl("https://example.com", ""), "https://example.com/api");
+  assert.equal(normalizeApiUrl("https://example.com/", "/api/"), "https://example.com/api");
+});

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,11 +1,21 @@
 const DEFAULT_API_BASE_URL = "https://uhsocial.in/api";
 
-export function getApiUrl(path: string) {
-  const baseUrl = (process.env.NEXT_PUBLIC_API_BASE_URL || DEFAULT_API_BASE_URL).replace(
-    /\/$/,
-    ""
-  );
-  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+export function normalizeApiUrl(baseUrl: string, path: string) {
+  const normalizedBaseUrl = baseUrl.trim().replace(/\/+$/, "");
+  const apiBaseUrl = normalizedBaseUrl.endsWith("/api")
+    ? normalizedBaseUrl
+    : `${normalizedBaseUrl}/api`;
+  const normalizedPath = path
+    .trim()
+    .replace(/^\/+/, "")
+    .replace(/^api(?:\/+|$)/, "");
 
-  return `${baseUrl}${normalizedPath}`;
+  return normalizedPath ? `${apiBaseUrl}/${normalizedPath}` : apiBaseUrl;
+}
+
+export function getApiUrl(path: string) {
+  return normalizeApiUrl(
+    process.env.NEXT_PUBLIC_API_BASE_URL || DEFAULT_API_BASE_URL,
+    path
+  );
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,17 +1,8 @@
+import { normalizeApiUrl } from "./api-url.mjs";
+
 const DEFAULT_API_BASE_URL = "https://uhsocial.in/api";
 
-export function normalizeApiUrl(baseUrl: string, path: string) {
-  const normalizedBaseUrl = baseUrl.trim().replace(/\/+$/, "");
-  const apiBaseUrl = normalizedBaseUrl.endsWith("/api")
-    ? normalizedBaseUrl
-    : `${normalizedBaseUrl}/api`;
-  const normalizedPath = path
-    .trim()
-    .replace(/^\/+/, "")
-    .replace(/^api(?:\/+|$)/, "");
-
-  return normalizedPath ? `${apiBaseUrl}/${normalizedPath}` : apiBaseUrl;
-}
+export { normalizeApiUrl };
 
 export function getApiUrl(path: string) {
   return normalizeApiUrl(


### PR DESCRIPTION
## 📌 Related Issue
Closes #2050

## 📝 Description

This PR fixes inconsistent API URL composition in the frontend API client.

Previously, request URLs were generated using direct string concatenation between `NEXT_PUBLIC_API_BASE_URL` and the request path. Depending on the environment configuration and the supplied endpoint, this could generate malformed URLs such as:

- Duplicate `/api` segments (`/api/api/...`)
- Missing path separators
- Incorrect endpoints when the base URL contained or omitted a trailing slash
- Authentication and other API requests silently targeting unintended routes

## ✅ Changes Made

- Added URL normalization before constructing request URLs.
- Handled trailing slashes in `NEXT_PUBLIC_API_BASE_URL`.
- Normalized endpoint paths with or without leading slashes.
- Prevented duplicate `/api` path segments.
- Ensured consistent URL generation across different environment configurations.

## 🧪 Testing

Tested the following scenarios:

- ✅ Base URL with `/api`
- ✅ Base URL without `/api`
- ✅ Base URL with trailing slash
- ✅ Base URL without trailing slash
- ✅ Request paths with leading slash
- ✅ Request paths without leading slash

Verified that all requests resolve to the expected API endpoint.

## Checklist

- [x] Code follows the project's coding style
- [x] Existing functionality remains unaffected
- [x] Tested locally
- [x] Linked the related issue