### PR TITLE
feat: Add Playback Speed Controls to the PodcastDetail Screen #1092

### DIFF
--- a/frontend/src/__tests__/screens/podcast/PodcastDetail.test.tsx
+++ b/frontend/src/__tests__/screens/podcast/PodcastDetail.test.tsx
@@ -484,6 +484,6 @@ describe('PodcastDetail', () => {
     });
     
     expect(getByText('1.25x')).toBeTruthy();
-    expect(mockPlayer.setRateAsync).toHaveBeenCalledWith(1.25, true, 'high');
+    expect(mockPlayer.setRateAsync).toHaveBeenCalledWith(1.25, false, 'high');
   });
-});
+});

--- a/frontend/src/__tests__/screens/podcast/PodcastDetail.test.tsx
+++ b/frontend/src/__tests__/screens/podcast/PodcastDetail.test.tsx
@@ -20,6 +20,7 @@ const mockPlayer = {
   pause: jest.fn(),
   seekTo: jest.fn(),
   replace: jest.fn(),
+  setRateAsync: jest.fn(),
 };
 
 jest.mock('@expo/vector-icons/Ionicons', () => {
@@ -467,5 +468,22 @@ describe('PodcastDetail', () => {
 
     const {getByText} = renderScreen();
     expect(getByText(longTitle)).toBeTruthy();
+  });
+
+  it('cycles playback speed correctly on speed button press', async () => {
+    const {getByTestId, getByText} = renderScreen();
+    
+    const speedButton = getByTestId('podcast-speed-button');
+    expect(speedButton).toBeTruthy();
+    
+    // Initial speed is 1.0, which renders as "1x"
+    expect(getByText('1x')).toBeTruthy();
+    
+    await act(async () => {
+      fireEvent.press(speedButton);
+    });
+    
+    expect(getByText('1.25x')).toBeTruthy();
+    expect(mockPlayer.setRateAsync).toHaveBeenCalledWith(1.25, true, 'high');
   });
 });

--- a/frontend/src/screens/podcast/PodcastDetail.tsx
+++ b/frontend/src/screens/podcast/PodcastDetail.tsx
@@ -311,19 +311,17 @@ useEffect(() => {
 
   const handleSpeedChange = async () => {
     if (!player) return;
-    const nextSpeed = speed === 1.0 ? 1.25 : speed === 1.25 ? 1.5 : speed === 1.5 ? 2.0 : 1.0;
+
+    const speeds = [1.0, 1.25, 1.5, 2.0];
+    const currentIndex = speeds.indexOf(speed);
+    const nextIndex = (currentIndex + 1) % speeds.length;
+    const nextSpeed = speeds[nextIndex];
+
     setSpeed(nextSpeed);
 
     try {
-      if ('setPlaybackRate' in player) {
-        (player as any).setPlaybackRate(nextSpeed, 'high');
-      } else {
-        player.playbackRate = nextSpeed;
-      }
-      
-      if ('setRateAsync' in player) {
-        await (player as any).setRateAsync(nextSpeed, true, 'high');
-      }
+      type AudioSound = { setRateAsync: (rate: number, shouldPlay: boolean, pitchCorrectionQuality: string) => Promise<void> };
+      await (player as unknown as AudioSound).setRateAsync(nextSpeed, true, 'high');
     } catch (err) {
       console.warn('Failed to set playback rate:', err);
     }

--- a/frontend/src/screens/podcast/PodcastDetail.tsx
+++ b/frontend/src/screens/podcast/PodcastDetail.tsx
@@ -90,6 +90,7 @@ const PodcastDetail = ({navigation, route}: PodcastDetailScreenProp) => {
 
   const [isLike, setLike] = useState(false);
   const [likeCount, setLikeCount] = useState(0);
+  const [speed, setSpeed] = useState(1.0);
 
   const {data: podcast, refetch, isLoading: isPodcastLoading, isError: isPodcastError, error: podcastError} = useGetSinglePodcastDetails(trackId);
   const {mutate: likePodcast, isPending: likePodcastPending} = useLikePodcast();
@@ -307,6 +308,26 @@ useEffect(() => {
       setLikeCount(podcast.likedUsers.length);
     }
   }, [podcast, user_id])
+
+  const handleSpeedChange = async () => {
+    if (!player) return;
+    const nextSpeed = speed === 1.0 ? 1.25 : speed === 1.25 ? 1.5 : speed === 1.5 ? 2.0 : 1.0;
+    setSpeed(nextSpeed);
+
+    try {
+      if ('setPlaybackRate' in player) {
+        (player as any).setPlaybackRate(nextSpeed, 'high');
+      } else {
+        player.playbackRate = nextSpeed;
+      }
+      
+      if ('setRateAsync' in player) {
+        await (player as any).setRateAsync(nextSpeed, true, 'high');
+      }
+    } catch (err) {
+      console.warn('Failed to set playback rate:', err);
+    }
+  };
 
   const SKIP_TIME = 5; // seconds
 
@@ -603,6 +624,24 @@ useEffect(() => {
           onPress={handleForward}
           style={styles.controlButton}>
           <Ionicons name="play-forward" size={32} color="#9BB3C8" />
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          testID="podcast-speed-button"
+          accessibilityLabel="podcast-speed-button"
+          onPress={handleSpeedChange}
+          style={{ marginLeft: 10 }}>
+          <XStack
+            backgroundColor="$backgroundFocus"
+            paddingHorizontal="$3"
+            paddingVertical="$2"
+            borderRadius="$4"
+            alignItems="center"
+            justifyContent="center">
+            <Text color="$color" fontSize={14} fontWeight="800">
+              {speed}x
+            </Text>
+          </XStack>
         </TouchableOpacity>
       </XStack>
     </View>

--- a/frontend/src/screens/podcast/PodcastDetail.tsx
+++ b/frontend/src/screens/podcast/PodcastDetail.tsx
@@ -17,7 +17,7 @@ import {PRIMARY_COLOR} from '../../lib/ui/Theme';
 import Slider from '../../components/podcast/SliderCompat';
 import {GlassStyles} from '../../styles/GlassStyles';
 
-import {useAudioPlayer} from 'expo-audio';
+import {useAudioPlayer, type AudioPlayer} from 'expo-audio';
 
 // GET_IMAGE is defined as `${PROD_URL}/getfile` (resolves to absolute URL: https://uhsocial.in/api/getfile).
 // This absolute, securely-configured endpoint ensures that relative resource paths cannot access local device files via traversal.
@@ -61,6 +61,8 @@ const isAllowedUrl = (urlStr?: string | null): boolean => {
     return false;
   }
 };
+
+const PLAYBACK_SPEEDS = [1.0, 1.25, 1.5, 2.0];
 
 const PodcastDetail = ({navigation, route}: PodcastDetailScreenProp) => {
   //const [progress, setProgress] = useState(10);
@@ -113,7 +115,9 @@ const PodcastDetail = ({navigation, route}: PodcastDetailScreenProp) => {
     typeof loadedSource === 'string' && loadedSource.startsWith('http');
 
   // only initialize once a valid uri exists
-  const player = useAudioPlayer(initialSource);
+  const player = useAudioPlayer(initialSource) as AudioPlayer & {
+    setRateAsync?: (rate: number, shouldPlay: boolean, pitchCorrectionQuality: string) => Promise<void>;
+  };
 
   useEffect(() => {
     if (podcast?.audio_url) {
@@ -312,18 +316,24 @@ useEffect(() => {
   const handleSpeedChange = async () => {
     if (!player) return;
 
-    const speeds = [1.0, 1.25, 1.5, 2.0];
-    const currentIndex = speeds.indexOf(speed);
-    const nextIndex = (currentIndex + 1) % speeds.length;
-    const nextSpeed = speeds[nextIndex];
-
-    setSpeed(nextSpeed);
+    const currentIndex = PLAYBACK_SPEEDS.indexOf(speed);
+    const nextIndex = (currentIndex + 1) % PLAYBACK_SPEEDS.length;
+    const nextSpeed = PLAYBACK_SPEEDS[nextIndex];
 
     try {
-      type AudioSound = { setRateAsync: (rate: number, shouldPlay: boolean, pitchCorrectionQuality: string) => Promise<void> };
-      await (player as unknown as AudioSound).setRateAsync(nextSpeed, true, 'high');
+      if (player.setRateAsync) {
+        await player.setRateAsync(nextSpeed, playing, 'high');
+      } else {
+        // Fallback for expo-audio if setRateAsync is not available
+        (player as any).playbackRate = nextSpeed;
+      }
+      setSpeed(nextSpeed);
     } catch (err) {
       console.warn('Failed to set playback rate:', err);
+      Snackbar.show({
+        text: 'Failed to change playback speed. Please try again.',
+        duration: Snackbar.LENGTH_SHORT,
+      });
     }
   };
 
@@ -626,7 +636,7 @@ useEffect(() => {
 
         <TouchableOpacity
           testID="podcast-speed-button"
-          accessibilityLabel="podcast-speed-button"
+          accessibilityLabel={`Playback speed: ${speed}x. Tap to change.`}
           onPress={handleSpeedChange}
           style={{ marginLeft: 10 }}>
           <XStack


### PR DESCRIPTION
#### PR Description
Added a playback speed control button to the `PodcastDetail` screen. The UI now features a sleek, pill-shaped button that dynamically cycles through playback speeds (`1.0x` -> `1.25x` -> `1.5x` -> `2.0x` -> `1.0x`). It utilizes Tamagui variables for styling to ensure it adapts perfectly to both Light and Dark modes. The audio playback rate is updated using the `expo-audio` APIs with pitch correction to prevent distorted voices.

#### Type of Change
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Documentation update

#### Select your work-area
- [x] Frontend
- [ ] Backend
- [ ] Documentation
- [ ] Others

#### Related Issue
https://github.com/SB2318/UltimateHealth/issues/1092


#### Fixes (mention the issue number which this fixes)
#closes #1092

#### Checklist
- [x] I have updated my branch and synced it with the project's 'develop' branch before making this PR.
- [x] I have optimized the file changes.
- [x] I have made a PR to the project's develop branch.

#### Undertaking
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have checked for plagiarism and assure its authenticity.
- [x] I have read and followed the code of conduct for this repository. I understand that violation of this undertaking may have legal consequences.

- [x] I Agree
