### PR TITLE
fix: typo in deep link intent filter paths

### DIFF
--- a/frontend/app.config.js
+++ b/frontend/app.config.js
@@ -50,12 +50,12 @@ const defaultStaticConfig = {
           {
             scheme: "https",
             host: "uhsocial.in",
-            pathPrefix: "/ap/share/article"
+            pathPrefix: "/api/share/article"
           },
           {
             scheme: "https",
             host: "uhsocial.in",
-            pathPrefix: "/ap/share/podcast"
+            pathPrefix: "/api/share/podcast"
           }
         ]
       }


### PR DESCRIPTION
## Bug Fix

**app.config.js** — The deep link intent filter paths for article and podcast sharing had a typo: `/ap/share/article` and `/ap/share/podcast` instead of `/api/share/article` and `/api/share/podcast`.

Since app.config.js overrides app.json at build time, these typos would break deep linking for shared article and podcast URLs.

```diff
- pathPrefix: "/ap/share/article"
+ pathPrefix: "/api/share/article"

- pathPrefix: "/ap/share/podcast"
+ pathPrefix: "/api/share/podcast"
```