### PR TITLE
fix: add fallback defaults for API URL configs

### DIFF
--- a/frontend/src/lib/api/APIUtils.ts
+++ b/frontend/src/lib/api/APIUtils.ts
@@ -16,9 +16,9 @@ import Constants from "expo-constants";
 declare const __DEV__: boolean;
 const extra = Constants.expoConfig?.extra ?? {};
 
-const PROD_URL: string = extra.PROD_URL;
-const SOCKET_PROD: string = extra.SOCKET_PROD;
-const CONTENT_CHECKER_PROD: string = extra.CONTENT_CHECKER_PROD;
+const PROD_URL: string = extra.PROD_URL ?? 'http://10.0.2.2:3000/api';
+const SOCKET_PROD: string = extra.SOCKET_PROD ?? 'http://10.0.2.2:3000';
+const CONTENT_CHECKER_PROD: string = extra.CONTENT_CHECKER_PROD ?? 'http://10.0.2.2:3000/content-intel';
 const SHARE_BASE_URL = 'https://uhsocial.in';
 
 const LOGIN_API = `${PROD_URL}/user/login`;


### PR DESCRIPTION
PROD_URL, SOCKET_PROD, and CONTENT_CHECKER_PROD lacked fallback values when extra.PROD_URL etc. were undefined, causing all API endpoints to resolve to undefined/... URLs. The apiClient.ts already had this fallback; APIUtils.ts was inconsistent.

Fix: Added nullish coalescing fallbacks matching frontend/src/lib/api/apiClient.ts.