### PR TITLE
test: add coverage for reading analytics hooks

### DIFF
--- a/frontend/src/hooks/__tests__/useGetMonthlyReadReport.test.ts
+++ b/frontend/src/hooks/__tests__/useGetMonthlyReadReport.test.ts
@@ -1,8 +1,16 @@
-import {renderHook} from '@testing-library/react-native';
-import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
 
-import {useGetAuthorMonthlyReadReport} from '../useGetMonthlyReadReport';
+import { useGetAuthorMonthlyReadReport } from '../useGetMonthlyReadReport';
+
+import axios from 'axios';
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+beforeEach(() => {
+  mockedAxios.get.mockClear();
+});
 
 jest.mock('axios', () => ({
   get: jest.fn(),
@@ -15,14 +23,14 @@ jest.mock('react-redux', () => ({
 function makeWrapper() {
   const queryClient = new QueryClient({
     defaultOptions: {
-      queries: {retry: false},
+      queries: { retry: false },
     },
   });
 
-  function QueryWrapper({children}: {children: React.ReactNode}) {
+  function QueryWrapper({ children }: { children: React.ReactNode }) {
     return React.createElement(
       QueryClientProvider,
-      {client: queryClient},
+      { client: queryClient },
       children,
     );
   }
@@ -32,7 +40,7 @@ function makeWrapper() {
 
 describe('useGetAuthorMonthlyReadReport', () => {
   it('renders successfully', () => {
-    const {result} = renderHook(
+    const { result } = renderHook(
       () =>
         useGetAuthorMonthlyReadReport({
           user_id: 'user-1',
@@ -48,7 +56,7 @@ describe('useGetAuthorMonthlyReadReport', () => {
   });
 
   it('handles selectedMonth = -1', () => {
-    const {result} = renderHook(
+    const { result } = renderHook(
       () =>
         useGetAuthorMonthlyReadReport({
           user_id: 'user-1',
@@ -61,5 +69,57 @@ describe('useGetAuthorMonthlyReadReport', () => {
     );
 
     expect(result.current).toBeDefined();
+  });
+  it('returns monthly read report data', async () => {
+    mockedAxios.get.mockResolvedValueOnce({
+      data: {
+        monthlyReads: [
+          {
+            date: '2026-07-01',
+            value: 12,
+          },
+        ],
+      },
+    });
+
+    const { result } = renderHook(
+      () =>
+        useGetAuthorMonthlyReadReport({
+          user_id: 'user-1',
+          selectedMonth: 7,
+          isConnected: true,
+        }),
+      {
+        wrapper: makeWrapper(),
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toEqual([
+      {
+        date: '2026-07-01',
+        value: 12,
+      },
+    ]);
+
+    expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+  });
+  it('does not fetch when selectedMonth is -1', () => {
+    renderHook(
+      () =>
+        useGetAuthorMonthlyReadReport({
+          user_id: 'user-1',
+          selectedMonth: -1,
+          isConnected: true,
+        }),
+      {
+        wrapper: makeWrapper(),
+      },
+    );
+
+    expect(mockedAxios.get).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/hooks/__tests__/useGetMonthlyReadReport.test.ts
+++ b/frontend/src/hooks/__tests__/useGetMonthlyReadReport.test.ts
@@ -1,0 +1,65 @@
+import {renderHook} from '@testing-library/react-native';
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import React from 'react';
+
+import {useGetAuthorMonthlyReadReport} from '../useGetMonthlyReadReport';
+
+jest.mock('axios', () => ({
+  get: jest.fn(),
+}));
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(() => false),
+}));
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {retry: false},
+    },
+  });
+
+  function QueryWrapper({children}: {children: React.ReactNode}) {
+    return React.createElement(
+      QueryClientProvider,
+      {client: queryClient},
+      children,
+    );
+  }
+
+  return QueryWrapper;
+}
+
+describe('useGetAuthorMonthlyReadReport', () => {
+  it('renders successfully', () => {
+    const {result} = renderHook(
+      () =>
+        useGetAuthorMonthlyReadReport({
+          user_id: 'user-1',
+          selectedMonth: 6,
+          isConnected: true,
+        }),
+      {
+        wrapper: makeWrapper(),
+      },
+    );
+
+    expect(result.current).toBeDefined();
+  });
+
+  it('handles selectedMonth = -1', () => {
+    const {result} = renderHook(
+      () =>
+        useGetAuthorMonthlyReadReport({
+          user_id: 'user-1',
+          selectedMonth: -1,
+          isConnected: true,
+        }),
+      {
+        wrapper: makeWrapper(),
+      },
+    );
+
+    expect(result.current).toBeDefined();
+  });
+});

--- a/frontend/src/hooks/__tests__/useGetTotalLikeViewStatus.test.ts
+++ b/frontend/src/hooks/__tests__/useGetTotalLikeViewStatus.test.ts
@@ -1,0 +1,65 @@
+import {renderHook, waitFor} from '@testing-library/react-native';
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import React from 'react';
+
+import {useGetTotalLikeViewStatus} from '../useGetTotalLikeViewStatus';
+
+jest.mock('axios', () => ({
+  get: jest.fn(),
+}));
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(() => false),
+}));
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {retry: false},
+    },
+  });
+
+  function QueryWrapper({children}: {children: React.ReactNode}) {
+    return React.createElement(
+      QueryClientProvider,
+      {client: queryClient},
+      children,
+    );
+  }
+
+  return QueryWrapper;
+}
+
+describe('useGetTotalLikeViewStatus', () => {
+  it('renders successfully', () => {
+    const {result} = renderHook(
+      () =>
+        useGetTotalLikeViewStatus({
+          user_id: 'user-1',
+          isConnected: true,
+        }),
+      {
+        wrapper: makeWrapper(),
+      },
+    );
+
+    expect(result.current).toBeDefined();
+  });
+
+  it('returns a query result object', async () => {
+    const {result} = renderHook(
+      () =>
+        useGetTotalLikeViewStatus({
+          user_id: 'user-1',
+          isConnected: true,
+        }),
+      {
+        wrapper: makeWrapper(),
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.status).toBeDefined();
+    });
+  });
+});

--- a/frontend/src/hooks/__tests__/useGetTotalLikeViewStatus.test.ts
+++ b/frontend/src/hooks/__tests__/useGetTotalLikeViewStatus.test.ts
@@ -1,8 +1,17 @@
-import {renderHook, waitFor} from '@testing-library/react-native';
-import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
 
-import {useGetTotalLikeViewStatus} from '../useGetTotalLikeViewStatus';
+import { useGetTotalLikeViewStatus } from '../useGetTotalLikeViewStatus';
+
+import axios from 'axios';
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+beforeEach(() => {
+  mockedAxios.get.mockClear();
+});
+
+
 
 jest.mock('axios', () => ({
   get: jest.fn(),
@@ -15,14 +24,14 @@ jest.mock('react-redux', () => ({
 function makeWrapper() {
   const queryClient = new QueryClient({
     defaultOptions: {
-      queries: {retry: false},
+      queries: { retry: false },
     },
   });
 
-  function QueryWrapper({children}: {children: React.ReactNode}) {
+  function QueryWrapper({ children }: { children: React.ReactNode }) {
     return React.createElement(
       QueryClientProvider,
-      {client: queryClient},
+      { client: queryClient },
       children,
     );
   }
@@ -32,7 +41,7 @@ function makeWrapper() {
 
 describe('useGetTotalLikeViewStatus', () => {
   it('renders successfully', () => {
-    const {result} = renderHook(
+    const { result } = renderHook(
       () =>
         useGetTotalLikeViewStatus({
           user_id: 'user-1',
@@ -47,7 +56,7 @@ describe('useGetTotalLikeViewStatus', () => {
   });
 
   it('returns a query result object', async () => {
-    const {result} = renderHook(
+    const { result } = renderHook(
       () =>
         useGetTotalLikeViewStatus({
           user_id: 'user-1',
@@ -61,5 +70,49 @@ describe('useGetTotalLikeViewStatus', () => {
     await waitFor(() => {
       expect(result.current.status).toBeDefined();
     });
+  });
+  it('returns data from the API', async () => {
+    mockedAxios.get.mockResolvedValueOnce({
+      data: {
+        totalLikes: 10,
+        totalViews: 100,
+        likeProgress: 25,
+        viewProgress: 50,
+      },
+    });
+
+    const { result } = renderHook(
+      () =>
+        useGetTotalLikeViewStatus({
+          user_id: 'user-1',
+          isConnected: true,
+        }),
+      { wrapper: makeWrapper() },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toEqual({
+      totalLikes: 10,
+      totalViews: 100,
+      likeProgress: 25,
+      viewProgress: 50,
+    });
+
+    expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+  });
+  it('does not fetch when disconnected', () => {
+    renderHook(
+      () =>
+        useGetTotalLikeViewStatus({
+          user_id: 'user-1',
+          isConnected: false,
+        }),
+      { wrapper: makeWrapper() },
+    );
+
+    expect(mockedAxios.get).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/hooks/__tests__/useGetTotalReads.test.ts
+++ b/frontend/src/hooks/__tests__/useGetTotalReads.test.ts
@@ -1,0 +1,65 @@
+import {renderHook, waitFor} from '@testing-library/react-native';
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import React from 'react';
+
+import {useGetTotalReads} from '../useGetTotalReads';
+
+jest.mock('axios', () => ({
+  get: jest.fn(),
+}));
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(() => false),
+}));
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {retry: false},
+    },
+  });
+
+  function QueryWrapper({children}: {children: React.ReactNode}) {
+    return React.createElement(
+      QueryClientProvider,
+      {client: queryClient},
+      children,
+    );
+  }
+
+  return QueryWrapper;
+}
+
+describe('useGetTotalReads', () => {
+  it('renders successfully', () => {
+    const {result} = renderHook(
+      () =>
+        useGetTotalReads({
+          user_id: 'user-1',
+          isConnected: true,
+        }),
+      {
+        wrapper: makeWrapper(),
+      },
+    );
+
+    expect(result.current).toBeDefined();
+  });
+
+  it('returns a query result object', async () => {
+  const {result} = renderHook(
+    () =>
+      useGetTotalReads({
+        user_id: 'user-1',
+        isConnected: true,
+      }),
+    {
+      wrapper: makeWrapper(),
+    },
+  );
+
+  await waitFor(() => {
+    expect(result.current.status).toBeDefined();
+  });
+});
+});

--- a/frontend/src/hooks/__tests__/useGetTotalReads.test.ts
+++ b/frontend/src/hooks/__tests__/useGetTotalReads.test.ts
@@ -1,12 +1,19 @@
-import {renderHook, waitFor} from '@testing-library/react-native';
-import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
 
-import {useGetTotalReads} from '../useGetTotalReads';
+import { useGetTotalReads } from '../useGetTotalReads';
+
+import axios from 'axios';
 
 jest.mock('axios', () => ({
   get: jest.fn(),
 }));
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+beforeEach(() => {
+  mockedAxios.get.mockClear();
+});
 
 jest.mock('react-redux', () => ({
   useSelector: jest.fn(() => false),
@@ -15,14 +22,14 @@ jest.mock('react-redux', () => ({
 function makeWrapper() {
   const queryClient = new QueryClient({
     defaultOptions: {
-      queries: {retry: false},
+      queries: { retry: false },
     },
   });
 
-  function QueryWrapper({children}: {children: React.ReactNode}) {
+  function QueryWrapper({ children }: { children: React.ReactNode }) {
     return React.createElement(
       QueryClientProvider,
-      {client: queryClient},
+      { client: queryClient },
       children,
     );
   }
@@ -32,7 +39,7 @@ function makeWrapper() {
 
 describe('useGetTotalReads', () => {
   it('renders successfully', () => {
-    const {result} = renderHook(
+    const { result } = renderHook(
       () =>
         useGetTotalReads({
           user_id: 'user-1',
@@ -47,19 +54,63 @@ describe('useGetTotalReads', () => {
   });
 
   it('returns a query result object', async () => {
-  const {result} = renderHook(
-    () =>
-      useGetTotalReads({
-        user_id: 'user-1',
-        isConnected: true,
-      }),
-    {
-      wrapper: makeWrapper(),
-    },
-  );
+    const { result } = renderHook(
+      () =>
+        useGetTotalReads({
+          user_id: 'user-1',
+          isConnected: true,
+        }),
+      {
+        wrapper: makeWrapper(),
+      },
+    );
 
-  await waitFor(() => {
-    expect(result.current.status).toBeDefined();
+    await waitFor(() => {
+      expect(result.current.status).toBeDefined();
+    });
   });
-});
+  it('returns data from the API', async () => {
+    mockedAxios.get.mockResolvedValueOnce({
+      data: {
+        totalReads: 50,
+        progress: 80,
+      },
+    });
+
+    const { result } = renderHook(
+      () =>
+        useGetTotalReads({
+          user_id: 'user-1',
+          isConnected: true,
+        }),
+      {
+        wrapper: makeWrapper(),
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toEqual({
+      totalReads: 50,
+      progress: 80,
+    });
+
+    expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+  });
+  it('does not fetch when disconnected', () => {
+    renderHook(
+      () =>
+        useGetTotalReads({
+          user_id: 'user-1',
+          isConnected: false,
+        }),
+      {
+        wrapper: makeWrapper(),
+      },
+    );
+
+    expect(mockedAxios.get).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/src/hooks/__tests__/useGetYearlyReadReport.test.ts
+++ b/frontend/src/hooks/__tests__/useGetYearlyReadReport.test.ts
@@ -1,0 +1,65 @@
+import {renderHook} from '@testing-library/react-native';
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import React from 'react';
+
+import {useGetAuthorYearlyReadReport} from '../useGetYearlyReadReport';
+
+jest.mock('axios', () => ({
+  get: jest.fn(),
+}));
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(() => false),
+}));
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {retry: false},
+    },
+  });
+
+  function QueryWrapper({children}: {children: React.ReactNode}) {
+    return React.createElement(
+      QueryClientProvider,
+      {client: queryClient},
+      children,
+    );
+  }
+
+  return QueryWrapper;
+}
+
+describe('useGetAuthorYearlyReadReport', () => {
+  it('renders successfully', () => {
+    const {result} = renderHook(
+      () =>
+        useGetAuthorYearlyReadReport({
+          user_id: 'user-1',
+          selectedYear: 2023,
+          isConnected: true,
+        }),
+      {
+        wrapper: makeWrapper(),
+      },
+    );
+
+    expect(result.current).toBeDefined();
+  });
+
+  it('handles selectedYear = -1', () => {
+    const {result} = renderHook(
+      () =>
+        useGetAuthorYearlyReadReport({
+          user_id: 'user-1',
+          selectedYear: -1,
+          isConnected: true,
+        }),
+      {
+        wrapper: makeWrapper(),
+      },
+    );
+
+    expect(result.current).toBeDefined();
+  });
+});

--- a/frontend/src/hooks/__tests__/useGetYearlyReadReport.test.ts
+++ b/frontend/src/hooks/__tests__/useGetYearlyReadReport.test.ts
@@ -1,8 +1,16 @@
-import {renderHook} from '@testing-library/react-native';
-import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
 
-import {useGetAuthorYearlyReadReport} from '../useGetYearlyReadReport';
+import { useGetAuthorYearlyReadReport } from '../useGetYearlyReadReport';
+
+import axios from 'axios';
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+beforeEach(() => {
+  mockedAxios.get.mockClear();
+});
 
 jest.mock('axios', () => ({
   get: jest.fn(),
@@ -15,14 +23,14 @@ jest.mock('react-redux', () => ({
 function makeWrapper() {
   const queryClient = new QueryClient({
     defaultOptions: {
-      queries: {retry: false},
+      queries: { retry: false },
     },
   });
 
-  function QueryWrapper({children}: {children: React.ReactNode}) {
+  function QueryWrapper({ children }: { children: React.ReactNode }) {
     return React.createElement(
       QueryClientProvider,
-      {client: queryClient},
+      { client: queryClient },
       children,
     );
   }
@@ -32,7 +40,7 @@ function makeWrapper() {
 
 describe('useGetAuthorYearlyReadReport', () => {
   it('renders successfully', () => {
-    const {result} = renderHook(
+    const { result } = renderHook(
       () =>
         useGetAuthorYearlyReadReport({
           user_id: 'user-1',
@@ -48,7 +56,7 @@ describe('useGetAuthorYearlyReadReport', () => {
   });
 
   it('handles selectedYear = -1', () => {
-    const {result} = renderHook(
+    const { result } = renderHook(
       () =>
         useGetAuthorYearlyReadReport({
           user_id: 'user-1',
@@ -62,4 +70,73 @@ describe('useGetAuthorYearlyReadReport', () => {
 
     expect(result.current).toBeDefined();
   });
+  it('returns yearly read report data', async () => {
+    mockedAxios.get.mockResolvedValueOnce({
+      data: {
+        yearlyReads: [
+          {
+            month: 'January',
+            value: 25,
+          },
+        ],
+      },
+    });
+
+    const { result } = renderHook(
+      () =>
+        useGetAuthorYearlyReadReport({
+          user_id: 'user-1',
+          selectedYear: 2026,
+          isConnected: true,
+        }),
+      {
+        wrapper: makeWrapper(),
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toEqual([
+      {
+        month: 'January',
+        value: 25,
+      },
+    ]);
+
+    expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+  });
+  it('does not fetch when selectedYear is -1', () => {
+    renderHook(
+      () =>
+        useGetAuthorYearlyReadReport({
+          user_id: 'user-1',
+          selectedYear: -1,
+          isConnected: true,
+        }),
+      {
+        wrapper: makeWrapper(),
+      },
+    );
+
+    expect(mockedAxios.get).not.toHaveBeenCalled();
+  });
+
+  it('does not fetch when disconnected', () => {
+    renderHook(
+      () =>
+        useGetAuthorYearlyReadReport({
+          user_id: 'user-1',
+          selectedYear: 2026,
+          isConnected: false,
+        }),
+      {
+        wrapper: makeWrapper(),
+      },
+    );
+
+    expect(mockedAxios.get).not.toHaveBeenCalled();
+  });
+
 });


### PR DESCRIPTION
#### PR Description

This PR adds automated test coverage for the reading analytics hooks used throughout the analytics dashboard.

### Changes Made
- Added tests for `useGetTotalReads`
- Added tests for `useGetTotalLikeViewStatus`
- Added tests for `useGetMonthlyReadReport`
- Added tests for `useGetYearlyReadReport`
- Followed the existing hook testing pattern already used in the repository
- Verified successful execution of all newly added test cases

These tests help improve reliability of analytics-related functionality and provide a foundation for detecting regressions in future updates.

#### Type of Change
- [x] New Feature (Change which adds functionality)

#### Select your work-area
- [x] Frontend

#### Related Issue

Issue assigned by maintainer regarding testing and validation of reading analytics functionality.

#### Add your Work Example

📷 Attached screenshots showing all analytics hook tests passing successfully.
<img width="1086" height="922" alt="Screenshot 2026-07-08 223256" src="https://github.com/user-attachments/assets/c6e5dfea-b1c7-42d4-92d5-b5130264068f" />
<img width="1006" height="242" alt="Screenshot 2026-07-08 223554" src="https://github.com/user-attachments/assets/51181bd6-e249-483d-97c9-b8494b9f9f5e" />


#### Fixes (mention the issue number which this fixes)

#closes #2093 

#### Checklist

- [x] I have updated my branch and synced it with the project's 'develop' branch before making this PR.
- [x] I have optimized the file changes.
- [x] I have added a snapshot of my work example.
- [x] I have made a PR to the project's develop branch.

#### Undertaking

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have checked for plagiarism and assure its authenticity.
- [x] I have read and followed the code of conduct for this repository. I understand that violation of this undertaking may have legal consequences.

- [x] I Agree
