### PR TITLE
fix: API helpers silently swallow HTTP error responses + remove @ts-nocheck

### DIFF
--- a/frontend/src/lib/api/CallAPI.ts
+++ b/frontend/src/lib/api/CallAPI.ts
@@ -42,7 +42,10 @@ export function postMethodCallwithToken<T = unknown>(
       Authorization: `Bearer ${authToken}`,
     },
     body: JSON.stringify(params),
-  }).then(response => response.json());
+  }).then(response => {
+    if (!response.ok) throw new Error(`POST ${url} failed: ${response.status}`);
+    return response.json();
+  });
 }
 
 /**
@@ -74,7 +77,10 @@ export function postMethodCall<T = unknown>(
       'Content-Type': 'application/json',
     },
     body: JSON.stringify(params),
-  }).then(response => response.json());
+  }).then(response => {
+    if (!response.ok) throw new Error(`POST ${url} failed: ${response.status}`);
+    return response.json();
+  });
 }
 
 /**
@@ -106,7 +112,10 @@ export function getMethodCallwithToken<T = unknown>(
       'Content-Type': 'application/json',
       Authorization: `Bearer ${authToken}`,
     },
-  }).then(response => response.json());
+  }).then(response => {
+    if (!response.ok) throw new Error(`GET ${url} failed: ${response.status}`);
+    return response.json();
+  });
 }
 
 /**
@@ -132,5 +141,8 @@ export function getMethodCall<T = unknown>(url: string): Promise<T> {
       Accept: 'application/json',
       'Content-Type': 'application/json',
     },
-  }).then(response => response.json());
+  }).then(response => {
+    if (!response.ok) throw new Error(`GET ${url} failed: ${response.status}`);
+    return response.json();
+  });
 }

--- a/frontend/src/lib/api/apiClient.ts
+++ b/frontend/src/lib/api/apiClient.ts
@@ -1,14 +1,12 @@
-// @ts-nocheck
 // frontend/src/services/apiClient.ts
 import Constants from 'expo-constants';
 
 const extra = Constants.expoConfig?.extra ?? {};
 const PROD_URL: string = extra.PROD_URL ?? 'http://10.0.2.2:3000/api';
 
-// 🔥 Main fix: Sirf successful responses return
 export async function apiRequest(endpoint: string, options?: RequestInit) {
   const url = `${PROD_URL}${endpoint}`;
-  
+
   try {
     const response = await fetch(url, {
       ...options,
@@ -18,28 +16,22 @@ export async function apiRequest(endpoint: string, options?: RequestInit) {
       },
     });
 
-    
-    if (response.ok) {  // status 200-299
+    if (response.ok) {
       const data = await response.json();
-      return { 
-        success: true, 
-        data: data, 
-        status: response.status 
-      };
-    } 
-    
-    
-    else {
-      const errorData = await response.json().catch(() => ({}));
-      throw { 
-        success: false, 
-        status: response.status, 
-        error: errorData 
+      return {
+        success: true,
+        data: data,
+        status: response.status,
       };
     }
-    
+
+    const errorData = await response.json().catch(() => ({}));
+    throw {
+      success: false,
+      status: response.status,
+      error: errorData,
+    };
   } catch (error) {
-    // Network errors bhi cache mat karo
     throw error;
   }
 }


### PR DESCRIPTION
**Bugs fixed:**

1. **HTTP error responses silently swallowed (CallAPI.ts)**: All four API helper functions called `response.json()` without checking `response.ok`. 4xx/5xx error responses were parsed as successful data, causing confusing downstream failures. Added `response.ok` guard that throws descriptive errors.

2. **@ts-nocheck disabled type safety (apiClient.ts)**: The entire file had type checking turned off, hiding potential type errors. Removed the directive and cleaned up formatting.

Verification:
- HTTP errors now properly throw instead of silently parsing as success
- TypeScript will now catch type errors in apiClient.ts