### PR TITLE
feat(web): add Articles navigation entry with active state (#1014)

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,7 @@
     "dev": "node --no-warnings node_modules/next/dist/bin/next dev",
     "build": "next build",
     "start": "next start",
-    "test": "node --no-warnings --test src/app/[locale]/admin-agreement/signatureValidation.test.mjs src/app/api/csp-report/sanitizeCspReport.test.mjs src/components/articles/article-layout.test.mjs src/lib/api.test.mjs",
+    "test": "node --no-warnings --test src/app/[locale]/admin-agreement/signatureValidation.test.mjs src/app/api/csp-report/sanitizeCspReport.test.mjs src/components/articles/article-layout.test.mjs src/lib/api.test.mjs src/lib/nav-active.test.mjs",
     "lint": "eslint",
     "knip": "knip",
     "knip:deps": "knip --dependencies",

--- a/web/src/app/[locale]/articles/page.tsx
+++ b/web/src/app/[locale]/articles/page.tsx
@@ -50,13 +50,12 @@ export default async function ArticlesPage({ searchParams }: PageProps) {
   const totalPages = actualTotalPages;
   const currentPage = page;
 
-  return (<>
-    <Navbar /><main className="min-h-screen bg-[#f8fafc] text-slate-900 overflow-x-hidden">
+  return (
+    <>
+      <Navbar />
+      <main className="min-h-screen bg-[#f8fafc] text-slate-900 overflow-x-hidden">
 
       {/* ── Hero ── */}
-      </main>
-      </>
-  );
       <section className="relative w-full overflow-hidden bg-gradient-to-b from-[#eef2ff] to-[#f8fafc] pt-36 pb-24 px-4 flex justify-center border-b border-slate-100">
         {/* Decorative background blobs */}
         <div className="absolute top-0 left-1/2 -translate-x-1/2 w-full max-w-7xl h-full pointer-events-none opacity-60">
@@ -169,6 +168,9 @@ export default async function ArticlesPage({ searchParams }: PageProps) {
           </Link>
         </PageWrapper>
       </footer>
+      </main>
+    </>
+  );
 }
 
 function ArticleCard({ article }: { article: ApiArticle }) {

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -509,6 +509,22 @@ html.dark .nav-item-icon {
   border-bottom: 1px solid rgba(0, 0, 0, 0.05);
 }
 
+/* Mirrors the desktop highlight so the current page is obvious in the drawer. */
+.mobile-nav a.active {
+  color: var(--primary);
+  box-shadow: inset 3px 0 0 0 var(--primary);
+  padding-left: 12px;
+}
+
+/* Keyboard users get the same affordance as the mouse hover state. */
+.nav-links a:focus-visible,
+.mobile-nav a:focus-visible,
+.mobile-menu-toggle:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 3px;
+  border-radius: 6px;
+}
+
 /* ==================== HERO ==================== */
 .hero {
   background: var(--gradient-primary);
@@ -3277,6 +3293,23 @@ html.dark .nav-links a {
 
 html.dark .nav-links a:hover {
   color: #a78bfa;
+}
+
+/* Needs to outrank `html.dark .nav-links a` above, which would otherwise
+   repaint the active entry with the default light-on-dark colour. */
+html.dark .nav-links a.active,
+html.dark .mobile-nav a.active {
+  color: #a78bfa;
+}
+
+html.dark .mobile-nav a.active {
+  box-shadow: inset 3px 0 0 0 #a78bfa;
+}
+
+html.dark .nav-links a:focus-visible,
+html.dark .mobile-nav a:focus-visible,
+html.dark .mobile-menu-toggle:focus-visible {
+  outline-color: #a78bfa;
 }
 
 html.dark .logo {

--- a/web/src/components/HeroAndDownload.tsx
+++ b/web/src/components/HeroAndDownload.tsx
@@ -1,6 +1,9 @@
 "use client";
 
 import Image from "next/image";
+import Link from "next/link";
+
+import { withBasePath } from "@/lib/basePath";
 
 type HeroAndDownloadProps = {
   onJoinTestFlight: () => void;
@@ -95,6 +98,10 @@ export default function HeroAndDownload({ onJoinTestFlight, onShowComingSoon }: 
                   <i className="fas fa-download" aria-hidden="true" />
                   Download App
                 </a>
+                <Link href={withBasePath("/articles")} className="uh-btn-secondary">
+                  <i className="fas fa-file-lines" aria-hidden="true" />
+                  Read Articles
+                </Link>
                 <a href="#features" className="uh-btn-secondary">
                   <i className="fas fa-play" aria-hidden="true" />
                   Explore Features

--- a/web/src/components/layout/Navbar.tsx
+++ b/web/src/components/layout/Navbar.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 
 import { PageWrapper } from "./index";
+import { useActiveRoute } from "@/hooks/use-active-route";
 import { withBasePath } from "@/lib/basePath";
 
 interface NavbarProps {
@@ -20,6 +21,13 @@ interface NavbarProps {
 export default function Navbar({ activeSection }: NavbarProps) {
   const [scrolled, setScrolled] = useState(false);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const isRouteActive = useActiveRoute();
+
+  // Route-based entries stay highlighted for the whole section, so "Read
+  // Articles" also reads as active on an individual article page.
+  const articlesActive = isRouteActive("/articles");
+  const glossaryActive = isRouteActive("/medical-glossary");
+  const contributeActive = isRouteActive("/contribute");
 
   useEffect(() => {
     const handleScroll = () => setScrolled(window.scrollY > 50);
@@ -75,19 +83,31 @@ export default function Navbar({ activeSection }: NavbarProps) {
             </a>
           </li>
           <li>
-            <Link href={withBasePath("/articles")} className="nav-link-item">
+            <Link
+              href={withBasePath("/articles")}
+              className={`nav-link-item${articlesActive ? " active" : ""}`}
+              aria-current={articlesActive ? "page" : undefined}
+            >
               <i className="fas fa-file-lines nav-item-icon" aria-hidden="true"></i>
               <span className="nav-item-text">Read Articles</span>
             </Link>
           </li>
           <li>
-            <Link href={withBasePath("/medical-glossary")} className="nav-link-item">
+            <Link
+              href={withBasePath("/medical-glossary")}
+              className={`nav-link-item${glossaryActive ? " active" : ""}`}
+              aria-current={glossaryActive ? "page" : undefined}
+            >
               <i className="fas fa-book-medical nav-item-icon" aria-hidden="true"></i>
               <span className="nav-item-text">Medical Glossary</span>
             </Link>
           </li>
           <li>
-            <Link href={withBasePath("/contribute")} className="nav-link-item">
+            <Link
+              href={withBasePath("/contribute")}
+              className={`nav-link-item${contributeActive ? " active" : ""}`}
+              aria-current={contributeActive ? "page" : undefined}
+            >
               <i className="fas fa-users nav-item-icon" aria-hidden="true"></i>
               <span className="nav-item-text">Join Us to Contribute</span>
             </Link>
@@ -114,9 +134,30 @@ export default function Navbar({ activeSection }: NavbarProps) {
         <a href={withBasePath("/#screenshots")} onClick={() => setMobileMenuOpen(false)}>Screenshots</a>
         <a href={withBasePath("/#features")} onClick={() => setMobileMenuOpen(false)}>Platform Highlights</a>
         <a href={withBasePath("/#programs")} onClick={() => setMobileMenuOpen(false)}>Community Programs</a>
-        <Link href={withBasePath("/articles")} onClick={() => setMobileMenuOpen(false)}>Read Articles</Link>
-        <Link href={withBasePath("/medical-glossary")} onClick={() => setMobileMenuOpen(false)}>Medical Glossary</Link>
-        <Link href={withBasePath("/contribute")} onClick={() => setMobileMenuOpen(false)}>Join Us to Contribute</Link>
+        <Link
+          href={withBasePath("/articles")}
+          className={articlesActive ? "active" : undefined}
+          aria-current={articlesActive ? "page" : undefined}
+          onClick={() => setMobileMenuOpen(false)}
+        >
+          Read Articles
+        </Link>
+        <Link
+          href={withBasePath("/medical-glossary")}
+          className={glossaryActive ? "active" : undefined}
+          aria-current={glossaryActive ? "page" : undefined}
+          onClick={() => setMobileMenuOpen(false)}
+        >
+          Medical Glossary
+        </Link>
+        <Link
+          href={withBasePath("/contribute")}
+          className={contributeActive ? "active" : undefined}
+          aria-current={contributeActive ? "page" : undefined}
+          onClick={() => setMobileMenuOpen(false)}
+        >
+          Join Us to Contribute
+        </Link>
         <a href={withBasePath("/#downloads")} onClick={() => setMobileMenuOpen(false)}>Login / Register</a>
       </nav>
     </header>

--- a/web/src/components/ui/navbar.tsx
+++ b/web/src/components/ui/navbar.tsx
@@ -8,12 +8,20 @@ import { PageWrapper } from '../layout'
 
 import { withBasePath } from '@/lib/basePath'
 import { ModeToggle } from '@/components/mode-toggle'
+import { useActiveRoute } from '@/hooks/use-active-route'
 import { useEffect, useMemo, useState } from 'react'
 
 export const Navbar = (props: { tracking_id: string[] }) => {
   const [scrolled, setScrolled] = useState(false)
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
   const [activeSection, setActiveSection] = useState<string>('')
+  const isRouteActive = useActiveRoute()
+
+  // Route-based entries stay highlighted for the whole section, so "Read
+  // Articles" also reads as active on an individual article page.
+  const articlesActive = isRouteActive('/articles')
+  const glossaryActive = isRouteActive('/medical-glossary')
+  const contributeActive = isRouteActive('/contribute')
   // useMemo stabilises the array reference so the IntersectionObserver
   // effect below doesn't re-run on every render (avoids infinite loop).
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -130,7 +138,11 @@ export const Navbar = (props: { tracking_id: string[] }) => {
               </a>
             </li>
             <li>
-              <Link href={withBasePath('/articles')} className="nav-link-item">
+              <Link
+                href={withBasePath('/articles')}
+                className={`nav-link-item${articlesActive ? ' active' : ''}`}
+                aria-current={articlesActive ? 'page' : undefined}
+              >
                 <i
                   className="fas fa-file-lines nav-item-icon"
                   aria-hidden="true"
@@ -141,7 +153,8 @@ export const Navbar = (props: { tracking_id: string[] }) => {
             <li>
               <Link
                 href={withBasePath('/medical-glossary')}
-                className="nav-link-item"
+                className={`nav-link-item${glossaryActive ? ' active' : ''}`}
+                aria-current={glossaryActive ? 'page' : undefined}
               >
                 <i
                   className="fas fa-book-medical nav-item-icon"
@@ -151,7 +164,11 @@ export const Navbar = (props: { tracking_id: string[] }) => {
               </Link>
             </li>
             <li>
-              <Link href={withBasePath('/contribute')} className="nav-link-item">
+              <Link
+                href={withBasePath('/contribute')}
+                className={`nav-link-item${contributeActive ? ' active' : ''}`}
+                aria-current={contributeActive ? 'page' : undefined}
+              >
                 <i
                   className="fas fa-users nav-item-icon"
                   aria-hidden="true"
@@ -181,28 +198,52 @@ export const Navbar = (props: { tracking_id: string[] }) => {
         </PageWrapper>
 
         <nav className={`mobile-nav${mobileMenuOpen ? ' open' : ''}`}>
-          <a href="#screenshots" onClick={() => setMobileMenuOpen(false)}>
+          <a
+            href={withBasePath('/#screenshots')}
+            onClick={() => setMobileMenuOpen(false)}
+          >
             Screenshots
           </a>
-          <a href="#features" onClick={() => setMobileMenuOpen(false)}>
+          <a
+            href={withBasePath('/#features')}
+            onClick={() => setMobileMenuOpen(false)}
+          >
             Platform Highlights
           </a>
-          <a href="#programs" onClick={() => setMobileMenuOpen(false)}>
+          <a
+            href={withBasePath('/#programs')}
+            onClick={() => setMobileMenuOpen(false)}
+          >
             Community Programs
           </a>
-          <a href="https://uhsocial.in/docs" target="_blank" rel="noreferrer" onClick={() => setMobileMenuOpen(false)}>
-            Read Articles
-          </a>
           <Link
-            href="/medical-glossary"
+            href={withBasePath('/articles')}
+            className={articlesActive ? 'active' : undefined}
+            aria-current={articlesActive ? 'page' : undefined}
+            onClick={() => setMobileMenuOpen(false)}
+          >
+            Read Articles
+          </Link>
+          <Link
+            href={withBasePath('/medical-glossary')}
+            className={glossaryActive ? 'active' : undefined}
+            aria-current={glossaryActive ? 'page' : undefined}
             onClick={() => setMobileMenuOpen(false)}
           >
             Medical Glossary
           </Link>
-          <Link href="/contribute" onClick={() => setMobileMenuOpen(false)}>
+          <Link
+            href={withBasePath('/contribute')}
+            className={contributeActive ? 'active' : undefined}
+            aria-current={contributeActive ? 'page' : undefined}
+            onClick={() => setMobileMenuOpen(false)}
+          >
             Join Us to Contribute
           </Link>
-          <a href="#downloads" onClick={() => setMobileMenuOpen(false)}>
+          <a
+            href={withBasePath('/#downloads')}
+            onClick={() => setMobileMenuOpen(false)}
+          >
             Login / Register
           </a>
         </nav>

--- a/web/src/hooks/use-active-route.ts
+++ b/web/src/hooks/use-active-route.ts
@@ -1,0 +1,26 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { useCallback } from "react";
+
+import { routing } from "@/i18n/routing";
+import { BASE_PATH } from "@/lib/basePath";
+import { isNavRouteActive } from "@/lib/nav-active.js";
+
+/**
+ * Returns a predicate that tells whether an app-relative route (e.g. "/articles")
+ * is the one currently being viewed, so the matching navigation entry can be
+ * rendered in its active state.
+ */
+export function useActiveRoute(): (route: string) => boolean {
+  const pathname = usePathname();
+
+  return useCallback(
+    (route: string) =>
+      isNavRouteActive(pathname, route, {
+        basePath: BASE_PATH,
+        locales: routing.locales,
+      }),
+    [pathname]
+  );
+}

--- a/web/src/lib/nav-active.js
+++ b/web/src/lib/nav-active.js
@@ -1,0 +1,61 @@
+/**
+ * Helpers for deciding which navigation entry is the one currently being viewed.
+ *
+ * An app route such as `/articles` is served behind two prefixes that never
+ * appear in the `href` we hand to `<Link>`:
+ *
+ *   1. the deployment base path (`NEXT_PUBLIC_BASE_PATH`, e.g. `/frontend/v2`)
+ *   2. the next-intl locale segment (e.g. `/en`)
+ *
+ * so `usePathname()` reports `/frontend/v2/en/articles`. Both are stripped
+ * before comparing, which keeps the match correct in local development (no
+ * base path, and often no locale segment yet) and in production alike.
+ */
+
+/**
+ * Splits a URL path into its non-empty segments, ignoring query and hash.
+ * @param {string} path
+ * @returns {string[]}
+ */
+function toSegments(path) {
+  return String(path ?? "")
+    .split(/[?#]/)[0]
+    .split("/")
+    .filter(Boolean);
+}
+
+/**
+ * Drops `prefix` from the front of `segments` when it is present.
+ * @param {string[]} segments
+ * @param {string[]} prefix
+ * @returns {string[]}
+ */
+function stripPrefix(segments, prefix) {
+  const hasPrefix = prefix.every((segment, index) => segments[index] === segment);
+  return hasPrefix ? segments.slice(prefix.length) : segments;
+}
+
+/**
+ * Whether `pathname` is `route` or one of its sub-routes, so the matching nav
+ * item can be highlighted. Sub-routes count as active, which keeps "Read
+ * Articles" highlighted while reading a single article (`/articles/<id>`).
+ *
+ * @param {string} pathname current location, e.g. from `usePathname()`
+ * @param {string} route app-relative route, e.g. `/articles`
+ * @param {{ basePath?: string, locales?: ReadonlyArray<string> }} [options]
+ * @returns {boolean}
+ */
+export function isNavRouteActive(pathname, route, options = {}) {
+  const { basePath = "", locales = [] } = options;
+  const baseSegments = toSegments(basePath);
+
+  const routeSegments = stripPrefix(toSegments(route), baseSegments);
+  if (routeSegments.length === 0) return false;
+
+  let pathSegments = stripPrefix(toSegments(pathname), baseSegments);
+  if (pathSegments.length > 0 && locales.includes(pathSegments[0])) {
+    pathSegments = pathSegments.slice(1);
+  }
+
+  return routeSegments.every((segment, index) => pathSegments[index] === segment);
+}

--- a/web/src/lib/nav-active.test.mjs
+++ b/web/src/lib/nav-active.test.mjs
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { isNavRouteActive } from "./nav-active.js";
+
+const LOCALES = ["en", "de", "es", "fr", "hr"];
+const BASE_PATH = "/frontend/v2";
+
+test("matches the route in local development, where there is no base path", () => {
+  assert.equal(isNavRouteActive("/articles", "/articles", { locales: LOCALES }), true);
+  assert.equal(isNavRouteActive("/en/articles", "/articles", { locales: LOCALES }), true);
+});
+
+test("matches the route behind the deployment base path and locale segment", () => {
+  const options = { basePath: BASE_PATH, locales: LOCALES };
+
+  for (const locale of LOCALES) {
+    assert.equal(
+      isNavRouteActive(`${BASE_PATH}/${locale}/articles`, "/articles", options),
+      true,
+      `locale ${locale}`
+    );
+  }
+
+  assert.equal(isNavRouteActive(`${BASE_PATH}/articles`, "/articles", options), true);
+});
+
+test("keeps the articles entry active while reading a single article", () => {
+  const options = { basePath: BASE_PATH, locales: LOCALES };
+
+  assert.equal(isNavRouteActive(`${BASE_PATH}/en/articles/abc123`, "/articles", options), true);
+  assert.equal(isNavRouteActive("/en/articles/abc123", "/articles", options), true);
+});
+
+test("does not match a different route", () => {
+  const options = { basePath: BASE_PATH, locales: LOCALES };
+
+  assert.equal(isNavRouteActive(`${BASE_PATH}/en/contribute`, "/articles", options), false);
+  assert.equal(isNavRouteActive(`${BASE_PATH}/en`, "/articles", options), false);
+  assert.equal(isNavRouteActive(`${BASE_PATH}/en/medical-glossary`, "/articles", options), false);
+});
+
+test("matches whole segments only, never a partial prefix", () => {
+  const options = { basePath: BASE_PATH, locales: LOCALES };
+
+  assert.equal(isNavRouteActive(`${BASE_PATH}/en/articles-archive`, "/articles", options), false);
+  assert.equal(isNavRouteActive("/en/medical-glossary", "/medical", options), false);
+});
+
+test("ignores query strings and hash fragments", () => {
+  const options = { basePath: BASE_PATH, locales: LOCALES };
+
+  assert.equal(isNavRouteActive(`${BASE_PATH}/en/articles?page=3`, "/articles", options), true);
+  assert.equal(isNavRouteActive(`${BASE_PATH}/en/articles#top`, "/articles", options), true);
+});
+
+test("accepts an href that already carries the base path", () => {
+  const options = { basePath: BASE_PATH, locales: LOCALES };
+
+  assert.equal(
+    isNavRouteActive(`${BASE_PATH}/en/articles`, `${BASE_PATH}/articles`, options),
+    true
+  );
+});
+
+test("never marks the home route active, it has no dedicated nav entry", () => {
+  assert.equal(isNavRouteActive("/en", "/", { locales: LOCALES }), false);
+  assert.equal(isNavRouteActive("/en/articles", "/", { locales: LOCALES }), false);
+});
+
+test("tolerates a missing pathname during the first client render", () => {
+  assert.equal(isNavRouteActive("", "/articles", { locales: LOCALES }), false);
+});


### PR DESCRIPTION
Closes #1014

## Overview

Makes the Article Listing Page reachable and discoverable from the Home Page, and shows the user where they are once they get there.

The navbar already carried a **Read Articles** entry, but the pieces the issue asks for were missing: it never showed an active state, the mobile drawer on two pages routed it to the wrong place, and there was no visible keyboard focus indicator.

## What changed

### Navigation entry & routing

- The mobile drawer on **Contribute** and **Our Contributors** (`components/ui/navbar.tsx`) sent **Read Articles** to `https://uhsocial.in/docs` — the external API docs — instead of the Article Listing Page. It now routes to `/articles`.
- The other mobile drawer entries in that navbar dropped `withBasePath()`, so they broke under the `/frontend/v2` deployment base path. They now use it, matching the desktop entries.
- Added a **Read Articles** call-to-action to the Home Page hero, next to *Download App*, so the listing is discoverable without opening the nav menu.

### Active state

`Read Articles`, `Medical Glossary` and `Join Us to Contribute` now get `.active` and `aria-current="page"` when their route is the one being viewed — on desktop and in the mobile drawer.

Matching is done by a new `useActiveRoute()` hook backed by a pure helper, `isNavRouteActive()`. A direct `pathname === href` comparison does not work here: at runtime an app route is served behind the deployment base path (`/frontend/v2`) **and** the next-intl locale segment (`/en`), so `usePathname()` reports `/frontend/v2/en/articles` while the `href` is `/articles`. The helper strips both before comparing, and matches sub-routes so the entry stays lit on an individual article page.

`isNavRouteActive()` is covered by 9 unit tests (`src/lib/nav-active.test.mjs`, wired into `npm test`) across locale prefixes, base paths, sub-routes, query strings and partial-segment near-misses.

### Styling & accessibility

- The active entry in the mobile drawer now mirrors the desktop highlight (accent colour + left accent bar).
- Dark mode: `html.dark .nav-links a` was outranking `.nav-links a.active`, so the active colour was invisible on dark backgrounds. Added a dark-mode override.
- Nav entries and the mobile menu button now render a visible `:focus-visible` ring in both themes. The **Read Articles** entry is reachable in 5 <kbd>Tab</kbd> presses from page load.

### Prerequisite fix — Articles listing rendered blank

`src/app/[locale]/articles/page.tsx` closed its fragment right after the hero comment, leaving the hero section, article grid, pagination and footer as unreachable code after the `return`. The page rendered `<Navbar />` and an empty `<main>`.

This was introduced by [`2b0360b`](https://github.com/SB2318/UltimateHealth/commit/2b0360bfc4b40d967943565dcfa9589b1ad8d6d9) (*"fix: JSX formatting in articles page"*), which wrapped the tree in a fragment but placed the closing tags before the body instead of after it. Restored by moving `</main></>);` to the end of the tree — the JSX itself is untouched.

Without this, "navigation routes correctly to the Article Listing Page" could not be demonstrated: the link worked, but the destination was blank.

## Screenshots

**Home Page — nav entry + new hero call-to-action**

<img src="https://raw.githubusercontent.com/Anijesh/UltimateHealth/assets/issue-1014/home-desktop.png" width="900" alt="Home page with Read Articles in the navbar and a Read Articles call-to-action in the hero" />

**Article Listing Page — active state (desktop)**

<img src="https://raw.githubusercontent.com/Anijesh/UltimateHealth/assets/issue-1014/articles-desktop.png" width="900" alt="Articles listing page with the Read Articles nav entry highlighted and underlined" />

**Dark mode**

<img src="https://raw.githubusercontent.com/Anijesh/UltimateHealth/assets/issue-1014/articles-dark-nav.png" width="900" alt="Navbar in dark mode with the Read Articles entry highlighted in violet" />

**Mobile drawer — active state**

<img src="https://raw.githubusercontent.com/Anijesh/UltimateHealth/assets/issue-1014/articles-mobile-drawer.png" width="320" alt="Mobile navigation drawer with Read Articles highlighted and marked by a left accent bar" />

**Keyboard focus ring**

<img src="https://raw.githubusercontent.com/Anijesh/UltimateHealth/assets/issue-1014/articles-focus-ring.png" width="900" alt="Read Articles nav entry showing a visible focus ring when reached with the Tab key" />

## Acceptance criteria

- [x] Share screenshot
- [x] "Articles" navigation item present in Home Page navigation — kept as **Read Articles** to match the existing label voice (*Medical Glossary*, *Join Us to Contribute*)
- [x] Navigation routes correctly to the Article Listing Page — including the mobile drawer, which previously did not
- [x] Active state is displayed when viewing articles
- [x] Works on desktop, tablet and mobile layouts
- [x] Navigation follows existing design system patterns — reuses the existing `.nav-link-item` / `.active` classes and `--primary` accent, no new component
- [x] Navigation is keyboard accessible

## Verification

```
npm test          # 20/20 pass (9 new)
npx tsc --noEmit  # clean
npm run lint      # no new errors or warnings; the 2 remaining errors are pre-existing on web
npm run build     # compiles successfully
```

Also verified in a real browser (Chrome, `npm run dev`): active state and `aria-current="page"` on `/en/articles` desktop + mobile drawer, dark-mode contrast, focus ring, and every mobile drawer `href` on the Contribute page.

Notes for reviewers:

- `npm run knip` fails on `web` today with `Invalid input (unrecognized_keys: $comment)` — pre-existing, and the workflow is `continue-on-error`. Left alone.
- `src/components/Navbar.tsx` is currently unused (the Home Page inlines its own header), so it was left untouched rather than updated as dead code.
