### PR TITLE
feat: Add Playback Speed Controls to the PodcastDetail Screen #1092

### DIFF
--- a/frontend/src/screens/podcast/PodcastDetail.tsx
+++ b/frontend/src/screens/podcast/PodcastDetail.tsx
@@ -90,6 +90,7 @@ const PodcastDetail = ({navigation, route}: PodcastDetailScreenProp) => {
 
   const [isLike, setLike] = useState(false);
   const [likeCount, setLikeCount] = useState(0);
+  const [speed, setSpeed] = useState(1.0);
 
   const {data: podcast, refetch, isLoading: isPodcastLoading, isError: isPodcastError, error: podcastError} = useGetSinglePodcastDetails(trackId);
   const {mutate: likePodcast, isPending: likePodcastPending} = useLikePodcast();
@@ -307,6 +308,26 @@ useEffect(() => {
       setLikeCount(podcast.likedUsers.length);
     }
   }, [podcast, user_id])
+
+  const handleSpeedChange = async () => {
+    if (!player) return;
+    const nextSpeed = speed === 1.0 ? 1.25 : speed === 1.25 ? 1.5 : speed === 1.5 ? 2.0 : 1.0;
+    setSpeed(nextSpeed);
+
+    try {
+      if ('setPlaybackRate' in player) {
+        (player as any).setPlaybackRate(nextSpeed, 'high');
+      } else {
+        player.playbackRate = nextSpeed;
+      }
+      
+      if ('setRateAsync' in player) {
+        await (player as any).setRateAsync(nextSpeed, true, 'high');
+      }
+    } catch (err) {
+      console.warn('Failed to set playback rate:', err);
+    }
+  };
 
   const SKIP_TIME = 5; // seconds
 
@@ -603,6 +624,24 @@ useEffect(() => {
           onPress={handleForward}
           style={styles.controlButton}>
           <Ionicons name="play-forward" size={32} color="#9BB3C8" />
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          testID="podcast-speed-button"
+          accessibilityLabel="podcast-speed-button"
+          onPress={handleSpeedChange}
+          style={{ marginLeft: 10 }}>
+          <XStack
+            backgroundColor="$backgroundFocus"
+            paddingHorizontal="$3"
+            paddingVertical="$2"
+            borderRadius="$4"
+            alignItems="center"
+            justifyContent="center">
+            <Text color="$color" fontSize={14} fontWeight="800">
+              {speed}x
+            </Text>
+          </XStack>
         </TouchableOpacity>
       </XStack>
     </View>


### PR DESCRIPTION
#### PR Description
Added a playback speed control button to the `PodcastDetail` screen. The UI now features a sleek, pill-shaped button that dynamically cycles through playback speeds (`1.0x` -> `1.25x` -> `1.5x` -> `2.0x` -> `1.0x`). It utilizes Tamagui variables for styling to ensure it adapts perfectly to both Light and Dark modes. The audio playback rate is updated using the `expo-audio` APIs with pitch correction to prevent distorted voices.

#### Type of Change
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Documentation update

#### Select your work-area
- [x] Frontend
- [ ] Backend
- [ ] Documentation
- [ ] Others

#### Related Issue
https://github.com/SB2318/UltimateHealth/issues/1092


#### Fixes (mention the issue number which this fixes)
#closes #1092
#closes #738

#### Checklist
- [x] I have updated my branch and synced it with the project's 'develop' branch before making this PR.
- [x] I have optimized the file changes.
- [x] I have made a PR to the project's develop branch.

#### Undertaking
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have checked for plagiarism and assure its authenticity.
- [x] I have read and followed the code of conduct for this repository. I understand that violation of this undertaking may have legal consequences.

- [x] I Agree
