### PR TITLE
test: expand ReadingProgressService unit test coverage

### DIFF
--- a/frontend/src/__tests__/lib/services/ReadingProgressService.test.ts
+++ b/frontend/src/__tests__/lib/services/ReadingProgressService.test.ts
@@ -88,4 +88,118 @@ describe('ReadingProgressService', () => {
       'reading_progress_article-1',
     );
   });
+
+  it('returns null when no progress exists', async () => {
+    mockedGetReadingProgressItem.mockResolvedValue(undefined);
+
+    await expect(getProgress('article-1')).resolves.toBeNull();
+
+    expect(mockedDeleteReadingProgressItem).not.toHaveBeenCalled();
+  });
+
+  it('removes progress with scroll position greater than 100', async () => {
+    mockedGetReadingProgressItem.mockResolvedValue(
+      JSON.stringify({
+        articleId: 'article-1',
+        scrollPosition: 150,
+        updatedAt: 123456,
+      }),
+    );
+
+    await expect(getProgress('article-1')).resolves.toBeNull();
+
+    expect(mockedDeleteReadingProgressItem).toHaveBeenCalledWith(
+      'reading_progress_article-1',
+    );
+  });
+
+  it('removes progress with negative scroll position', async () => {
+    mockedGetReadingProgressItem.mockResolvedValue(
+      JSON.stringify({
+        articleId: 'article-1',
+        scrollPosition: -10,
+        updatedAt: 123456,
+      }),
+    );
+
+    await expect(getProgress('article-1')).resolves.toBeNull();
+
+    expect(mockedDeleteReadingProgressItem).toHaveBeenCalledWith(
+      'reading_progress_article-1',
+    );
+  });
+
+  it('removes progress with invalid timestamp', async () => {
+    mockedGetReadingProgressItem.mockResolvedValue(
+      JSON.stringify({
+        articleId: 'article-1',
+        scrollPosition: 50,
+        updatedAt: 0,
+      }),
+    );
+
+    await expect(getProgress('article-1')).resolves.toBeNull();
+
+    expect(mockedDeleteReadingProgressItem).toHaveBeenCalledWith(
+      'reading_progress_article-1',
+    );
+  });
+
+  it('removes progress with non-numeric scroll position', async () => {
+    mockedGetReadingProgressItem.mockResolvedValue(
+      JSON.stringify({
+        articleId: 'article-1',
+        scrollPosition: null,
+        updatedAt: 123456,
+      }),
+    );
+
+    await expect(getProgress('article-1')).resolves.toBeNull();
+
+    expect(mockedDeleteReadingProgressItem).toHaveBeenCalledWith(
+      'reading_progress_article-1',
+    );
+  });
+
+  it('clamps negative progress to 0', async () => {
+    await saveProgress('article-1', -25);
+
+    const [, serialized] = mockedSetReadingProgressItem.mock.calls[0];
+
+    expect(JSON.parse(serialized)).toMatchObject({
+      articleId: 'article-1',
+      scrollPosition: 0,
+    });
+  });
+
+  it('stores the current timestamp when saving progress', async () => {
+    jest.spyOn(Date, 'now').mockReturnValue(987654321);
+
+    await saveProgress('article-1', 75);
+
+    expect(mockedSetReadingProgressItem).toHaveBeenCalledTimes(1);
+
+    const [, serialized] = mockedSetReadingProgressItem.mock.calls[0];
+
+    expect(JSON.parse(serialized)).toEqual({
+      articleId: 'article-1',
+      scrollPosition: 75,
+      updatedAt: 987654321,
+    });
+  });
+
+  it('returns null even if cleanup of invalid progress fails', async () => {
+    mockedGetReadingProgressItem.mockResolvedValue('{broken');
+
+    mockedDeleteReadingProgressItem.mockRejectedValue(
+      new Error('Storage error'),
+    );
+
+    await expect(getProgress('article-1')).resolves.toBeNull();
+
+    expect(mockedDeleteReadingProgressItem).toHaveBeenCalledWith(
+      'reading_progress_article-1',
+    );
+  });
+
 });


### PR DESCRIPTION
#### PR Description
Please include a summary of the changes and the related issue. Describe your changes in detail.

This PR expands the unit test coverage for `ReadingProgressService` by adding additional validation and edge-case scenarios.

### Added tests

- Return `null` when no reading progress exists.
- Remove persisted progress when:
  - `scrollPosition` is greater than 100.
  - `scrollPosition` is negative.
  - `scrollPosition` is non-numeric.
  - `updatedAt` is invalid.
- Clamp negative progress values to `0` when saving.
- Verify that `updatedAt` is populated using the current timestamp.
- Ensure cleanup failures are handled gracefully without throwing.

These tests improve confidence around validation logic, persistence behavior, and error handling while keeping the existing functionality unchanged.


#### Type of Change
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Documentation update

#### Select your work-area
- [x] Frontend
- [ ] Backend
- [ ] Documentation
- [ ] Others

#### Related Issue
Please provide a link to the issue solved if applicable.
Solved  #2187 
#### Add your Work Example
📷 Add a Snapshot

#### Fixes (mention the issue number which this fixes)
#closes #2187 

#### Checklist
- [x] I have updated my branch and synced it with the project's 'develop' branch before making this PR.
- [x] I have optimized the file changes.
- [ ] I have added a snapshot of my work example.
- [x] I have made a PR to the project's develop branch.

#### Undertaking
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have checked for plagiarism and assure its authenticity.
- [x] I have read and followed the code of conduct for this repository. I understand that violation of this undertaking may have legal consequences.

- [x] I Agree
