### PR TITLE
fix: prevent podcast deletion on upload cancel

### DIFF
--- a/frontend/src/screens/podcast/PodcastPlayer.tsx
+++ b/frontend/src/screens/podcast/PodcastPlayer.tsx
@@ -169,9 +169,6 @@ const PodcastPlayer = ({navigation, route}: PodcastPlayerScreenProps) => {
       // Show confirmation alert
       const confirmation = await showConfirmationAlert();
       if (!confirmation) {
-        //Alert.alert('Post discarded');
-        await unlinkFile();
-        navigation.navigate('TabNavigation');
         return;
       }
 


### PR DESCRIPTION
#### PR Description
This PR fixes a critical bug where canceling the podcast upload confirmation alert resulted in the irreversible deletion of the user's recorded audio and forcefully navigated them away from the screen. Now, clicking "Cancel" simply closes the alert, keeping the user on the `PodcastPlayer` screen with their recorded audio intact.

#### Type of Change
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update

#### Select your work-area
- [x] Frontend
- [ ] Backend
- [ ] Documentation
- [ ] Others

#### Related Issue
https://github.com/pisum-sativum/UltimateHealth/issues/2143

#### Add your Work Example
📷 N/A - This is a programmatic routing/state fix.

#### Fixes (mention the issue number which this fixes)
#closes #2143

#### Checklist
- [x] I have updated my branch and synced it with the project's 'develop' branch before making this PR.
- [x] I have optimized the file changes.
- [ ] I have added a snapshot of my work example.
- [x] I have made a PR to the project's develop branch.

#### Undertaking
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have checked for plagiarism and assure its authenticity.
- [x] I have read and followed the code of conduct for this repository. I understand that violation of this undertaking may have legal consequences.

- [x] I Agree
