### PR TITLE
fix: protect CommentScreen input from Android navigation bar

### DIFF
--- a/frontend/src/screens/CommentScreen.tsx
+++ b/frontend/src/screens/CommentScreen.tsx
@@ -485,7 +485,7 @@ const CommentScreen = ({
 
   return (
     <ErrorBoundary onRetry={fetchComments}>
-    <SafeAreaView style={styles.safeArea}>
+    <SafeAreaView style={styles.safeArea} edges={['top']}>
       <KeyboardAvoidingView
         style={{flex: 1}}
         behavior={
@@ -577,6 +577,7 @@ const CommentScreen = ({
                 })}
 
                 {/* Comment input */}
+                <SafeAreaView edges={['bottom']}>
                 <TextInput
                   {...textInputProps}
                   style={styles.textInput}
@@ -621,6 +622,7 @@ const CommentScreen = ({
                     </Text>
                   </TouchableOpacity>
                 </XStack>
+                </SafeAreaView>
 
                 <View
                   style={

--- a/frontend/src/screens/CommentScreen.tsx
+++ b/frontend/src/screens/CommentScreen.tsx
@@ -58,9 +58,7 @@ const CommentScreen = ({
   const flatListRef =
     useRef<any>(null);
 
-  const [comments, setComments] = useState
-    Comment[]
-  >([]);
+  const [comments, setComments] = useState<Comment[]>([]);
   const MAX_COMMENT_LENGTH = 500;
   const [newComment, setNewComment] =
     useState('');
@@ -110,15 +108,11 @@ const CommentScreen = ({
     setCommentLikeLoading,
   ] = useState<boolean>(false);
 
-  const [mentions, setMentions] = useState
-    User[]
-  >([]);
+  const [mentions, setMentions] = useState<User[]>([]);
 
   const dispatch = useDispatch();
 
-  const triggersConfig: TriggersConfig
-    'mention' | 'hashtag'
-  > = {
+  const triggersConfig: TriggersConfig<'mention' | 'hashtag'> = {
     mention: {
       trigger: '@',
       textStyle: {


### PR DESCRIPTION
Closes #2129

## Summary
- apply the top safe-area inset to the screen container
- apply the bottom safe-area inset directly to the comment input and submit controls

## Validation
- git diff --check passed
- ESLint/Jest binaries were unavailable in the isolated checkout; no test result is claimed.