### PR TITLE
chore: clean OpenSourcePage imports

### DIFF
--- a/frontend/src/screens/OpenSourcePage.tsx
+++ b/frontend/src/screens/OpenSourcePage.tsx
@@ -1,15 +1,14 @@
 import React from 'react';
 import { ScrollView, Image, Linking } from 'react-native';
 import { safeOpenUrl } from '../utils/safeOpenUrl';
-import { 
-  YStack, 
-  XStack, 
-  Text, 
-  Card, 
+import {
+  YStack,
+  XStack,
+  Text,
+  Card,
   H3,
   Separator,
-  Theme, 
- 
+  Theme,
   Paragraph,
   Button
 } from 'tamagui';


### PR DESCRIPTION
Closes #2130

## Summary
- Remove blank and trailing whitespace from the Tamagui import block in OpenSourcePage.tsx.
- Keep all existing imports and behavior unchanged.

## Validation
- pnpm exec eslint src/screens/OpenSourcePage.tsx
- git diff --check
- Full type-check/lint attempted; the repository has unrelated pre-existing syntax errors in other files.