### PR TITLE
fix: preserve hidden selections when Clear All is used during search filter

### DIFF
--- a/frontend/src/__tests__/screens/notification/NotificationPreferencesScreen.test.tsx
+++ b/frontend/src/__tests__/screens/notification/NotificationPreferencesScreen.test.tsx
@@ -255,4 +255,40 @@ describe('NotificationPreferencesScreen', () => {
       expect.any(Object),
     );
   });
+
+  it('relabels to "Clear Visible" while filtering and preserves hidden selections on press', () => {
+    const {getByTestId, getByText, queryByText} = renderScreen();
+
+    // Select everything first (Nutrition, Fitness, Mental Health all selected)
+    fireEvent.press(getByText('Select All'));
+
+    // Filter down to just Fitness
+    const searchInput = getByTestId('search-input');
+    fireEvent.changeText(searchInput, 'Fit');
+
+    // Button should relabel while a filter is active
+    expect(getByText('Clear Visible')).toBeTruthy();
+    expect(queryByText('Clear All')).toBeNull();
+
+    // Press it - should only clear the visible Fitness selection
+    fireEvent.press(getByText('Clear Visible'));
+
+    // Remove the filter to inspect full state again
+    fireEvent.press(getByTestId('clear-search-button'));
+
+    // Label should revert now that nothing is filtered
+    expect(getByText('Clear All')).toBeTruthy();
+
+    // Nutrition and Mental Health should still be selected; Fitness should not
+    fireEvent.press(getByText('Save Preferences'));
+    expect(mockUpdatePreferences).toHaveBeenLastCalledWith(
+      {
+        contentClusters: [
+          {_id: 'cat-1', id: 1, name: 'Nutrition', __v: 0},
+          {_id: 'cat-3', id: 3, name: 'Mental Health', __v: 0},
+        ],
+      },
+      expect.any(Object),
+    );
+  });
 });

--- a/frontend/src/screens/notification/NotificationPreferencesScreen.tsx
+++ b/frontend/src/screens/notification/NotificationPreferencesScreen.tsx
@@ -81,6 +81,20 @@ const NotificationPreferencesScreen = ({
     );
   };
 
+  // Whether a search filter is currently narrowing the visible list
+  const isFiltering = searchQuery.trim().length > 0;
+
+  // Clear only what's currently visible when filtering, so hidden
+  // selections outside the filtered view are never silently dropped.
+  const handleClearAll = () => {
+    if (isFiltering) {
+      const visibleIds = new Set(filteredCategories.map(t => t._id));
+      setSelectedIds(prev => prev.filter(id => !visibleIds.has(id)));
+    } else {
+      setSelectedIds([]);
+    }
+  };
+
   const handleSave = () => {
     if (isGuest) {
       navigation.navigate('GuestPlaceholderScreen', {
@@ -239,9 +253,10 @@ const NotificationPreferencesScreen = ({
                   </TouchableOpacity>
                   <TouchableOpacity
                     style={[styles.bulkBtn, styles.bulkBtnClear]}
-                    onPress={() => setSelectedIds([])}>
+                    onPress={handleClearAll}
+                    testID="clear-all-button">
                     <Text style={[styles.bulkBtnText, {color: '#6b7280'}]}>
-                      Clear All
+                      {isFiltering ? 'Clear Visible' : 'Clear All'}
                     </Text>
                   </TouchableOpacity>
                 </View>


### PR DESCRIPTION
#### PR Description
Please include a summary of the changes and the related issue. Describe your changes in detail.

Fixes the "Clear All" button in notification preferences, which was
unconditionally clearing all selected topics even when a search filter
was hiding some of them from view — silently discarding selections the
user couldn't see at the time.

The fix scopes "Clear All" to only the currently visible (filtered) list
when a search filter is active, mirroring how "Select All" already
behaves. The button also relabels to "Clear Visible" while filtering,
and reverts to "Clear All" once the filter is cleared.

Tested with the existing + a new regression test (9/9 passing) and a
clean tsc --noEmit typecheck.

#### Type of Change
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update

#### Select your work-area
- [x] Frontend
- [ ] Backend
- [ ] Documentation
- [ ] Others

#### Related Issue
Please provide a link to the issue solved if applicable.
https://github.com/SB2318/UltimateHealth/issues/1998

#### Add your Work Example
📷 Snapshot pending — fork-originated preview/CI workflows require maintainer approval before they run.

#### Fixes (mention the issue number which this fixes)
closes #1998

#### Checklist
- [ ] I have updated my branch and synced it with the project's 'develop' branch before making this PR.
- [x] I have optimized the file changes.
- [ ] I have added a snapshot of my work example.
- [ ] I have made a PR to the project's develop branch.

#### Undertaking
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have checked for plagiarism and assure its authenticity.
- [x] I have read and followed the code of conduct for this repository. I understand that violation of this undertaking may have legal consequences.

- [x] I Agree
