### PR TITLE
fix: guard messaging init on web and fix plugin debugStatement

### DIFF
--- a/frontend/index.js
+++ b/frontend/index.js
@@ -19,18 +19,23 @@ if (Platform.OS === 'web') {
     }
   `;
   document.head.appendChild(style);
-}// Firebase background handler must be registered at the app root (run once,
+}
+
+// Firebase background handler must be registered at the app root (run once,
 // before any component mounts). FCM requires this to be at module scope.
 // NOTE: initMonitoring() is intentionally NOT called here — it has been moved
 // to AppContent.tsx's first useEffect so that expo-application metadata
 // (nativeApplicationVersion, nativeBuildVersion) is fully available before
 // Sentry initialises.
-messaging().setBackgroundMessageHandler(async remoteMessage => {
-  // Only log notification payloads in development to avoid leaking user data
-  // or FCM tokens in production log aggregators.
-  
+// Only register on native platforms — @react-native-firebase/messaging
+// does not support web and will throw if invoked in a browser context.
+if (Platform.OS !== 'web') {
+  messaging().setBackgroundMessageHandler(async remoteMessage => {
+    // Only log notification payloads in development to avoid leaking user data
+    // or FCM tokens in production log aggregators.
     logger.log('Background notification received:', remoteMessage);
-});
+  });
+}
 
 const AppWrapper = () => {
   return (

--- a/frontend/plugins/withWebViewDebug.js
+++ b/frontend/plugins/withWebViewDebug.js
@@ -13,18 +13,23 @@ const withWebViewDebug = (config) => {
     }
 
     // Add the WebView debug configuration before DefaultNewArchitectureEntryPoint
-    const debugStatement = `
-    // Security: Only enable WebView remote debugging in debug builds.
+    const debugStatement = `    // Security: Only enable WebView remote debugging in debug builds.
     // In production, this prevents Chrome DevTools from inspecting WebView
     // content, extracting session cookies, or reading localStorage.
-    WebView.setWebContentsDebuggingEnabled(BuildConfig.DEBUG)
-    `;
+    WebView.setWebContentsDebuggingEnabled(BuildConfig.DEBUG)`;
 
     if (!mainApplication.includes('WebView.setWebContentsDebuggingEnabled')) {
-      mainApplication = mainApplication.replace(
-        'DefaultNewArchitectureEntryPoint.releaseLevel',
-        `${debugStatement}\n    DefaultNewArchitectureEntryPoint.releaseLevel`
-      );
+      const target = 'DefaultNewArchitectureEntryPoint.releaseLevel';
+      if (mainApplication.includes(target)) {
+        mainApplication = mainApplication.replace(
+          target,
+          `${debugStatement}\n    ${target}`
+        );
+      } else {
+        console.warn(
+          '[withWebViewDebug] Could not find injection point "' + target + '" — WebView debugging will not be enabled.',
+        );
+      }
     }
 
     config.modResults.contents = mainApplication;


### PR DESCRIPTION
## Bugs Fixed

1. **index.js**: Guarded messaging().setBackgroundMessageHandler behind platform check to prevent crash on web where @react-native-firebase/messaging is unsupported.

2. **plugins/withWebViewDebug.js**: Fixed debug statement template literal to avoid leading newline. Added safety check so injection silently fails with a warning instead of producing no output when the target string is missing.
