### PR TITLE
fix: gate chatbot retry on connectivity (#2127)

### DIFF
--- a/frontend/src/__tests__/screens/ai/ChatbotScreen.test.tsx
+++ b/frontend/src/__tests__/screens/ai/ChatbotScreen.test.tsx
@@ -133,6 +133,20 @@ describe('ChatbotScreen', () => {
     });
   });
 
+  const setNetwork = (isConnected: boolean) =>
+    mockuseAppSelector.mockImplementation((selector: any) =>
+      selector({
+        user: {
+          user_id: 'user-1',
+          user_token: 'token-xyz',
+        },
+        network: {isConnected},
+      }),
+    );
+
+  const goOffline = () => setNetwork(false);
+  const goOnline = () => setNetwork(true);
+
   const renderScreen = () =>
     render(
       <ChatbotScreen
@@ -253,5 +267,61 @@ describe('ChatbotScreen', () => {
     expect(getByText('Failed to send message')).toBeTruthy();
     expect(getByText('Unable to connect. Please check your internet connection and try again.')).toBeTruthy();
     expect(mockSendMessageToAI).not.toHaveBeenCalled();
+  });
+
+  it('keeps retry inert while the device is still offline', () => {
+    goOffline();
+
+    const {getByTestId, getByText, queryByText, getByLabelText, getAllByText} =
+      renderScreen();
+
+    const giftedChat = getByTestId('mock-gifted-chat');
+    fireEvent(giftedChat, 'onSend', [{text: 'Hello when offline', _id: 1, createdAt: new Date(), user: {_id: 1}}]);
+
+    // The control announces why it cannot be used instead of offering a retry
+    // that is guaranteed to fail.
+    expect(getByText('Waiting for connection')).toBeTruthy();
+    expect(queryByText('Retry')).toBeNull();
+
+    const retryBtn = getByLabelText('Retry unavailable, waiting for a network connection');
+    expect(retryBtn.props.accessibilityState.disabled).toBe(true);
+
+    fireEvent.press(retryBtn);
+
+    // Still exactly one failure card, and nothing was sent.
+    expect(getAllByText('Failed to send message')).toHaveLength(1);
+    expect(mockSendMessageToAI).not.toHaveBeenCalled();
+  });
+
+  it('sends the stored prompt once the connection is back', () => {
+    goOffline();
+
+    const {getByTestId, getByText, rerender, queryByText} = renderScreen();
+
+    const giftedChat = getByTestId('mock-gifted-chat');
+    fireEvent(giftedChat, 'onSend', [{text: 'My knee hurts', _id: 1, createdAt: new Date(), user: {_id: 1}}]);
+
+    expect(getByText('Waiting for connection')).toBeTruthy();
+
+    // Network comes back.
+    goOnline();
+    rerender(
+      <ChatbotScreen
+        navigation={{navigate: mockNavigate, goBack: mockGoBack} as any}
+        route={{} as any}
+      />,
+    );
+
+    const retryBtn = getByText('Retry');
+    expect(retryBtn).toBeTruthy();
+
+    fireEvent.press(retryBtn);
+
+    // The failure card is cleared and the original prompt is resent.
+    expect(queryByText('Failed to send message')).toBeNull();
+    expect(mockSendMessageToAI).toHaveBeenCalledWith(
+      expect.objectContaining({text: 'My knee hurts'}),
+      expect.any(Object),
+    );
   });
 });

--- a/frontend/src/screens/ai/ChatbotScreen.tsx
+++ b/frontend/src/screens/ai/ChatbotScreen.tsx
@@ -308,6 +308,10 @@ const ChatbotScreen = ({navigation, route}: ChatBotScreenProps) => {
     });
   }, [isConnected, safeSetMessages, sendMessageToAI, setIsLoading, characterId]);
 
+  // A failed message can only be resent once the device is back online and no
+  // other request is in flight; until then the retry control stays inert.
+  const canRetry = isConnected && !isPending;
+
   const onSend = useCallback((newMessages: IMessage[] = []) => {
     if (isPending) {
       return;
@@ -325,12 +329,21 @@ const ChatbotScreen = ({navigation, route}: ChatBotScreenProps) => {
     if (isPending) {
       return;
     }
+    // Retrying while still offline would only swap the failure card for an
+    // identical one, so the prompt is held until the connection is back.
+    if (!isConnected) {
+      Snackbar.show({
+        text: 'Still offline. Your message will be ready to send once you reconnect.',
+        duration: Snackbar.LENGTH_SHORT,
+      });
+      return;
+    }
     safeSetMessages(previousMessages =>
       previousMessages.filter(m => m._id !== failedMessage._id)
     );
 
     performSendMessage(failedMessage.originalPrompt);
-  }, [isPending, safeSetMessages, performSendMessage]);
+  }, [isPending, isConnected, safeSetMessages, performSendMessage]);
 
   return (
     <SafeAreaView style={{flex: 1, backgroundColor: 'white'}} edges={['top']}>
@@ -456,10 +469,20 @@ const ChatbotScreen = ({navigation, route}: ChatBotScreenProps) => {
                     {currentMessage.originalPrompt && (
                       <TouchableOpacity
                         onPress={() => handleRetry(currentMessage)}
+                        disabled={!canRetry}
+                        accessibilityRole="button"
+                        accessibilityState={{disabled: !canRetry}}
+                        accessibilityLabel={
+                          canRetry
+                            ? 'Retry sending message'
+                            : 'Retry unavailable, waiting for a network connection'
+                        }
                         style={{
                           flexDirection: 'row',
                           alignItems: 'center',
-                          backgroundColor: '#dc2626',
+                          backgroundColor: canRetry ? '#dc2626' : '#f3f4f6',
+                          borderWidth: canRetry ? 0 : 1,
+                          borderColor: '#d1d5db',
                           paddingVertical: 8,
                           paddingHorizontal: 16,
                           borderRadius: 8,
@@ -468,9 +491,18 @@ const ChatbotScreen = ({navigation, route}: ChatBotScreenProps) => {
                           gap: 6,
                         }}
                       >
-                        <Ionicons name="refresh" size={16} color="white" />
-                        <Text style={{ color: 'white', fontWeight: '600', fontSize: 14 }}>
-                          Retry
+                        <Ionicons
+                          name={isConnected ? 'refresh' : 'cloud-offline-outline'}
+                          size={16}
+                          color={canRetry ? 'white' : '#4b5563'}
+                        />
+                        <Text
+                          style={{
+                            color: canRetry ? 'white' : '#4b5563',
+                            fontWeight: '600',
+                            fontSize: 14,
+                          }}>
+                          {isConnected ? 'Retry' : 'Waiting for connection'}
                         </Text>
                       </TouchableOpacity>
                     )}


### PR DESCRIPTION
Closes #2127

## Context

The Retry button, the `originalPrompt` metadata and the `handleRetry` handler already exist on `main`. What was missing is the part of the issue that says the handler should call `performSendMessage(prompt)` **once the network is connected** — today it fires regardless of network state.

That produced a control that looked broken: tapping Retry while still offline removed the failure card, ran `performSendMessage`, hit the `!isConnected` branch, and appended an identical failure card. From the user's side the button appeared to do nothing.

## What changed

`frontend/src/screens/ai/ChatbotScreen.tsx`

- **Retry waits for connectivity.** A new `canRetry = isConnected && !isPending` drives the control. While offline it is `disabled` and reads **"Waiting for connection"** with a `cloud-offline-outline` icon on a muted surface, so the reason it cannot be used is visible before the tap rather than after it. Once the connection returns it goes back to the actionable red **"Retry"** state and resends the stored `originalPrompt`.
- **`handleRetry` guards on connectivity too.** If a press slips through it returns early and explains the wait through a snackbar instead of destroying and recreating the failure card. `isConnected` was added to the callback's dependency list.
- **Accessibility.** The control now carries `accessibilityRole="button"`, an `accessibilityState.disabled` flag, and a label that changes with state (`Retry sending message` / `Retry unavailable, waiting for a network connection`).

The disabled styling keeps AA contrast: `#4b5563` on `#f3f4f6` is 6.87:1, and on the `#fee2e2` error card 6.19:1.

### A note on the design choice

"Once the network is connected" could also mean auto-resending the moment connectivity returns. I deliberately did not do that — silently sending a message the user typed minutes earlier, without them asking again, is surprising and can fire several queued prompts at once. Instead the button becomes actionable the moment the network is back, so the send is still the user's decision. Happy to switch to auto-retry if you'd prefer it.

## Tests

Two tests added to `frontend/src/__tests__/screens/ai/ChatbotScreen.test.tsx`:

- **`keeps retry inert while the device is still offline`** — asserts the control renders "Waiting for connection" (not "Retry"), reports `accessibilityState.disabled`, and that pressing it leaves exactly one failure card and sends nothing.
- **`sends the stored prompt once the connection is back`** — sends while offline, flips the network mock to connected, re-renders, and asserts the control becomes "Retry", the failure card clears, and the original prompt is resent.

A `setNetwork` / `goOffline` / `goOnline` helper was added next to `renderScreen` so network state is set the same way in every test.

## Verification

```
yarn test    # 457/458 pass, 130 suites
             # ChatbotScreen suite: 7/7 pass (5 existing + 2 new)
yarn lint    # 0 errors (182 pre-existing warnings, none from this change)
tsc --noEmit # no errors in the changed files
```

Notes for reviewers:

- The single failing test in the full run is `src/__tests__/hooks/article/useGetMostViewedArticle.test.ts`. It passes in isolation both with and without this change, so it is a flake under parallel load and unrelated to this PR.
- `yarn install --immutable` fails on `main` today with `The lockfile would have been modified by this install` (peer-dependency drift in `@lottiefiles/dotlottie-react`, `@babel/core`, `@babel/runtime`, `@react-native/metro-config`, `react-refresh`). Pre-existing and untouched here — `yarn.lock` is not modified by this PR.
