### PR TITLE
fix: correct invalid import type syntax in 4 auth screen files

### DIFF
--- a/frontend/src/screens/auth/LogoutScreen.tsx
+++ b/frontend/src/screens/auth/LogoutScreen.tsx
@@ -10,7 +10,6 @@ import {
 } from 'react-native';
 import {PRIMARY_COLOR} from '../../lib/ui/Theme';
 import {GET_STORAGE_DATA} from '../../lib/api/APIUtils';
-import type  from 'axios';
 import {resetUserState} from '../../store/UserSlice';
 import {useAppDispatch} from '../../store/hooks';
 import {clearStorage} from '../../lib/utils/Utils';

--- a/frontend/src/screens/auth/NewPasswordScreen.tsx
+++ b/frontend/src/screens/auth/NewPasswordScreen.tsx
@@ -22,7 +22,6 @@ import { useChangePasswordMutation } from '@/src/hooks/auth/useChangePassword';
 import AntDesign from '@expo/vector-icons/AntDesign';
 import Entypo from '@expo/vector-icons/Entypo';
 import Icon from '@expo/vector-icons/Ionicons';
-import type  from 'axios';
 import Loader from '../../components/common/Loader';
 import { NewPasswordScreenProp } from '../../schemas/type';
 import {Alert, ActivityIndicator} from 'react-native';

--- a/frontend/src/screens/auth/SignUpScreenFirst.tsx
+++ b/frontend/src/screens/auth/SignUpScreenFirst.tsx
@@ -11,7 +11,7 @@ import { useForm, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
 import {SignUpScreenFirstProp, UserDetail} from '../../schemas/type';
-import type  from 'axios';
+import { isAxiosError } from 'axios';
 import Snackbar from 'react-native-snackbar';
 import EmailVerifiedModal from '../../components/auth/VerifiedModal';
 import SecurityWarningModal from '../../components/auth/SecurityWarningModal';

--- a/frontend/src/screens/auth/SignUpScreenSecond.tsx
+++ b/frontend/src/screens/auth/SignUpScreenSecond.tsx
@@ -8,7 +8,6 @@ import { useForm, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
 import {Contactdetail, SignUpScreenSecondProp} from '../../schemas/type';
-import type  from 'axios';
 import EmailVerifiedModal from '../../components/auth/VerifiedModal';
 import SecurityWarningModal from '../../components/auth/SecurityWarningModal';
 import Loader from '../../components/common/Loader';


### PR DESCRIPTION
Bugs fixed:
- import type from axios was missing named import in 4 auth screen files
- Fixed SignUpScreenFirst to import isAxiosError
- Removed unused broken import from SignUpScreenSecond, NewPasswordScreen, LogoutScreen