### PR TITLE
docs: add PodcastEpisode to Mongoose schema reference

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -134,7 +134,7 @@ Push notifications to mobile users for review updates, new articles, and moderat
 | `src/index.js` | Express app bootstrap |
 | `src/routes/` | All API route definitions |
 | `src/controllers/` | Request handlers per domain |
-| `src/models/` | Mongoose schemas (User, Article, Podcast, Report) |
+| `src/models/` | Mongoose schemas (User, Article, Podcast, PodcastEpisode, Report) |
 | `src/middleware/` | JWT auth, validation, error handling |
 | `src/services/` | Email, storage, and external integrations |
 | `.env.example` | All required environment variables |


### PR DESCRIPTION
#### PR Description
Please include a summary of the changes and the related issue. Describe your changes in detail.
Adds the PodcastEpisode schema to the architecture doc's list of Mongoose
models. This was missing after the PodcastEpisode schema was introduced
in SB2318/ultimatehealth-backend#16 (issue #2164).

#### Type of Change
- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [x] Documentation update

#### Select your work-area
- [ ] Frontend
- [ ] Backend
- [x] Documentation
- [ ] Others

#### Related Issue
Please provide a link to the issue solved if applicable.
https://github.com/SB2318/UltimateHealth/issues/2164

#### Add your Work Example
📷 Add a Snapshot
📷 Not applicable — single-line documentation reference update.

#### Fixes (mention the issue number which this fixes)
Related to #2164

#### Checklist
- [ ] I have updated my branch and synced it with the project's 'develop' branch before making this PR.
- [x] I have optimized the file changes.
- [ ] I have added a snapshot of my work example.
- [ ] I have made a PR to the project's develop branch.

#### Undertaking
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have checked for plagiarism and assure its authenticity.
- [x] I have read and followed the code of conduct for this repository. I understand that violation of this undertaking may have legal consequences.

- [x] I Agree
