### PR TITLE
fix(podcast): resolve playback speed fallback and useCallback bugs (#2263)

### DIFF
--- a/frontend/src/__tests__/screens/podcast/PodcastDetail.test.tsx
+++ b/frontend/src/__tests__/screens/podcast/PodcastDetail.test.tsx
@@ -470,8 +470,8 @@ describe('PodcastDetail', () => {
     expect(getByText(longTitle)).toBeTruthy();
   });
 
-  it('cycles playback speed correctly on speed button press', async () => {
-    const {getByTestId, getByText} = renderScreen();
+  it('cycles playback speed correctly on speed button press in both playing and paused states', async () => {
+    const {getByTestId, getByText, getByLabelText} = renderScreen();
     
     const speedButton = getByTestId('podcast-speed-button');
     expect(speedButton).toBeTruthy();
@@ -479,11 +479,38 @@ describe('PodcastDetail', () => {
     // Initial speed is 1.0, which renders as "1x"
     expect(getByText('1x')).toBeTruthy();
     
+    // 1.0 -> 1.25 (paused)
     await act(async () => {
       fireEvent.press(speedButton);
     });
-    
     expect(getByText('1.25x')).toBeTruthy();
     expect(mockPlayer.setRateAsync).toHaveBeenCalledWith(1.25, false, 'high');
+    
+    // 1.25 -> 1.5 (paused)
+    await act(async () => {
+      fireEvent.press(speedButton);
+    });
+    expect(getByText('1.5x')).toBeTruthy();
+    expect(mockPlayer.setRateAsync).toHaveBeenCalledWith(1.5, false, 'high');
+
+    // Play the audio
+    await act(async () => {
+      fireEvent.press(getByLabelText('podcast-play-pause-button'));
+    });
+
+    // 1.5 -> 2.0 (playing)
+    await act(async () => {
+      fireEvent.press(speedButton);
+    });
+    expect(getByText('2x')).toBeTruthy();
+    expect(mockPlayer.setRateAsync).toHaveBeenCalledWith(2.0, true, 'high');
+
+    // 2.0 -> 1.0 (playing)
+    await act(async () => {
+      fireEvent.press(speedButton);
+    });
+    expect(getByText('1x')).toBeTruthy();
+    expect(mockPlayer.setRateAsync).toHaveBeenCalledWith(1.0, true, 'high');
   });
-});
+});
+

--- a/frontend/src/screens/podcast/PodcastDetail.tsx
+++ b/frontend/src/screens/podcast/PodcastDetail.tsx
@@ -116,7 +116,7 @@ const PodcastDetail = ({navigation, route}: PodcastDetailScreenProp) => {
 
   // only initialize once a valid uri exists
   const player = useAudioPlayer(initialSource) as AudioPlayer & {
-    setRateAsync?: (rate: number, shouldPlay: boolean, pitchCorrectionQuality: string) => Promise<void>;
+    setRateAsync: (rate: number, shouldPlay: boolean, pitchCorrectionQuality: string) => Promise<void>;
   };
 
   useEffect(() => {
@@ -313,7 +313,7 @@ useEffect(() => {
     }
   }, [podcast, user_id])
 
-  const handleSpeedChange = async () => {
+  const handleSpeedChange = React.useCallback(async () => {
     if (!player) return;
 
     const currentIndex = PLAYBACK_SPEEDS.indexOf(speed);
@@ -321,12 +321,7 @@ useEffect(() => {
     const nextSpeed = PLAYBACK_SPEEDS[nextIndex];
 
     try {
-      if (player.setRateAsync) {
-        await player.setRateAsync(nextSpeed, playing, 'high');
-      } else {
-        // Fallback for expo-audio if setRateAsync is not available
-        (player as any).playbackRate = nextSpeed;
-      }
+      await player.setRateAsync(nextSpeed, playing, 'high');
       setSpeed(nextSpeed);
     } catch (err) {
       console.warn('Failed to set playback rate:', err);
@@ -335,7 +330,7 @@ useEffect(() => {
         duration: Snackbar.LENGTH_SHORT,
       });
     }
-  };
+  }, [player, playing, speed]);
 
   const SKIP_TIME = 5; // seconds
 


### PR DESCRIPTION
#### PR Description
This PR resolves an issue in the `PodcastDetail` screen where the playback speed control fallback logic was incorrectly modifying `(player as any).playbackRate` instead of using the supported `expo-audio` APIs. It also includes several stability and testing improvements.

**Detailed Changes:**
- Removed the incorrect `playbackRate` fallback assignment.
- Enforced `setRateAsync` as a required method in the `useAudioPlayer` type definition to accurately reflect `expo-audio`'s API contract.
- Wrapped `handleSpeedChange` in `React.useCallback` with proper dependencies to prevent unnecessary function re-creation on every render.
- Added comprehensive unit tests in `PodcastDetail.test.tsx` to verify the full playback speed cycle (1.0x → 1.25x → 1.5x → 2.0x → 1.0x) in both playing and paused states.
- Fixed the missing trailing newline at the EOF in the test file.

#### Type of Change
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update

#### Select your work-area
- [x] Frontend
- [ ] Backend
- [ ] Documentation
- [ ] Others

#### Related Issue
https://github.com/pisum-sativum/UltimateHealth/issues/2263


#### Fixes (mention the issue number which this fixes)
Fixes #2263

#### Checklist
- [x] I have updated my branch and synced it with the project's 'develop' branch before making this PR.
- [x] I have optimized the file changes.
- [x] I have made a PR to the project's develop branch.

#### Undertaking
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have checked for plagiarism and assure its authenticity.
- [x] I have read and followed the code of conduct for this repository. I understand that violation of this undertaking may have legal consequences.

- [x] I Agree
