### PR TITLE
fix: add dark theme support to article headers

### DIFF
--- a/frontend/src/components/ArticleCard.tsx
+++ b/frontend/src/components/ArticleCard.tsx
@@ -7,6 +7,7 @@ import {
   Pressable,
   Alert,
   Platform,
+  useColorScheme,
 } from 'react-native';
 import {useEffect, useRef, useState} from 'react';
 import AccessibleTouchable from './common/AccessibleTouchable';
@@ -65,6 +66,15 @@ const ArticleCard = ({
 }: ArticleCardProps) => {
   const {user_id, user_handle, isGuest} = useSelector((state: any) => state.user || {});
   const {isConnected} = useSelector((state: any) => state.network || {});
+  const isDarkMode = useColorScheme() === 'dark';
+  const themeColors = {
+    surface: isDarkMode ? '#1F2937' : '#FFFFFF',
+    text: isDarkMode ? '#F3F4F6' : '#121212',
+    secondaryText: isDarkMode ? '#D1D5DB' : '#7A869A',
+    mutedText: isDarkMode ? '#9CA3AF' : '#414A4C',
+    border: isDarkMode ? '#374151' : '#F0F0F0',
+    icon: isDarkMode ? '#D1D5DB' : '#414A4C',
+  };
   const readTime = calculateReadTime(item.content || item.body || '');
   const socket = useSocket();
   const width = useSharedValue(0);
@@ -108,6 +118,7 @@ const ArticleCard = ({
     score: 78,
     level: 'Beginner Friendly' as 'Beginner Friendly' | 'Intermediate' | 'Advanced',
     approved: true,
+  };
   const heartScale = useSharedValue(0);
 
   const heartStyle = useAnimatedStyle(() => {
@@ -422,7 +433,7 @@ const ArticleCard = ({
     accessibilityLabel={`Open article ${item?.title}`}
     accessibilityHint="Opens full article"
     onPress={handleCardPress}>
-      <View style={styles.cardContainer}>
+      <View style={[styles.cardContainer, {backgroundColor: themeColors.surface}]}>
         {/* Image Section */}
 <Pressable onPress={handleImagePress} style={styles.imageWrapper}>
   <ImageFallback
@@ -531,58 +542,58 @@ const ArticleCard = ({
             )}
             <ReadingDifficulty difficulty={getArticleDifficulty(item)} />
           </View>
-          <Text style={styles.title} numberOfLines={2} ellipsizeMode="tail">{item?.title}</Text>
+          <Text style={[styles.title, {color: themeColors.text}]} numberOfLines={2} ellipsizeMode="tail">{item?.title}</Text>
 
 
           {/* Readability & Accessibility indicators (mock data, issue #845) */}
           <View style={styles.readabilityRow}>
-            <View style={styles.readabilityBadge}>
-              <Text style={styles.readabilityBadgeText}>
+            <View style={[styles.readabilityBadge, {backgroundColor: isDarkMode ? '#14532D' : '#E8F5E9'}]}>
+              <Text style={[styles.readabilityBadgeText, {color: isDarkMode ? '#BBF7D0' : '#2E7D32'}]}>
                 {mockReadability.level}
               </Text>
             </View>
-            <View style={styles.scoreBadge}>
-              <Text style={styles.scoreBadgeText}>
+            <View style={[styles.scoreBadge, {backgroundColor: isDarkMode ? '#1E3A5F' : '#E3F2FD'}]}>
+              <Text style={[styles.scoreBadgeText, {color: isDarkMode ? '#BFDBFE' : '#1565C0'}]}>
                 Score: {mockReadability.score}
               </Text>
             </View>
             <View
               style={[
                 styles.statusChip,
-                mockReadability.approved
-                  ? styles.approvedChip
-                  : styles.needsImprovementChip,
+                {backgroundColor: isDarkMode
+                  ? (mockReadability.approved ? '#14532D' : '#78350F')
+                  : (mockReadability.approved ? '#E8F5E9' : '#FFF3E0')},
               ]}>
-              <Text style={styles.statusChipText}>
+              <Text style={[styles.statusChipText, {color: isDarkMode ? '#E5E7EB' : '#424242'}]}>
                 {mockReadability.approved ? 'Approved' : 'Needs Improvement'}
               </Text>
             </View>
           </View>
 
           <View style={styles.metaRow}>
-  <Text style={styles.footerText1}>{item?.authorName}</Text>
-  <Text style={styles.dot}>•</Text>
-  <Text style={styles.footerText1}>
+  <Text style={[styles.footerText1, {color: themeColors.secondaryText}]}>{item?.authorName}</Text>
+  <Text style={[styles.dot, {color: themeColors.mutedText}]}>•</Text>
+  <Text style={[styles.footerText1, {color: themeColors.secondaryText}]}>
     {formatCount(item?.viewCount || 0)} views
   </Text>
-  <Text style={styles.dot}>•</Text>
-  <Text style={styles.footerText1}>
+  <Text style={[styles.dot, {color: themeColors.mutedText}]}>•</Text>
+  <Text style={[styles.footerText1, {color: themeColors.secondaryText}]}>
     {formatDateShort(item?.lastUpdated)}
   </Text>
-  <Text style={styles.dot}>•</Text>
-  <Text style={styles.footerText1}>
+  <Text style={[styles.dot, {color: themeColors.mutedText}]}>•</Text>
+  <Text style={[styles.footerText1, {color: themeColors.secondaryText}]}>
     {getReadTime(item?.title + ' ' + (item?.description || ''))}
   </Text>
   {(item?.trustUsers?.length ?? 0) > 0 && (
     <>
-      <Text style={styles.dot}>•</Text>
-      <Text style={styles.footerText1}>
+      <Text style={[styles.dot, {color: themeColors.mutedText}]}>•</Text>
+      <Text style={[styles.footerText1, {color: themeColors.secondaryText}]}>
         🛡️ Trusted by {formatCount(item?.trustUsers?.length ?? 0)}
       </Text>
     </>
   )}
 </View>
-          <Text style={styles.readTime}>{readTime} min read</Text>
+          <Text style={[styles.readTime, {color: themeColors.secondaryText}]}>{readTime} min read</Text>
           <EditRequestModal
             visible={requestModalVisible}
             callback={(reason: string) => {
@@ -596,7 +607,7 @@ const ArticleCard = ({
           />
 
           {/* Like, Save, and Comment Actions */}
-          <View style={styles.likeSaveContainer}>
+          <View style={[styles.likeSaveContainer, {borderTopColor: themeColors.border}]}>
             {likeMutationPending ? (
               <LoadingSpinner size="small" />
             ) : (
@@ -667,14 +678,14 @@ const ArticleCard = ({
                 {isLiked ? (
                   <AntDesign name="heart" size={24} color={PRIMARY_COLOR} />
                 ) : (
-                  <FontAwesome name="heart-o" size={24} color={'black'} />
+                  <FontAwesome name="heart-o" size={24} color={themeColors.icon} />
                 )}
                 <Text
                   style={{
                     ...styles.title,
                     marginStart: 3,
                     fontWeight: '500',
-                    color: 'black',
+                    color: themeColors.text,
                   }}>
                   {formatCount(likeCount)}
                 </Text>
@@ -703,7 +714,7 @@ const ArticleCard = ({
                 });
               }}
               style={styles.likeSaveChildContainer}>
-              <FontAwesome name="commenting" size={27} color={'#414A4C'} />
+              <FontAwesome name="commenting" size={27} color={themeColors.icon} />
             </AccessibleTouchable>
 
             {source === 'home' && (
@@ -722,14 +733,14 @@ const ArticleCard = ({
                     <FontAwesome6
                       name="arrows-rotate"
                       size={24}
-                      color={!reposted ? '#414A4C' : PRIMARY_COLOR}
+                      color={!reposted ? themeColors.icon : PRIMARY_COLOR}
                     />
                     <Text
                       style={{
                         ...styles.title,
                         fontWeight: '500',
                         marginStart: 3,
-                        color: 'black',
+                        color: themeColors.text,
                       }}>
                       {formatCount(repostCount)}
                     </Text>
@@ -747,7 +758,7 @@ const ArticleCard = ({
                   handleShare();
                 }}
                 style={styles.likeSaveChildContainer}>
-                <FontAwesome name="share-alt" size={24} color={'#414A4C'} />
+                <FontAwesome name="share-alt" size={24} color={themeColors.icon} />
               </AccessibleTouchable>
             )}
 
@@ -800,7 +811,7 @@ const ArticleCard = ({
                   <IonIcons
                     name="bookmark-outline"
                     size={24}
-                    color={'#414A4C'}
+                    color={themeColors.icon}
                   />
                 )}
               </AccessibleTouchable>
@@ -826,7 +837,7 @@ const ArticleCard = ({
                 <Entypo
                   name="dots-three-vertical"
                   size={20}
-                  color={'#414A4C'}
+                  color={themeColors.icon}
                 />
               </AccessibleTouchable>
             )}
@@ -1146,4 +1157,3 @@ const styles = StyleSheet.create({
 
 });
 */
-

--- a/frontend/src/components/HeaderRightMenu.tsx
+++ b/frontend/src/components/HeaderRightMenu.tsx
@@ -1,4 +1,5 @@
 import {useNavigation} from '@react-navigation/native';
+import {useColorScheme} from 'react-native';
 import {useCallback, useRef, useState} from 'react';
 import {StackNavigationProp} from '@react-navigation/stack';
 import {useDispatch, useSelector} from 'react-redux';
@@ -16,7 +17,6 @@ import {
   Text,
 } from 'tamagui';
 import {Feather, FontAwesome, MaterialCommunityIcons} from '@expo/vector-icons';
-import {ON_PRIMARY_COLOR} from '../helper/Theme';
 import {SafeAreaView} from 'react-native-safe-area-context';
 import {useFilterPodcasts} from '../hooks/useFilterPodcasts';
 
@@ -25,6 +25,11 @@ interface Props {
 }
 
 const HeaderRightMenu = ({onClick}: Props) => {
+  const isDarkMode = useColorScheme() === 'dark';
+  const surface = isDarkMode ? '#1F2937' : '#FFFFFF';
+  const text = isDarkMode ? '#F9FAFB' : '#333333';
+  const mutedText = isDarkMode ? '#D1D5DB' : '#555555';
+  const hoverSurface = isDarkMode ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.05)';
   const navigation = useNavigation<StackNavigationProp<RootStackParamList>>();
   const [menuOpen, setMenuOpen] = useState(false);
   const [sortingType, setSortingType] = useState<string>('');
@@ -76,8 +81,8 @@ const HeaderRightMenu = ({onClick}: Props) => {
         <Button
           size="$5"
           circular
-          backgroundColor={ON_PRIMARY_COLOR}
-          icon={<Feather name="search" size={20} color="#333" />}
+          backgroundColor={surface}
+          icon={<Feather name="search" size={20} color={text} />}
           onPress={onClick}
           pressStyle={{opacity: 0.7}}
         />
@@ -88,12 +93,12 @@ const HeaderRightMenu = ({onClick}: Props) => {
             <Button
               size="$5"
               circular
-              backgroundColor={ON_PRIMARY_COLOR}
+              backgroundColor={surface}
               icon={
                 <MaterialCommunityIcons
                   name="dots-vertical"
                   size={20}
-                  color="#333"
+                  color={text}
                 />
               }
               pressStyle={{opacity: 0.7}}
@@ -101,7 +106,7 @@ const HeaderRightMenu = ({onClick}: Props) => {
           </Popover.Trigger>
 
           <Popover.Content
-            backgroundColor={ON_PRIMARY_COLOR}
+            backgroundColor={surface}
             borderRadius="$4"
             elevation="$3"
             padding="$1"
@@ -115,7 +120,7 @@ const HeaderRightMenu = ({onClick}: Props) => {
                 paddingVertical="$2"
                 paddingHorizontal="$2"
                 borderRadius="$4"
-                hoverStyle={{backgroundColor: 'rgba(0,0,0,0.05)'}}
+                hoverStyle={{backgroundColor: hoverSurface}}
                 pressStyle={{opacity: 0.8}}
                 onPress={() => {
                   setMenuOpen(false);
@@ -130,10 +135,10 @@ const HeaderRightMenu = ({onClick}: Props) => {
                   }
                   navigation.navigate('PodcastProfile');
                 }}>
-                <Text fontSize={15} color="#333">
+                <Text fontSize={15} color={text}>
                   Profile
                 </Text>
-                <FontAwesome name="user" size={17} color="#555" />
+                <FontAwesome name="user" size={17} color={mutedText} />
               </XStack>
 
               {/* Menu Row: Downloads */}
@@ -143,7 +148,7 @@ const HeaderRightMenu = ({onClick}: Props) => {
                 paddingVertical="$2"
                 paddingHorizontal="$1"
                 borderRadius="$4"
-                hoverStyle={{backgroundColor: 'rgba(0,0,0,0.05)'}}
+                hoverStyle={{backgroundColor: hoverSurface}}
                 pressStyle={{opacity: 0.8}}
                 onPress={() => {
                   setMenuOpen(false);
@@ -157,10 +162,10 @@ const HeaderRightMenu = ({onClick}: Props) => {
                   }
                   navigation.navigate('OfflinePodcastList');
                 }}>
-                <Text fontSize={15} color="#333">
+                <Text fontSize={15} color={text}>
                   Downloads
                 </Text>
-                <Feather name="download" size={17} color="#555" />
+                <Feather name="download" size={17} color={mutedText} />
               </XStack>
 
               <Separator marginVertical="$1" />
@@ -172,13 +177,13 @@ const HeaderRightMenu = ({onClick}: Props) => {
                 paddingVertical="$3"
                 paddingHorizontal="$3"
                 borderRadius="$4"
-                hoverStyle={{backgroundColor: 'rgba(0,0,0,0.05)'}}
+                hoverStyle={{backgroundColor: hoverSurface}}
                 pressStyle={{opacity: 0.8}}
                 onPress={handlePresentModalPress}>
-                <Text fontSize={15} color="#333">
+                <Text fontSize={15} color={text}>
                   Filter
                 </Text>
-                <Feather name="filter" size={17} color="#555" />
+                <Feather name="filter" size={17} color={mutedText} />
               </XStack>
             </YStack>
           </Popover.Content>

--- a/frontend/src/components/HeaderRightMenu.tsx
+++ b/frontend/src/components/HeaderRightMenu.tsx
@@ -6,7 +6,7 @@ import {useDispatch, useSelector} from 'react-redux';
 import Snackbar from 'react-native-snackbar';
 import {BottomSheetModal} from '@gorhom/bottom-sheet';
 import {setPodcasts} from '../store/dataSlice';
-import {RootStackParamList, Category, CategoryType} from '../type';
+import {RootStackParamList, Category} from '../type';
 import FilterModal from './FilterModal';
 import {
   XStack,
@@ -38,12 +38,11 @@ const HeaderRightMenu = ({onClick}: Props) => {
   );
 
   const {categories} = useSelector((state: any) => state.data);
-  const {user_token, isGuest} = useSelector((state: any) => state.user);
+  const {isGuest} = useSelector((state: any) => state.user);
   const {isConnected} = useSelector((state: any) => state.network);
   const dispatch = useDispatch();
 
-  const {mutate: filterPodcast, isPending: filterPodcastPending} =
-    useFilterPodcasts();
+  const {mutate: filterPodcast} = useFilterPodcasts();
 
   const bottomSheetModalRef = useRef<BottomSheetModal>(null);
 

--- a/frontend/src/components/HomeScreenHeader.tsx
+++ b/frontend/src/components/HomeScreenHeader.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useColorScheme } from 'react-native';
 import { Input, XStack, YStack, Button, Text } from "tamagui";
 import Feather from '@expo/vector-icons/Feather';
 import AntDesign from '@expo/vector-icons/AntDesign';
@@ -14,27 +15,33 @@ const HomeScreenHeader = ({
   onFilterReset,
   searchText,
 }: HomeScreenHeaderProps) => {
+  const isDarkMode = useColorScheme() === 'dark';
+  const headerBackground = isDarkMode ? '#0B1425' : '#000A60';
+  const surface = isDarkMode ? '#1F2937' : '#FFFFFF';
+  const text = isDarkMode ? '#F9FAFB' : '#333333';
+  const mutedText = isDarkMode ? '#D1D5DB' : '#778599';
+
   return (
-    <YStack backgroundColor="#000A60" width="100%" paddingHorizontal="$2" paddingVertical="$2" elevation={1}>
+    <YStack backgroundColor={headerBackground} width="100%" paddingHorizontal="$2" paddingVertical="$2" elevation={1}>
       <XStack alignItems="center" justifyContent="space-between" gap="$1.5" height={50}>
         
         {/* Left Side Menu Button - Restored! */}
         <Button chromeless onPress={handlePresentModalPress} padding="$0" width={40} height={40} justifyContent="center" alignItems="center">
-          <AntDesign name="menu-fold" size={24} color="white" />
+          <AntDesign name="menu-fold" size={24} color={text} />
         </Button>
 
         {/* Center search bar wrapper */}
         <XStack 
           flex={1} 
           alignItems="center" 
-          backgroundColor="white" 
+          backgroundColor={surface}
           borderWidth={1.5} 
           borderColor="#4D6360" 
           borderRadius={10} 
           paddingHorizontal="$2" 
           minHeight={40}
         >
-          <Feather name="search" size={18} color="#778599" style={{ marginLeft: 4 }} />
+          <Feather name="search" size={18} color={mutedText} style={{ marginLeft: 4 }} />
           
           <Input 
             unstyled
@@ -42,7 +49,8 @@ const HomeScreenHeader = ({
             paddingLeft={8}
             paddingVertical={4}
             placeholder="Search articles..."
-            placeholderTextColor="#778599"
+            placeholderTextColor={mutedText}
+            color={text}
             fontSize={16}
             value={searchText}
             onChangeText={onTextInputChange}
@@ -52,7 +60,7 @@ const HomeScreenHeader = ({
 
         {/* Right Side Notification Bell with Unread Badge - Restored! */}
         <Button chromeless onPress={onNotificationClick} padding="$0" width={40} height={40} justifyContent="center" alignItems="center" position="relative">
-          <Ionicons name="notifications-outline" size={24} color="white" />
+          <Ionicons name="notifications-outline" size={24} color={text} />
           {unreadCount > 0 && (
             <XStack 
               position="absolute" 
@@ -65,7 +73,7 @@ const HomeScreenHeader = ({
               alignItems="center" 
               justifyContent="center"
             >
-              <Text color="white" fontSize={10} fontWeight="bold">
+              <Text color={text} fontSize={10} fontWeight="bold">
                 {unreadCount}
               </Text>
             </XStack>


### PR DESCRIPTION
## Summary
- add dark-mode-aware surface, text, border, badge, and icon colors to the current ArticleCard implementation
- update HomeScreenHeader and HeaderRightMenu to use readable theme-aware controls and popovers
- close the existing ArticleCard readability object so the touched component parses correctly

Fixes #2128

## Validation
- `git diff --check`
- direct `tsc --noEmit`: touched files parse; repository still reports pre-existing syntax errors in `src/contexts/PreferencesContext.tsx`, `src/screens/CommentScreen.tsx`, and `src/screens/HomeScreen.tsx`
- focused ESLint: existing React Compiler immutability errors remain in `ArticleCard.tsx` animation shared-value assignments; no new errors in header theme logic