### PR TITLE
feat: msToTime conversion, debounce bug, and import fix

### DIFF
--- a/frontend/src/lib/utils/Utils.ts
+++ b/frontend/src/lib/utils/Utils.ts
@@ -75,7 +75,7 @@ export const handleExternalClick = (request: any) => {
 };
 
 export function msToTime(ms: number): string {
-  let totalSeconds = Math.floor(ms);
+  let totalSeconds = Math.floor(ms / 1000);
   const hours = Math.floor(totalSeconds / 3600);
   totalSeconds %= 3600;
   const minutes = Math.floor(totalSeconds / 60);

--- a/frontend/src/screens/article/ArticleScreen.tsx
+++ b/frontend/src/screens/article/ArticleScreen.tsx
@@ -13,7 +13,7 @@ import {
   useColorScheme,
  ScrollView } from 'react-native';
 import ArticleShareModal from '../../components/article/ArticleShareModal';
-import React, {useCallback, useEffect, useRef, useState} from 'react';
+import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import FontAwesome from '@expo/vector-icons/FontAwesome';
 import {PRIMARY_COLOR} from '../../lib/ui/Theme';
 import GlobalStyles from '../../styles/GlobalStyle';
@@ -247,8 +247,8 @@ const ArticleScreen = ({navigation, route}: ArticleScreenProp) => {
     };
   };
 
-  const debouncedPersistFontScale = useCallback(
-    (nextValue: number) => debounce(persistFontScale, 300)(nextValue),
+  const debouncedPersistFontScale = useMemo(
+    () => debounce(persistFontScale, 300),
     [],
   );
 


### PR DESCRIPTION
### Bug 1: msToTime treats milliseconds as seconds
- `frontend/src/lib/utils/Utils.ts:78` — divided input by 1000 to correctly convert ms to seconds

### Bug 2: debouncedPersistFontScale debounce never worked
- `frontend/src/screens/article/ArticleScreen.tsx:250` — `useCallback` returned a new debounce() call on every invocation, creating a fresh closure each time. Changed to `useMemo` so the debounced function is created once and reused.