### PR TITLE
feat(web): add authentication infrastructure (#1949)

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,7 @@
     "dev": "node --no-warnings node_modules/next/dist/bin/next dev",
     "build": "next build",
     "start": "next start",
-    "test": "node --no-warnings --test src/app/[locale]/admin-agreement/signatureValidation.test.mjs src/app/api/csp-report/sanitizeCspReport.test.mjs src/components/articles/article-layout.test.mjs src/lib/api.test.mjs src/lib/nav-active.test.mjs",
+    "test": "node --no-warnings --test src/app/[locale]/admin-agreement/signatureValidation.test.mjs src/app/api/csp-report/sanitizeCspReport.test.mjs src/components/articles/article-layout.test.mjs src/lib/api.test.mjs src/lib/nav-active.test.mjs src/lib/auth/auth-helpers.test.mjs",
     "lint": "eslint",
     "knip": "knip",
     "knip:deps": "knip --dependencies",

--- a/web/src/app/[locale]/forgot-password/page.tsx
+++ b/web/src/app/[locale]/forgot-password/page.tsx
@@ -4,17 +4,15 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState, type FormEvent } from "react";
 
-import { PageWrapper, Section } from "@/components/layout";
+import AuthShell, {
+  authErrorClass,
+  authFieldClass,
+  authLabelClass,
+  authLinkClass,
+  authSubmitClass,
+} from "@/components/auth/AuthShell";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Spinner } from "@/components/ui/spinner";
@@ -106,132 +104,183 @@ export default function ForgotPasswordPage() {
   };
 
   return (
-    <Section as="main" className="flex min-h-screen items-center bg-slate-50 px-4 py-10 dark:bg-slate-950">
-      <PageWrapper className="flex max-w-md justify-center px-0">
-        <Card className="w-full rounded-lg shadow-sm">
-          <CardHeader className="items-center text-center">
-            <CardTitle className="text-xl font-semibold">
-              <h1>Reset your password</h1>
-            </CardTitle>
-            <CardDescription>
-              {step === "request"
-                ? "We'll email you a six-digit code to confirm it's you."
-                : `Enter the code sent to ${email} and choose a new password.`}
-            </CardDescription>
-          </CardHeader>
+    <AuthShell
+      title="Reset your password"
+      description={
+        step === "request"
+          ? "We'll email you a six-digit code to confirm it's you."
+          : `Enter the code sent to ${email} and choose a new password.`
+      }
+      footer={
+        <>
+          Remembered it?{" "}
+          <Link href={withBasePath("/login")} className={authLinkClass}>
+            Sign in
+          </Link>
+        </>
+      }
+    >
+      {/* Two steps, one route: the backend splits reset across
+          /user/forgotpassword and /user/verifypassword. */}
+      <ol
+        className="mb-6! flex items-center gap-3 text-[0.72rem]! font-semibold tracking-wide text-slate-400 uppercase dark:text-slate-500"
+        aria-label="Password reset progress"
+      >
+        {(["request", "verify"] as const).map((s2, i) => {
+          const active = step === s2;
+          const done = step === "verify" && s2 === "request";
+          return (
+            <li key={s2} className="flex flex-1 items-center gap-2">
+              <span
+                aria-current={active ? "step" : undefined}
+                className={
+                  "flex size-6 shrink-0 items-center justify-center rounded-full text-[0.7rem]! font-bold transition-colors " +
+                  (active || done
+                    ? "bg-gradient-to-br from-[#667eea] to-[#764ba2] text-white"
+                    : "bg-slate-200 text-slate-500 dark:bg-white/10 dark:text-slate-400")
+                }
+              >
+                {i + 1}
+              </span>
+              <span className={active ? "text-slate-700 dark:text-slate-200" : undefined}>
+                {s2 === "request" ? "Your email" : "New password"}
+              </span>
+            </li>
+          );
+        })}
+      </ol>
 
-          <form onSubmit={step === "request" ? handleRequest : handleVerify} noValidate>
-            <CardContent className="space-y-4">
-              {step === "request" ? (
-                <div className="space-y-2">
-                  <Label htmlFor="email">Email</Label>
-                  <Input
-                    id="email"
-                    type="email"
-                    value={email}
-                    onChange={(e) => setEmail(e.target.value)}
-                    aria-invalid={fieldError?.field === "email"}
-                    aria-describedby={fieldError?.field === "email" ? "reset-error" : undefined}
-                    autoComplete="email"
-                  />
-                </div>
-              ) : (
-                <>
-                  <div className="space-y-2">
-                    <Label htmlFor="otp">Verification code</Label>
-                    <Input
-                      id="otp"
-                      inputMode="numeric"
-                      maxLength={6}
-                      value={otp}
-                      onChange={(e) => setOtp(e.target.value)}
-                      aria-invalid={fieldError?.field === "otp"}
-                      aria-describedby={fieldError?.field === "otp" ? "reset-error" : undefined}
-                      autoComplete="one-time-code"
-                    />
-                  </div>
+      <form
+        onSubmit={step === "request" ? handleRequest : handleVerify}
+        noValidate
+        className="space-y-5!"
+      >
+        {step === "request" ? (
+          <div className="space-y-2!">
+            <Label htmlFor="email" className={authLabelClass}>
+              Email
+            </Label>
+            <Input
+              id="email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              aria-invalid={fieldError?.field === "email"}
+              aria-describedby={fieldError?.field === "email" ? "reset-error" : undefined}
+              autoComplete="email"
+              placeholder="you@example.com"
+              className={authFieldClass}
+            />
+          </div>
+        ) : (
+          <>
+            <div className="space-y-2!">
+              <Label htmlFor="otp" className={authLabelClass}>
+                Verification code
+              </Label>
+              <Input
+                id="otp"
+                inputMode="numeric"
+                maxLength={6}
+                value={otp}
+                onChange={(e) => setOtp(e.target.value)}
+                aria-invalid={fieldError?.field === "otp"}
+                aria-describedby={fieldError?.field === "otp" ? "reset-error" : undefined}
+                autoComplete="one-time-code"
+                placeholder="123456"
+                className={`${authFieldClass} text-center! text-lg! font-semibold tracking-[0.5em]`}
+              />
+            </div>
 
-                  <div className="space-y-2">
-                    <Label htmlFor="newPassword">New password</Label>
-                    <Input
-                      id="newPassword"
-                      type="password"
-                      value={newPassword}
-                      onChange={(e) => setNewPassword(e.target.value)}
-                      aria-invalid={fieldError?.field === "newPassword"}
-                      aria-describedby={
-                        fieldError?.field === "newPassword"
-                          ? "reset-error new-password-hint"
-                          : "new-password-hint"
-                      }
-                      autoComplete="new-password"
-                    />
-                    <p id="new-password-hint" className="text-sm text-muted-foreground">
-                      At least 8 characters, with an uppercase letter, a lowercase
-                      letter, a number and a special character.
-                    </p>
-                  </div>
-                </>
-              )}
-
-              {fieldError && (
-                <p id="reset-error" role="alert" className="text-sm text-destructive">
-                  {fieldError.message}
-                </p>
-              )}
-
-              {formError && (
-                <Alert variant="destructive" role="alert">
-                  <AlertTitle>Something went wrong</AlertTitle>
-                  <AlertDescription>{formError}</AlertDescription>
-                </Alert>
-              )}
-
-              {notice && (
-                <Alert role="status">
-                  <AlertTitle>Check your email</AlertTitle>
-                  <AlertDescription>{notice}</AlertDescription>
-                </Alert>
-              )}
-            </CardContent>
-
-            <CardFooter className="flex-col items-stretch gap-3">
-              <Button type="submit" disabled={submitting}>
-                {submitting && <Spinner size="sm" className="mr-1" />}
-                {step === "request"
-                  ? submitting
-                    ? "Sending code..."
-                    : "Send reset code"
-                  : submitting
-                    ? "Resetting..."
-                    : "Reset password"}
-              </Button>
-
-              {step === "verify" && (
-                <Button
-                  type="button"
-                  variant="ghost"
-                  onClick={() => {
-                    setStep("request");
-                    setNotice(null);
-                    setFormError(null);
-                    setFieldError(null);
-                  }}
-                >
-                  Use a different email
-                </Button>
-              )}
-
-              <p className="text-center text-sm text-muted-foreground">
-                Remembered it?{" "}
-                <Link href={withBasePath("/login")} className="underline">
-                  Sign in
-                </Link>
+            <div className="space-y-2!">
+              <Label htmlFor="newPassword" className={authLabelClass}>
+                New password
+              </Label>
+              <Input
+                id="newPassword"
+                type="password"
+                value={newPassword}
+                onChange={(e) => setNewPassword(e.target.value)}
+                aria-invalid={fieldError?.field === "newPassword"}
+                aria-describedby={
+                  fieldError?.field === "newPassword"
+                    ? "reset-error new-password-hint"
+                    : "new-password-hint"
+                }
+                autoComplete="new-password"
+                className={authFieldClass}
+              />
+              <p
+                id="new-password-hint"
+                className="text-[0.75rem]! leading-relaxed text-slate-500 dark:text-slate-400"
+              >
+                At least 8 characters, with an uppercase letter, a lowercase letter, a
+                number and a special character.
               </p>
-            </CardFooter>
-          </form>
-        </Card>
-      </PageWrapper>
-    </Section>
+            </div>
+          </>
+        )}
+
+        {fieldError && (
+          <p id="reset-error" role="alert" className={authErrorClass}>
+            {fieldError.message}
+          </p>
+        )}
+
+        {formError && (
+          <Alert
+            variant="destructive"
+            role="alert"
+            className="rounded-xl border-rose-200/70 bg-rose-50/80 dark:border-rose-500/30 dark:bg-rose-500/10"
+          >
+            <AlertTitle className="text-[0.85rem]! font-semibold">
+              Something went wrong
+            </AlertTitle>
+            <AlertDescription className="text-[0.8rem]!">{formError}</AlertDescription>
+          </Alert>
+        )}
+
+        {notice && (
+          <Alert
+            role="status"
+            className="rounded-xl border-indigo-200/70 bg-indigo-50/80 dark:border-indigo-400/30 dark:bg-indigo-500/10"
+          >
+            <AlertTitle className="text-[0.85rem]! font-semibold">
+              Check your email
+            </AlertTitle>
+            <AlertDescription className="text-[0.8rem]!">{notice}</AlertDescription>
+          </Alert>
+        )}
+
+        <div className="space-y-2!">
+          <Button type="submit" disabled={submitting} className={authSubmitClass}>
+            {submitting && <Spinner size="sm" className="mr-2" />}
+            {step === "request"
+              ? submitting
+                ? "Sending code..."
+                : "Send reset code"
+              : submitting
+                ? "Resetting..."
+                : "Reset password"}
+          </Button>
+
+          {step === "verify" && (
+            <Button
+              type="button"
+              variant="ghost"
+              className="h-10! w-full rounded-xl text-[0.8rem]! text-slate-600 hover:bg-slate-100/70 dark:text-slate-300 dark:hover:bg-white/5"
+              onClick={() => {
+                setStep("request");
+                setNotice(null);
+                setFormError(null);
+                setFieldError(null);
+              }}
+            >
+              Use a different email
+            </Button>
+          )}
+        </div>
+      </form>
+    </AuthShell>
   );
 }

--- a/web/src/app/[locale]/forgot-password/page.tsx
+++ b/web/src/app/[locale]/forgot-password/page.tsx
@@ -42,7 +42,12 @@ export default function ForgotPasswordPage() {
   const [otp, setOtp] = useState("");
   const [newPassword, setNewPassword] = useState("");
 
-  const [fieldError, setFieldError] = useState<string | null>(null);
+  // Tracks which input the message belongs to, so aria-invalid lands on the
+  // field the user actually has to correct.
+  const [fieldError, setFieldError] = useState<{
+    field: "email" | "otp" | "newPassword";
+    message: string;
+  } | null>(null);
   const [formError, setFormError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
@@ -53,7 +58,7 @@ export default function ForgotPasswordPage() {
     setFieldError(null);
 
     if (!isValidEmail(email)) {
-      setFieldError("Enter a valid email address.");
+      setFieldError({ field: "email", message: "Enter a valid email address." });
       return;
     }
 
@@ -77,12 +82,12 @@ export default function ForgotPasswordPage() {
     setFieldError(null);
 
     if (!isValidOtp(otp)) {
-      setFieldError("Enter the six-digit code from your email.");
+      setFieldError({ field: "otp", message: "Enter the six-digit code from your email." });
       return;
     }
     const passwordError = validatePassword(newPassword);
     if (passwordError) {
-      setFieldError(passwordError);
+      setFieldError({ field: "newPassword", message: passwordError });
       return;
     }
 
@@ -125,7 +130,8 @@ export default function ForgotPasswordPage() {
                     type="email"
                     value={email}
                     onChange={(e) => setEmail(e.target.value)}
-                    aria-invalid={Boolean(fieldError)}
+                    aria-invalid={fieldError?.field === "email"}
+                    aria-describedby={fieldError?.field === "email" ? "reset-error" : undefined}
                     autoComplete="email"
                   />
                 </div>
@@ -139,7 +145,8 @@ export default function ForgotPasswordPage() {
                       maxLength={6}
                       value={otp}
                       onChange={(e) => setOtp(e.target.value)}
-                      aria-invalid={Boolean(fieldError)}
+                      aria-invalid={fieldError?.field === "otp"}
+                      aria-describedby={fieldError?.field === "otp" ? "reset-error" : undefined}
                       autoComplete="one-time-code"
                     />
                   </div>
@@ -151,7 +158,12 @@ export default function ForgotPasswordPage() {
                       type="password"
                       value={newPassword}
                       onChange={(e) => setNewPassword(e.target.value)}
-                      aria-describedby="new-password-hint"
+                      aria-invalid={fieldError?.field === "newPassword"}
+                      aria-describedby={
+                        fieldError?.field === "newPassword"
+                          ? "reset-error new-password-hint"
+                          : "new-password-hint"
+                      }
                       autoComplete="new-password"
                     />
                     <p id="new-password-hint" className="text-sm text-muted-foreground">
@@ -162,7 +174,11 @@ export default function ForgotPasswordPage() {
                 </>
               )}
 
-              {fieldError && <p className="text-sm text-destructive">{fieldError}</p>}
+              {fieldError && (
+                <p id="reset-error" role="alert" className="text-sm text-destructive">
+                  {fieldError.message}
+                </p>
+              )}
 
               {formError && (
                 <Alert variant="destructive" role="alert">

--- a/web/src/app/[locale]/forgot-password/page.tsx
+++ b/web/src/app/[locale]/forgot-password/page.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState, type FormEvent } from "react";
+
+import { PageWrapper, Section } from "@/components/layout";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Spinner } from "@/components/ui/spinner";
+import { useAuth } from "@/hooks/useAuth";
+import {
+  isValidEmail,
+  isValidOtp,
+  validatePassword,
+} from "@/lib/auth/auth-helpers.js";
+import { withBasePath } from "@/lib/basePath";
+
+/**
+ * Reset is two backend calls — `/user/forgotpassword` sends a six-digit OTP,
+ * `/user/verifypassword` consumes it — so the page is a two-step form rather
+ * than two routes. The email is carried over automatically.
+ */
+type Step = "request" | "verify";
+
+export default function ForgotPasswordPage() {
+  const { requestPasswordReset, resetPassword } = useAuth();
+  const router = useRouter();
+
+  const [step, setStep] = useState<Step>("request");
+  const [email, setEmail] = useState("");
+  const [otp, setOtp] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+
+  const [fieldError, setFieldError] = useState<string | null>(null);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleRequest = async (event: FormEvent) => {
+    event.preventDefault();
+    setFormError(null);
+    setFieldError(null);
+
+    if (!isValidEmail(email)) {
+      setFieldError("Enter a valid email address.");
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const message = await requestPasswordReset(email);
+      setNotice(message);
+      setStep("verify");
+    } catch (error) {
+      setFormError(
+        error instanceof Error ? error.message : "Could not send the reset code."
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleVerify = async (event: FormEvent) => {
+    event.preventDefault();
+    setFormError(null);
+    setFieldError(null);
+
+    if (!isValidOtp(otp)) {
+      setFieldError("Enter the six-digit code from your email.");
+      return;
+    }
+    const passwordError = validatePassword(newPassword);
+    if (passwordError) {
+      setFieldError(passwordError);
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const message = await resetPassword({ email, otp, newPassword });
+      setNotice(`${message} Redirecting you to sign in.`);
+      setTimeout(() => router.push(withBasePath("/login")), 1200);
+    } catch (error) {
+      setFormError(
+        error instanceof Error ? error.message : "Could not reset your password."
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Section as="main" className="flex min-h-screen items-center bg-slate-50 px-4 py-10 dark:bg-slate-950">
+      <PageWrapper className="flex max-w-md justify-center px-0">
+        <Card className="w-full rounded-lg shadow-sm">
+          <CardHeader className="items-center text-center">
+            <CardTitle className="text-xl font-semibold">
+              <h1>Reset your password</h1>
+            </CardTitle>
+            <CardDescription>
+              {step === "request"
+                ? "We'll email you a six-digit code to confirm it's you."
+                : `Enter the code sent to ${email} and choose a new password.`}
+            </CardDescription>
+          </CardHeader>
+
+          <form onSubmit={step === "request" ? handleRequest : handleVerify} noValidate>
+            <CardContent className="space-y-4">
+              {step === "request" ? (
+                <div className="space-y-2">
+                  <Label htmlFor="email">Email</Label>
+                  <Input
+                    id="email"
+                    type="email"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    aria-invalid={Boolean(fieldError)}
+                    autoComplete="email"
+                  />
+                </div>
+              ) : (
+                <>
+                  <div className="space-y-2">
+                    <Label htmlFor="otp">Verification code</Label>
+                    <Input
+                      id="otp"
+                      inputMode="numeric"
+                      maxLength={6}
+                      value={otp}
+                      onChange={(e) => setOtp(e.target.value)}
+                      aria-invalid={Boolean(fieldError)}
+                      autoComplete="one-time-code"
+                    />
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="newPassword">New password</Label>
+                    <Input
+                      id="newPassword"
+                      type="password"
+                      value={newPassword}
+                      onChange={(e) => setNewPassword(e.target.value)}
+                      aria-describedby="new-password-hint"
+                      autoComplete="new-password"
+                    />
+                    <p id="new-password-hint" className="text-sm text-muted-foreground">
+                      At least 8 characters, with an uppercase letter, a lowercase
+                      letter, a number and a special character.
+                    </p>
+                  </div>
+                </>
+              )}
+
+              {fieldError && <p className="text-sm text-destructive">{fieldError}</p>}
+
+              {formError && (
+                <Alert variant="destructive" role="alert">
+                  <AlertTitle>Something went wrong</AlertTitle>
+                  <AlertDescription>{formError}</AlertDescription>
+                </Alert>
+              )}
+
+              {notice && (
+                <Alert role="status">
+                  <AlertTitle>Check your email</AlertTitle>
+                  <AlertDescription>{notice}</AlertDescription>
+                </Alert>
+              )}
+            </CardContent>
+
+            <CardFooter className="flex-col items-stretch gap-3">
+              <Button type="submit" disabled={submitting}>
+                {submitting && <Spinner size="sm" className="mr-1" />}
+                {step === "request"
+                  ? submitting
+                    ? "Sending code..."
+                    : "Send reset code"
+                  : submitting
+                    ? "Resetting..."
+                    : "Reset password"}
+              </Button>
+
+              {step === "verify" && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  onClick={() => {
+                    setStep("request");
+                    setNotice(null);
+                    setFormError(null);
+                    setFieldError(null);
+                  }}
+                >
+                  Use a different email
+                </Button>
+              )}
+
+              <p className="text-center text-sm text-muted-foreground">
+                Remembered it?{" "}
+                <Link href={withBasePath("/login")} className="underline">
+                  Sign in
+                </Link>
+              </p>
+            </CardFooter>
+          </form>
+        </Card>
+      </PageWrapper>
+    </Section>
+  );
+}

--- a/web/src/app/[locale]/layout.tsx
+++ b/web/src/app/[locale]/layout.tsx
@@ -7,6 +7,7 @@ import { cn } from '@/lib/utils'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import { headers } from 'next/headers'
 import { ThemeProvider } from '@/components/theme-provider'
+import { AuthProvider } from '@/contexts/AuthContext'
 import { NextIntlClientProvider } from 'next-intl'
 import { getMessages } from 'next-intl/server'
 import { notFound } from 'next/navigation'
@@ -83,7 +84,9 @@ export default async function RootLayout({
             enableSystem
             disableTransitionOnChange
           >
-            <TooltipProvider>{children}</TooltipProvider>
+            <AuthProvider>
+              <TooltipProvider>{children}</TooltipProvider>
+            </AuthProvider>
           </ThemeProvider>
         </NextIntlClientProvider>
       </body>

--- a/web/src/app/[locale]/login/page.tsx
+++ b/web/src/app/[locale]/login/page.tsx
@@ -51,7 +51,18 @@ export default function UserLoginPage() {
     try {
       // The context stores the session, so the rest of the app sees the user
       // without this page having to know how tokens are persisted.
-      await login({ email, password });
+      const user = await login({ email, password });
+
+      // A 200 with no session is still a failed sign-in — reporting success and
+      // redirecting would drop the user on a page that bounces them back.
+      if (!user) {
+        setMessage({
+          title: t("failedTitle"),
+          description: t("failedDefaultDescription"),
+          variant: "destructive",
+        });
+        return;
+      }
 
       setMessage({
         title: t("successTitle"),

--- a/web/src/app/[locale]/login/page.tsx
+++ b/web/src/app/[locale]/login/page.tsx
@@ -5,17 +5,14 @@ import { useState } from "react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { PageWrapper, Section } from "@/components/layout";
+import AuthShell, {
+  authFieldClass,
+  authLabelClass,
+  authLinkClass,
+  authSubmitClass,
+} from "@/components/auth/AuthShell";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Spinner } from "@/components/ui/spinner";
@@ -89,76 +86,92 @@ export default function UserLoginPage() {
     }
   };
 
+  const failed = message?.variant === "destructive";
+
   return (
-    <Section
-      as="main"
-      className="flex min-h-screen items-center bg-slate-50 px-4 py-10"
+    <AuthShell
+      title={t("heading")}
+      description={t("description")}
+      footer={
+        <>
+          New to UltimateHealth?{" "}
+          <Link href={withBasePath("/register")} className={authLinkClass}>
+            Create an account
+          </Link>
+        </>
+      }
     >
-      <PageWrapper className="flex max-w-md justify-center px-0">
-        <Card className="w-full rounded-lg shadow-sm">
-          <CardHeader className="items-center text-center">
-            <div className="mb-2 flex size-12 items-center justify-center rounded-lg bg-primary/10 text-primary">
-              <span className="text-sm font-semibold" aria-hidden="true">
-                UH
-              </span>
-            </div>
-            <CardTitle className="text-xl font-semibold">
-              <h1>{t("heading")}</h1>
-            </CardTitle>
-            <CardDescription>{t("description")}</CardDescription>
-          </CardHeader>
+      <form id="loginForm" onSubmit={handleSubmit} className="space-y-5!">
+        <div className="space-y-2!">
+          <Label htmlFor="email" className={authLabelClass}>
+            {t("emailLabel")}
+          </Label>
+          <Input
+            id="email"
+            type="email"
+            required
+            placeholder={t("emailPlaceholder")}
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            autoComplete="email"
+            className={authFieldClass}
+          />
+        </div>
 
-          <form id="loginForm" onSubmit={handleSubmit}>
-            <CardContent className="space-y-4">
-              <div className="space-y-2">
-                <Label htmlFor="email">{t("emailLabel")}</Label>
-                <Input
-                  id="email"
-                  type="email"
-                  required
-                  placeholder={t("emailPlaceholder")}
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
-                />
-              </div>
+        <div className="space-y-2!">
+          <div className="flex items-baseline justify-between gap-3">
+            <Label htmlFor="password" className={authLabelClass}>
+              {t("passwordLabel")}
+            </Label>
+            <Link
+              href={withBasePath("/forgot-password")}
+              className={`${authLinkClass} text-[0.78rem]`}
+            >
+              Forgot password?
+            </Link>
+          </div>
+          <Input
+            id="password"
+            type="password"
+            required
+            placeholder={t("passwordPlaceholder")}
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            autoComplete="current-password"
+            className={authFieldClass}
+          />
+        </div>
 
-              <div className="space-y-2">
-                <Label htmlFor="password">{t("passwordLabel")}</Label>
-                <Input
-                  id="password"
-                  type="password"
-                  required
-                  placeholder={t("passwordPlaceholder")}
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                />
-              </div>
+        {message && (
+          <Alert
+            id="msg"
+            variant={message.variant}
+            role="status"
+            className={
+              failed
+                ? "rounded-xl border-rose-200/70 bg-rose-50/80 dark:border-rose-500/30 dark:bg-rose-500/10"
+                : "rounded-xl border-indigo-200/70 bg-indigo-50/80 dark:border-indigo-400/30 dark:bg-indigo-500/10"
+            }
+          >
+            <AlertTitle className="text-[0.85rem] font-semibold">
+              {message.title}
+            </AlertTitle>
+            <AlertDescription className="text-[0.8rem]">
+              {message.description}
+            </AlertDescription>
+          </Alert>
+        )}
 
-              {message && (
-                <Alert id="msg" variant={message.variant} role="status">
-                  <AlertTitle>{message.title}</AlertTitle>
-                  <AlertDescription>{message.description}</AlertDescription>
-                </Alert>
-              )}
-            </CardContent>
-
-            <CardFooter className="flex-col items-stretch gap-3">
-              <Button type="submit" id="login-btn" disabled={loading}>
-                {loading && <Spinner size="sm" className="mr-1" />}
-                {loading ? t("submitButtonLoading") : t("submitButton")}
-              </Button>
-              <div className="flex flex-wrap justify-between gap-2 text-sm text-muted-foreground">
-                <Link href={withBasePath("/forgot-password")} className="underline">
-                  Forgot password?
-                </Link>
-                <Link href={withBasePath("/register")} className="underline">
-                  Create an account
-                </Link>
-              </div>
-            </CardFooter>
-          </form>
-        </Card>
-      </PageWrapper>
-    </Section>
+        <Button
+          type="submit"
+          id="login-btn"
+          disabled={loading}
+          className={authSubmitClass}
+        >
+          {loading && <Spinner size="sm" className="mr-2" />}
+          {loading ? t("submitButtonLoading") : t("submitButton")}
+        </Button>
+      </form>
+    </AuthShell>
   );
 }

--- a/web/src/app/[locale]/login/page.tsx
+++ b/web/src/app/[locale]/login/page.tsx
@@ -2,7 +2,8 @@
 
 import type { FormEvent } from "react";
 import { useState } from "react";
-import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { PageWrapper, Section } from "@/components/layout";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
@@ -18,10 +19,15 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Spinner } from "@/components/ui/spinner";
-import { getApiUrl } from "@/lib/api";
+import { useAuth } from "@/hooks/useAuth";
+import { withBasePath } from "@/lib/basePath";
+
+/** Where to land after signing in when no `next` param was supplied. */
+const DEFAULT_REDIRECT = "/delete-account";
 
 export default function UserLoginPage() {
   const t = useTranslations("Login");
+  const { login } = useAuth();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [message, setMessage] = useState<{
@@ -31,6 +37,7 @@ export default function UserLoginPage() {
   } | null>(null);
   const [loading, setLoading] = useState(false);
   const router = useRouter();
+  const searchParams = useSearchParams();
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
@@ -41,32 +48,29 @@ export default function UserLoginPage() {
     setLoading(true);
 
     try {
-      const res = await fetch(getApiUrl("/user/login"), {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        credentials: "include",
-        body: JSON.stringify({ email, password, fcmToken: "web-client-login" }),
+      // The context stores the session, so the rest of the app sees the user
+      // without this page having to know how tokens are persisted.
+      await login({ email, password });
+
+      setMessage({
+        title: t("successTitle"),
+        description: t("successDescription"),
       });
 
-      const data = await res.json();
+      // Only same-origin paths are honoured, so a crafted `next` cannot bounce
+      // the user to another site after signing in.
+      const requested = searchParams?.get("next");
+      const destination =
+        requested && requested.startsWith("/") && !requested.startsWith("//")
+          ? requested
+          : withBasePath(DEFAULT_REDIRECT);
 
-      if (res.ok) {
-        setMessage({
-          title: t("successTitle"),
-          description: t("successDescription"),
-        });
-        setTimeout(() => router.push("/delete-account"), 1000);
-      } else {
-        setMessage({
-          title: t("failedTitle"),
-          description: data.error || data.message || t("failedDefaultDescription"),
-          variant: "destructive",
-        });
-      }
+      setTimeout(() => router.push(destination), 1000);
     } catch (err: unknown) {
       setMessage({
-        title: t("serverErrorTitle"),
-        description: err instanceof Error ? err.message : "Unknown error",
+        title: t("failedTitle"),
+        description:
+          err instanceof Error ? err.message : t("failedDefaultDescription"),
         variant: "destructive",
       });
     } finally {
@@ -127,11 +131,19 @@ export default function UserLoginPage() {
               )}
             </CardContent>
 
-            <CardFooter className="justify-end">
+            <CardFooter className="flex-col items-stretch gap-3">
               <Button type="submit" id="login-btn" disabled={loading}>
                 {loading && <Spinner size="sm" className="mr-1" />}
                 {loading ? t("submitButtonLoading") : t("submitButton")}
               </Button>
+              <div className="flex flex-wrap justify-between gap-2 text-sm text-muted-foreground">
+                <Link href={withBasePath("/forgot-password")} className="underline">
+                  Forgot password?
+                </Link>
+                <Link href={withBasePath("/register")} className="underline">
+                  Create an account
+                </Link>
+              </div>
             </CardFooter>
           </form>
         </Card>

--- a/web/src/app/[locale]/login/page.tsx
+++ b/web/src/app/[locale]/login/page.tsx
@@ -20,6 +20,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Spinner } from "@/components/ui/spinner";
 import { useAuth } from "@/hooks/useAuth";
+import { safeRedirectPath } from "@/lib/auth/auth-helpers.js";
 import { withBasePath } from "@/lib/basePath";
 
 /** Where to land after signing in when no `next` param was supplied. */
@@ -58,12 +59,11 @@ export default function UserLoginPage() {
       });
 
       // Only same-origin paths are honoured, so a crafted `next` cannot bounce
-      // the user to another site after signing in.
-      const requested = searchParams?.get("next");
+      // the user to another site after signing in. A leading-slash test is not
+      // enough here — see safeRedirectPath for the shapes that defeat it.
       const destination =
-        requested && requested.startsWith("/") && !requested.startsWith("//")
-          ? requested
-          : withBasePath(DEFAULT_REDIRECT);
+        safeRedirectPath(searchParams?.get("next"), window.location.origin) ??
+        withBasePath(DEFAULT_REDIRECT);
 
       setTimeout(() => router.push(destination), 1000);
     } catch (err: unknown) {

--- a/web/src/app/[locale]/register/page.tsx
+++ b/web/src/app/[locale]/register/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import Link from "next/link";
-import { useRouter } from "next/navigation";
 import { useState, type FormEvent } from "react";
 
 import { PageWrapper, Section } from "@/components/layout";
@@ -49,7 +48,6 @@ const DOCTOR_ONLY_ERRORS = [
 
 export default function RegisterPage() {
   const { register } = useAuth();
-  const router = useRouter();
 
   const [userName, setUserName] = useState("");
   const [userHandle, setUserHandle] = useState("");
@@ -111,7 +109,7 @@ export default function RegisterPage() {
 
     setSubmitting(true);
     try {
-      const user = await register({
+      const outcome = await register({
         user_name: userName,
         user_handle: userHandle,
         email,
@@ -123,15 +121,15 @@ export default function RegisterPage() {
         Years_of_experience: isDoctor ? Number(yearsOfExperience) : undefined,
       });
 
-      if (user) {
-        router.replace(withBasePath("/"));
-        return;
+      // Sign-up never signs the user in: the address has to be verified first,
+      // so the next step is always the inbox and then the login page.
+      if (outcome.verificationEmailSent) {
+        setNotice(
+          `Account created. Check ${email} to verify your address, then sign in.`
+        );
+      } else {
+        setFormError(outcome.message);
       }
-
-      // No session yet: the backend wants the address verified first.
-      setNotice(
-        "Account created. Check your inbox to verify your email, then sign in."
-      );
     } catch (error) {
       setFormError(
         error instanceof Error ? error.message : "Registration failed. Please try again."

--- a/web/src/app/[locale]/register/page.tsx
+++ b/web/src/app/[locale]/register/page.tsx
@@ -1,0 +1,336 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState, type FormEvent } from "react";
+
+import { PageWrapper, Section } from "@/components/layout";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Spinner } from "@/components/ui/spinner";
+import { useAuth } from "@/hooks/useAuth";
+import {
+  isValidEmail,
+  validatePassword,
+  validateUserHandle,
+  validateUserName,
+} from "@/lib/auth/auth-helpers.js";
+import { withBasePath } from "@/lib/basePath";
+
+interface FieldErrors {
+  user_name?: string;
+  user_handle?: string;
+  email?: string;
+  password?: string;
+  contact_detail?: string;
+  qualification?: string;
+  specialization?: string;
+  Years_of_experience?: string;
+}
+
+export default function RegisterPage() {
+  const { register } = useAuth();
+  const router = useRouter();
+
+  const [userName, setUserName] = useState("");
+  const [userHandle, setUserHandle] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [contactDetail, setContactDetail] = useState("");
+  const [isDoctor, setIsDoctor] = useState(false);
+  const [qualification, setQualification] = useState("");
+  const [specialization, setSpecialization] = useState("");
+  const [yearsOfExperience, setYearsOfExperience] = useState("");
+
+  const [errors, setErrors] = useState<FieldErrors>({});
+  const [formError, setFormError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  // Mirrors the backend rules so problems surface before the round trip.
+  const validate = (): FieldErrors => {
+    const next: FieldErrors = {};
+
+    next.user_name = validateUserName(userName) ?? undefined;
+    next.user_handle = validateUserHandle(userHandle) ?? undefined;
+    if (!isValidEmail(email)) next.email = "Enter a valid email address.";
+    next.password = validatePassword(password) ?? undefined;
+
+    // Optional for readers, required for doctors.
+    if (isDoctor && !contactDetail.trim()) {
+      next.contact_detail = "Doctors must provide a contact number.";
+    } else if (contactDetail.trim() && !/^\d{10,15}$/.test(contactDetail.trim())) {
+      next.contact_detail = "Contact number must be 10 to 15 digits.";
+    }
+
+    if (isDoctor) {
+      if (qualification.trim().length < 2) {
+        next.qualification = "Enter your qualification.";
+      }
+      if (specialization.trim().length < 2) {
+        next.specialization = "Enter your specialization.";
+      }
+      const years = Number(yearsOfExperience);
+      if (!yearsOfExperience.trim() || Number.isNaN(years) || years < 0 || years > 60) {
+        next.Years_of_experience = "Enter years of experience between 0 and 60.";
+      }
+    }
+
+    return Object.fromEntries(
+      Object.entries(next).filter(([, value]) => Boolean(value))
+    );
+  };
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    setFormError(null);
+    setNotice(null);
+
+    const fieldErrors = validate();
+    setErrors(fieldErrors);
+    if (Object.keys(fieldErrors).length > 0) return;
+
+    setSubmitting(true);
+    try {
+      const user = await register({
+        user_name: userName,
+        user_handle: userHandle,
+        email,
+        password,
+        isDoctor,
+        contact_detail: contactDetail || undefined,
+        qualification: isDoctor ? qualification : undefined,
+        specialization: isDoctor ? specialization : undefined,
+        Years_of_experience: isDoctor ? Number(yearsOfExperience) : undefined,
+      });
+
+      if (user) {
+        router.replace(withBasePath("/"));
+        return;
+      }
+
+      // No session yet: the backend wants the address verified first.
+      setNotice(
+        "Account created. Check your inbox to verify your email, then sign in."
+      );
+    } catch (error) {
+      setFormError(
+        error instanceof Error ? error.message : "Registration failed. Please try again."
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Section as="main" className="flex min-h-screen items-center bg-slate-50 px-4 py-10 dark:bg-slate-950">
+      <PageWrapper className="flex max-w-xl justify-center px-0">
+        <Card className="w-full rounded-lg shadow-sm">
+          <CardHeader className="items-center text-center">
+            <CardTitle className="text-xl font-semibold">
+              <h1>Create your account</h1>
+            </CardTitle>
+            <CardDescription>
+              Join UltimateHealth to publish health knowledge and follow the community.
+            </CardDescription>
+          </CardHeader>
+
+          <form onSubmit={handleSubmit} noValidate>
+            <CardContent className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="user_name">Full name</Label>
+                <Input
+                  id="user_name"
+                  value={userName}
+                  onChange={(e) => setUserName(e.target.value)}
+                  aria-invalid={Boolean(errors.user_name)}
+                  aria-describedby={errors.user_name ? "user_name-error" : undefined}
+                  autoComplete="name"
+                />
+                {errors.user_name && (
+                  <p id="user_name-error" className="text-sm text-destructive">
+                    {errors.user_name}
+                  </p>
+                )}
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="user_handle">Handle</Label>
+                <Input
+                  id="user_handle"
+                  value={userHandle}
+                  onChange={(e) => setUserHandle(e.target.value)}
+                  placeholder="ada_lovelace"
+                  aria-invalid={Boolean(errors.user_handle)}
+                  aria-describedby={errors.user_handle ? "user_handle-error" : undefined}
+                  autoComplete="username"
+                />
+                {errors.user_handle && (
+                  <p id="user_handle-error" className="text-sm text-destructive">
+                    {errors.user_handle}
+                  </p>
+                )}
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="email">Email</Label>
+                <Input
+                  id="email"
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  aria-invalid={Boolean(errors.email)}
+                  aria-describedby={errors.email ? "email-error" : undefined}
+                  autoComplete="email"
+                />
+                {errors.email && (
+                  <p id="email-error" className="text-sm text-destructive">
+                    {errors.email}
+                  </p>
+                )}
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="password">Password</Label>
+                <Input
+                  id="password"
+                  type="password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  aria-invalid={Boolean(errors.password)}
+                  aria-describedby="password-hint"
+                  autoComplete="new-password"
+                />
+                <p id="password-hint" className="text-sm text-muted-foreground">
+                  At least 8 characters, with an uppercase letter, a lowercase letter,
+                  a number and a special character.
+                </p>
+                {errors.password && (
+                  <p className="text-sm text-destructive">{errors.password}</p>
+                )}
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="contact_detail">
+                  Contact number{isDoctor ? "" : " (optional)"}
+                </Label>
+                <Input
+                  id="contact_detail"
+                  inputMode="numeric"
+                  value={contactDetail}
+                  onChange={(e) => setContactDetail(e.target.value)}
+                  aria-invalid={Boolean(errors.contact_detail)}
+                  autoComplete="tel"
+                />
+                {errors.contact_detail && (
+                  <p className="text-sm text-destructive">{errors.contact_detail}</p>
+                )}
+              </div>
+
+              <div className="flex items-center gap-2">
+                <Checkbox
+                  id="isDoctor"
+                  checked={isDoctor}
+                  onCheckedChange={(checked) => setIsDoctor(checked === true)}
+                />
+                <Label htmlFor="isDoctor" className="font-normal">
+                  I am a medical professional
+                </Label>
+              </div>
+
+              {isDoctor && (
+                <fieldset className="space-y-4 rounded-md border p-4">
+                  <legend className="px-1 text-sm font-medium">
+                    Professional details
+                  </legend>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="qualification">Qualification</Label>
+                    <Input
+                      id="qualification"
+                      value={qualification}
+                      onChange={(e) => setQualification(e.target.value)}
+                      aria-invalid={Boolean(errors.qualification)}
+                    />
+                    {errors.qualification && (
+                      <p className="text-sm text-destructive">{errors.qualification}</p>
+                    )}
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="specialization">Specialization</Label>
+                    <Input
+                      id="specialization"
+                      value={specialization}
+                      onChange={(e) => setSpecialization(e.target.value)}
+                      aria-invalid={Boolean(errors.specialization)}
+                    />
+                    {errors.specialization && (
+                      <p className="text-sm text-destructive">{errors.specialization}</p>
+                    )}
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="Years_of_experience">Years of experience</Label>
+                    <Input
+                      id="Years_of_experience"
+                      type="number"
+                      min={0}
+                      max={60}
+                      value={yearsOfExperience}
+                      onChange={(e) => setYearsOfExperience(e.target.value)}
+                      aria-invalid={Boolean(errors.Years_of_experience)}
+                    />
+                    {errors.Years_of_experience && (
+                      <p className="text-sm text-destructive">
+                        {errors.Years_of_experience}
+                      </p>
+                    )}
+                  </div>
+                </fieldset>
+              )}
+
+              {formError && (
+                <Alert variant="destructive" role="alert">
+                  <AlertTitle>Registration failed</AlertTitle>
+                  <AlertDescription>{formError}</AlertDescription>
+                </Alert>
+              )}
+
+              {notice && (
+                <Alert role="status">
+                  <AlertTitle>Almost there</AlertTitle>
+                  <AlertDescription>{notice}</AlertDescription>
+                </Alert>
+              )}
+            </CardContent>
+
+            <CardFooter className="flex-col items-stretch gap-3">
+              <Button type="submit" disabled={submitting}>
+                {submitting && <Spinner size="sm" className="mr-1" />}
+                {submitting ? "Creating account..." : "Create account"}
+              </Button>
+              <p className="text-center text-sm text-muted-foreground">
+                Already have an account?{" "}
+                <Link href={withBasePath("/login")} className="underline">
+                  Sign in
+                </Link>
+              </p>
+            </CardFooter>
+          </form>
+        </Card>
+      </PageWrapper>
+    </Section>
+  );
+}

--- a/web/src/app/[locale]/register/page.tsx
+++ b/web/src/app/[locale]/register/page.tsx
@@ -39,6 +39,14 @@ interface FieldErrors {
   Years_of_experience?: string;
 }
 
+/** Cleared when "I am a medical professional" is unticked. */
+const DOCTOR_ONLY_ERRORS = [
+  "qualification",
+  "specialization",
+  "Years_of_experience",
+  "contact_detail",
+] as const satisfies readonly (keyof FieldErrors)[];
+
 export default function RegisterPage() {
   const { register } = useAuth();
   const router = useRouter();
@@ -159,7 +167,7 @@ export default function RegisterPage() {
                   autoComplete="name"
                 />
                 {errors.user_name && (
-                  <p id="user_name-error" className="text-sm text-destructive">
+                  <p id="user_name-error" role="alert" className="text-sm text-destructive">
                     {errors.user_name}
                   </p>
                 )}
@@ -177,7 +185,7 @@ export default function RegisterPage() {
                   autoComplete="username"
                 />
                 {errors.user_handle && (
-                  <p id="user_handle-error" className="text-sm text-destructive">
+                  <p id="user_handle-error" role="alert" className="text-sm text-destructive">
                     {errors.user_handle}
                   </p>
                 )}
@@ -195,7 +203,7 @@ export default function RegisterPage() {
                   autoComplete="email"
                 />
                 {errors.email && (
-                  <p id="email-error" className="text-sm text-destructive">
+                  <p id="email-error" role="alert" className="text-sm text-destructive">
                     {errors.email}
                   </p>
                 )}
@@ -209,7 +217,9 @@ export default function RegisterPage() {
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
                   aria-invalid={Boolean(errors.password)}
-                  aria-describedby="password-hint"
+                  aria-describedby={
+                    errors.password ? "password-error password-hint" : "password-hint"
+                  }
                   autoComplete="new-password"
                 />
                 <p id="password-hint" className="text-sm text-muted-foreground">
@@ -217,7 +227,9 @@ export default function RegisterPage() {
                   a number and a special character.
                 </p>
                 {errors.password && (
-                  <p className="text-sm text-destructive">{errors.password}</p>
+                  <p id="password-error" role="alert" className="text-sm text-destructive">
+                    {errors.password}
+                  </p>
                 )}
               </div>
 
@@ -231,10 +243,13 @@ export default function RegisterPage() {
                   value={contactDetail}
                   onChange={(e) => setContactDetail(e.target.value)}
                   aria-invalid={Boolean(errors.contact_detail)}
+                  aria-describedby={errors.contact_detail ? "contact_detail-error" : undefined}
                   autoComplete="tel"
                 />
                 {errors.contact_detail && (
-                  <p className="text-sm text-destructive">{errors.contact_detail}</p>
+                  <p id="contact_detail-error" role="alert" className="text-sm text-destructive">
+                    {errors.contact_detail}
+                  </p>
                 )}
               </div>
 
@@ -242,7 +257,20 @@ export default function RegisterPage() {
                 <Checkbox
                   id="isDoctor"
                   checked={isDoctor}
-                  onCheckedChange={(checked) => setIsDoctor(checked === true)}
+                  onCheckedChange={(checked) => {
+                    const next = checked === true;
+                    setIsDoctor(next);
+                    // Errors raised by the doctor-only rules no longer apply, and
+                    // a "doctors must provide a contact number" message under a
+                    // field now labelled optional is just confusing.
+                    if (!next) {
+                      setErrors((current) => {
+                        const remaining = { ...current };
+                        for (const key of DOCTOR_ONLY_ERRORS) delete remaining[key];
+                        return remaining;
+                      });
+                    }
+                  }}
                 />
                 <Label htmlFor="isDoctor" className="font-normal">
                   I am a medical professional
@@ -262,9 +290,12 @@ export default function RegisterPage() {
                       value={qualification}
                       onChange={(e) => setQualification(e.target.value)}
                       aria-invalid={Boolean(errors.qualification)}
+                      aria-describedby={errors.qualification ? "qualification-error" : undefined}
                     />
                     {errors.qualification && (
-                      <p className="text-sm text-destructive">{errors.qualification}</p>
+                      <p id="qualification-error" role="alert" className="text-sm text-destructive">
+                        {errors.qualification}
+                      </p>
                     )}
                   </div>
 
@@ -275,9 +306,12 @@ export default function RegisterPage() {
                       value={specialization}
                       onChange={(e) => setSpecialization(e.target.value)}
                       aria-invalid={Boolean(errors.specialization)}
+                      aria-describedby={errors.specialization ? "specialization-error" : undefined}
                     />
                     {errors.specialization && (
-                      <p className="text-sm text-destructive">{errors.specialization}</p>
+                      <p id="specialization-error" role="alert" className="text-sm text-destructive">
+                        {errors.specialization}
+                      </p>
                     )}
                   </div>
 
@@ -291,9 +325,12 @@ export default function RegisterPage() {
                       value={yearsOfExperience}
                       onChange={(e) => setYearsOfExperience(e.target.value)}
                       aria-invalid={Boolean(errors.Years_of_experience)}
+                      aria-describedby={
+                        errors.Years_of_experience ? "Years_of_experience-error" : undefined
+                      }
                     />
                     {errors.Years_of_experience && (
-                      <p className="text-sm text-destructive">
+                      <p id="Years_of_experience-error" role="alert" className="text-sm text-destructive">
                         {errors.Years_of_experience}
                       </p>
                     )}

--- a/web/src/app/[locale]/register/page.tsx
+++ b/web/src/app/[locale]/register/page.tsx
@@ -3,17 +3,15 @@
 import Link from "next/link";
 import { useState, type FormEvent } from "react";
 
-import { PageWrapper, Section } from "@/components/layout";
+import AuthShell, {
+  authErrorClass,
+  authFieldClass,
+  authLabelClass,
+  authLinkClass,
+  authSubmitClass,
+} from "@/components/auth/AuthShell";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -140,232 +138,267 @@ export default function RegisterPage() {
   };
 
   return (
-    <Section as="main" className="flex min-h-screen items-center bg-slate-50 px-4 py-10 dark:bg-slate-950">
-      <PageWrapper className="flex max-w-xl justify-center px-0">
-        <Card className="w-full rounded-lg shadow-sm">
-          <CardHeader className="items-center text-center">
-            <CardTitle className="text-xl font-semibold">
-              <h1>Create your account</h1>
-            </CardTitle>
-            <CardDescription>
-              Join UltimateHealth to publish health knowledge and follow the community.
-            </CardDescription>
-          </CardHeader>
-
-          <form onSubmit={handleSubmit} noValidate>
-            <CardContent className="space-y-4">
-              <div className="space-y-2">
-                <Label htmlFor="user_name">Full name</Label>
+    <AuthShell
+      width="lg"
+      title="Create your account"
+      description="Join UltimateHealth to publish health knowledge and follow the community."
+      footer={
+        <>
+          Already have an account?{" "}
+          <Link href={withBasePath("/login")} className={authLinkClass}>
+            Sign in
+          </Link>
+        </>
+      }
+    >
+      <form onSubmit={handleSubmit} noValidate className="space-y-5!">
+        <div className="grid gap-5 sm:grid-cols-2">
+              <div className="space-y-2!">
+                <Label htmlFor="user_name" className={authLabelClass}>
+                  Full name
+                </Label>
                 <Input
                   id="user_name"
+                  autoComplete="name"
                   value={userName}
                   onChange={(e) => setUserName(e.target.value)}
                   aria-invalid={Boolean(errors.user_name)}
                   aria-describedby={errors.user_name ? "user_name-error" : undefined}
-                  autoComplete="name"
+                  className={authFieldClass}
                 />
                 {errors.user_name && (
-                  <p id="user_name-error" role="alert" className="text-sm text-destructive">
+                  <p id="user_name-error" role="alert" className={authErrorClass}>
                     {errors.user_name}
                   </p>
                 )}
               </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="user_handle">Handle</Label>
+              <div className="space-y-2!">
+                <Label htmlFor="user_handle" className={authLabelClass}>
+                  Handle
+                </Label>
                 <Input
                   id="user_handle"
+                  placeholder="ada_lovelace"
+                  autoComplete="username"
                   value={userHandle}
                   onChange={(e) => setUserHandle(e.target.value)}
-                  placeholder="ada_lovelace"
                   aria-invalid={Boolean(errors.user_handle)}
                   aria-describedby={errors.user_handle ? "user_handle-error" : undefined}
-                  autoComplete="username"
+                  className={authFieldClass}
                 />
                 {errors.user_handle && (
-                  <p id="user_handle-error" role="alert" className="text-sm text-destructive">
+                  <p id="user_handle-error" role="alert" className={authErrorClass}>
                     {errors.user_handle}
                   </p>
                 )}
               </div>
+        </div>
 
-              <div className="space-y-2">
-                <Label htmlFor="email">Email</Label>
+              <div className="space-y-2!">
+                <Label htmlFor="email" className={authLabelClass}>
+                  Email
+                </Label>
                 <Input
                   id="email"
                   type="email"
+                  autoComplete="email"
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
                   aria-invalid={Boolean(errors.email)}
                   aria-describedby={errors.email ? "email-error" : undefined}
-                  autoComplete="email"
+                  className={authFieldClass}
                 />
                 {errors.email && (
-                  <p id="email-error" role="alert" className="text-sm text-destructive">
+                  <p id="email-error" role="alert" className={authErrorClass}>
                     {errors.email}
                   </p>
                 )}
               </div>
 
-              <div className="space-y-2">
-                <Label htmlFor="password">Password</Label>
+        <div className="space-y-2!">
+          <Label htmlFor="password" className={authLabelClass}>
+            Password
+          </Label>
+          <Input
+            id="password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            aria-invalid={Boolean(errors.password)}
+            aria-describedby={
+              errors.password ? "password-error password-hint" : "password-hint"
+            }
+            autoComplete="new-password"
+            className={authFieldClass}
+          />
+          <p
+            id="password-hint"
+            className="text-[0.75rem]! leading-relaxed text-slate-500 dark:text-slate-400"
+          >
+            At least 8 characters, with an uppercase letter, a lowercase letter, a
+            number and a special character.
+          </p>
+          {errors.password && (
+            <p id="password-error" role="alert" className={authErrorClass}>
+              {errors.password}
+            </p>
+          )}
+        </div>
+
+        <div className="space-y-2!">
+          <Label htmlFor="contact_detail" className={authLabelClass}>
+            Contact number{isDoctor ? "" : " (optional)"}
+          </Label>
+          <Input
+            id="contact_detail"
+            inputMode="numeric"
+            value={contactDetail}
+            onChange={(e) => setContactDetail(e.target.value)}
+            aria-invalid={Boolean(errors.contact_detail)}
+            aria-describedby={errors.contact_detail ? "contact_detail-error" : undefined}
+            autoComplete="tel"
+            className={authFieldClass}
+          />
+          {errors.contact_detail && (
+            <p id="contact_detail-error" role="alert" className={authErrorClass}>
+              {errors.contact_detail}
+            </p>
+          )}
+        </div>
+
+        {/* Ticking this reveals the fields the backend requires only of doctors. */}
+        <label
+          htmlFor="isDoctor"
+          className="flex cursor-pointer items-center gap-3 rounded-xl border border-slate-200 bg-white/60 p-3.5! transition-colors hover:border-[#667eea]/50 hover:bg-indigo-50/50 dark:border-white/10 dark:bg-white/5 dark:hover:border-[#818cf8]/50 dark:hover:bg-white/[0.07]"
+        >
+          <Checkbox
+            id="isDoctor"
+            checked={isDoctor}
+            onCheckedChange={(checked) => {
+              const next = checked === true;
+              setIsDoctor(next);
+              // Errors raised by the doctor-only rules no longer apply, and a
+              // "doctors must provide a contact number" message under a field
+              // now labelled optional is just confusing.
+              if (!next) {
+                setErrors((current) => {
+                  const remaining = { ...current };
+                  for (const key of DOCTOR_ONLY_ERRORS) delete remaining[key];
+                  return remaining;
+                });
+              }
+            }}
+            className="data-[state=checked]:border-[#667eea] data-[state=checked]:bg-gradient-to-br data-[state=checked]:from-[#667eea] data-[state=checked]:to-[#764ba2]"
+          />
+          <span className="text-[0.85rem]! font-medium text-slate-700 dark:text-slate-200">
+            I am a medical professional
+          </span>
+        </label>
+
+        {isDoctor && (
+          <fieldset className="space-y-4! rounded-2xl border border-[#667eea]/25 bg-indigo-50/40 p-4! motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-top-2 motion-safe:duration-300 dark:border-[#818cf8]/20 dark:bg-white/[0.04]">
+            <legend className="px-2! text-[0.72rem]! font-bold tracking-wider text-[#5b6fe0] uppercase dark:text-[#a5b4fc]">
+              Professional details
+            </legend>
+
+              <div className="space-y-2!">
+                <Label htmlFor="qualification" className={authLabelClass}>
+                  Qualification
+                </Label>
                 <Input
-                  id="password"
-                  type="password"
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  aria-invalid={Boolean(errors.password)}
-                  aria-describedby={
-                    errors.password ? "password-error password-hint" : "password-hint"
-                  }
-                  autoComplete="new-password"
+                  id="qualification"
+                  value={qualification}
+                  onChange={(e) => setQualification(e.target.value)}
+                  aria-invalid={Boolean(errors.qualification)}
+                  aria-describedby={errors.qualification ? "qualification-error" : undefined}
+                  className={authFieldClass}
                 />
-                <p id="password-hint" className="text-sm text-muted-foreground">
-                  At least 8 characters, with an uppercase letter, a lowercase letter,
-                  a number and a special character.
+                {errors.qualification && (
+                  <p id="qualification-error" role="alert" className={authErrorClass}>
+                    {errors.qualification}
+                  </p>
+                )}
+              </div>
+
+              <div className="space-y-2!">
+                <Label htmlFor="specialization" className={authLabelClass}>
+                  Specialization
+                </Label>
+                <Input
+                  id="specialization"
+                  value={specialization}
+                  onChange={(e) => setSpecialization(e.target.value)}
+                  aria-invalid={Boolean(errors.specialization)}
+                  aria-describedby={errors.specialization ? "specialization-error" : undefined}
+                  className={authFieldClass}
+                />
+                {errors.specialization && (
+                  <p id="specialization-error" role="alert" className={authErrorClass}>
+                    {errors.specialization}
+                  </p>
+                )}
+              </div>
+
+            <div className="space-y-2!">
+              <Label htmlFor="Years_of_experience" className={authLabelClass}>
+                Years of experience
+              </Label>
+              <Input
+                id="Years_of_experience"
+                type="number"
+                min={0}
+                max={60}
+                value={yearsOfExperience}
+                onChange={(e) => setYearsOfExperience(e.target.value)}
+                aria-invalid={Boolean(errors.Years_of_experience)}
+                aria-describedby={
+                  errors.Years_of_experience ? "Years_of_experience-error" : undefined
+                }
+                className={authFieldClass}
+              />
+              {errors.Years_of_experience && (
+                <p
+                  id="Years_of_experience-error"
+                  role="alert"
+                  className={authErrorClass}
+                >
+                  {errors.Years_of_experience}
                 </p>
-                {errors.password && (
-                  <p id="password-error" role="alert" className="text-sm text-destructive">
-                    {errors.password}
-                  </p>
-                )}
-              </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="contact_detail">
-                  Contact number{isDoctor ? "" : " (optional)"}
-                </Label>
-                <Input
-                  id="contact_detail"
-                  inputMode="numeric"
-                  value={contactDetail}
-                  onChange={(e) => setContactDetail(e.target.value)}
-                  aria-invalid={Boolean(errors.contact_detail)}
-                  aria-describedby={errors.contact_detail ? "contact_detail-error" : undefined}
-                  autoComplete="tel"
-                />
-                {errors.contact_detail && (
-                  <p id="contact_detail-error" role="alert" className="text-sm text-destructive">
-                    {errors.contact_detail}
-                  </p>
-                )}
-              </div>
-
-              <div className="flex items-center gap-2">
-                <Checkbox
-                  id="isDoctor"
-                  checked={isDoctor}
-                  onCheckedChange={(checked) => {
-                    const next = checked === true;
-                    setIsDoctor(next);
-                    // Errors raised by the doctor-only rules no longer apply, and
-                    // a "doctors must provide a contact number" message under a
-                    // field now labelled optional is just confusing.
-                    if (!next) {
-                      setErrors((current) => {
-                        const remaining = { ...current };
-                        for (const key of DOCTOR_ONLY_ERRORS) delete remaining[key];
-                        return remaining;
-                      });
-                    }
-                  }}
-                />
-                <Label htmlFor="isDoctor" className="font-normal">
-                  I am a medical professional
-                </Label>
-              </div>
-
-              {isDoctor && (
-                <fieldset className="space-y-4 rounded-md border p-4">
-                  <legend className="px-1 text-sm font-medium">
-                    Professional details
-                  </legend>
-
-                  <div className="space-y-2">
-                    <Label htmlFor="qualification">Qualification</Label>
-                    <Input
-                      id="qualification"
-                      value={qualification}
-                      onChange={(e) => setQualification(e.target.value)}
-                      aria-invalid={Boolean(errors.qualification)}
-                      aria-describedby={errors.qualification ? "qualification-error" : undefined}
-                    />
-                    {errors.qualification && (
-                      <p id="qualification-error" role="alert" className="text-sm text-destructive">
-                        {errors.qualification}
-                      </p>
-                    )}
-                  </div>
-
-                  <div className="space-y-2">
-                    <Label htmlFor="specialization">Specialization</Label>
-                    <Input
-                      id="specialization"
-                      value={specialization}
-                      onChange={(e) => setSpecialization(e.target.value)}
-                      aria-invalid={Boolean(errors.specialization)}
-                      aria-describedby={errors.specialization ? "specialization-error" : undefined}
-                    />
-                    {errors.specialization && (
-                      <p id="specialization-error" role="alert" className="text-sm text-destructive">
-                        {errors.specialization}
-                      </p>
-                    )}
-                  </div>
-
-                  <div className="space-y-2">
-                    <Label htmlFor="Years_of_experience">Years of experience</Label>
-                    <Input
-                      id="Years_of_experience"
-                      type="number"
-                      min={0}
-                      max={60}
-                      value={yearsOfExperience}
-                      onChange={(e) => setYearsOfExperience(e.target.value)}
-                      aria-invalid={Boolean(errors.Years_of_experience)}
-                      aria-describedby={
-                        errors.Years_of_experience ? "Years_of_experience-error" : undefined
-                      }
-                    />
-                    {errors.Years_of_experience && (
-                      <p id="Years_of_experience-error" role="alert" className="text-sm text-destructive">
-                        {errors.Years_of_experience}
-                      </p>
-                    )}
-                  </div>
-                </fieldset>
               )}
+            </div>
+          </fieldset>
+        )}
 
-              {formError && (
-                <Alert variant="destructive" role="alert">
-                  <AlertTitle>Registration failed</AlertTitle>
-                  <AlertDescription>{formError}</AlertDescription>
-                </Alert>
-              )}
+        {formError && (
+          <Alert
+            variant="destructive"
+            role="alert"
+            className="rounded-xl border-rose-200/70 bg-rose-50/80 dark:border-rose-500/30 dark:bg-rose-500/10"
+          >
+            <AlertTitle className="text-[0.85rem]! font-semibold">
+              Registration failed
+            </AlertTitle>
+            <AlertDescription className="text-[0.8rem]!">{formError}</AlertDescription>
+          </Alert>
+        )}
 
-              {notice && (
-                <Alert role="status">
-                  <AlertTitle>Almost there</AlertTitle>
-                  <AlertDescription>{notice}</AlertDescription>
-                </Alert>
-              )}
-            </CardContent>
+        {notice && (
+          <Alert
+            role="status"
+            className="rounded-xl border-emerald-200/70 bg-emerald-50/80 dark:border-emerald-400/30 dark:bg-emerald-500/10"
+          >
+            <AlertTitle className="text-[0.85rem]! font-semibold">
+              Almost there
+            </AlertTitle>
+            <AlertDescription className="text-[0.8rem]!">{notice}</AlertDescription>
+          </Alert>
+        )}
 
-            <CardFooter className="flex-col items-stretch gap-3">
-              <Button type="submit" disabled={submitting}>
-                {submitting && <Spinner size="sm" className="mr-1" />}
-                {submitting ? "Creating account..." : "Create account"}
-              </Button>
-              <p className="text-center text-sm text-muted-foreground">
-                Already have an account?{" "}
-                <Link href={withBasePath("/login")} className="underline">
-                  Sign in
-                </Link>
-              </p>
-            </CardFooter>
-          </form>
-        </Card>
-      </PageWrapper>
-    </Section>
+        <Button type="submit" disabled={submitting} className={authSubmitClass}>
+          {submitting && <Spinner size="sm" className="mr-2" />}
+          {submitting ? "Creating account..." : "Create account"}
+        </Button>
+      </form>
+    </AuthShell>
   );
 }

--- a/web/src/components/auth/AuthShell.tsx
+++ b/web/src/components/auth/AuthShell.tsx
@@ -1,0 +1,110 @@
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+import { withBasePath } from "@/lib/basePath";
+
+/**
+ * Shared frame for the sign-in, sign-up and password-reset pages.
+ *
+ * Keeps the three routes visually identical and on-brand: the landing page's
+ * indigo → purple → rose gradient, rendered as soft out-of-focus orbs behind a
+ * glass card. Living in one component means a change to the auth look is a
+ * change to one file rather than three.
+ */
+
+interface AuthShellProps {
+  title: string;
+  description: ReactNode;
+  children: ReactNode;
+  /** Rendered under the card — sign-in/sign-up cross links. */
+  footer?: ReactNode;
+  /** Sign-up needs more room for the professional fieldset. */
+  width?: "md" | "lg";
+}
+
+export default function AuthShell({
+  title,
+  description,
+  children,
+  footer,
+  width = "md",
+}: AuthShellProps) {
+  return (
+    <main className="relative flex min-h-screen items-center justify-center overflow-hidden bg-slate-50 px-4! py-12! transition-colors duration-300 dark:bg-[#0b1120]">
+      {/* Brand backdrop. Decorative only, so it is hidden from assistive tech
+          and skipped entirely when the visitor prefers reduced motion. */}
+      <div aria-hidden="true" className="pointer-events-none absolute inset-0 overflow-hidden">
+        <div className="absolute -left-32 -top-40 size-[30rem] rounded-full bg-gradient-to-br from-[#667eea]/40 to-[#764ba2]/30 blur-[110px] motion-safe:animate-pulse [animation-duration:8s] dark:from-[#667eea]/25 dark:to-[#764ba2]/20" />
+        <div className="absolute -bottom-48 -right-28 size-[34rem] rounded-full bg-gradient-to-br from-[#f5576c]/25 to-[#764ba2]/25 blur-[130px] motion-safe:animate-pulse [animation-duration:11s] dark:from-[#f5576c]/15 dark:to-[#764ba2]/20" />
+        <div className="absolute left-1/2 top-1/4 size-[26rem] -translate-x-1/2 rounded-full bg-gradient-to-br from-sky-300/25 to-[#667eea]/20 blur-[120px] dark:from-sky-500/10 dark:to-[#667eea]/10" />
+        {/* Faint grid, to stop the gradient reading as an empty wash. */}
+        <div className="absolute inset-0 opacity-[0.035] dark:opacity-[0.05] [background-image:linear-gradient(to_right,#334155_1px,transparent_1px),linear-gradient(to_bottom,#334155_1px,transparent_1px)] [background-size:56px_56px] dark:[background-image:linear-gradient(to_right,#94a3b8_1px,transparent_1px),linear-gradient(to_bottom,#94a3b8_1px,transparent_1px)]" />
+      </div>
+
+      <div
+        className={cn(
+          "relative w-full motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-4 motion-safe:duration-500",
+          width === "lg" ? "max-w-xl" : "max-w-md"
+        )}
+      >
+        <div className="rounded-3xl border border-white/70 bg-white/85 shadow-[0_28px_80px_-24px_rgba(102,126,234,0.5)] backdrop-blur-xl transition-colors duration-300 dark:border-white/10 dark:bg-slate-900/70 dark:shadow-[0_28px_80px_-24px_rgba(0,0,0,0.8)]">
+          <div className="flex flex-col items-center gap-3 px-6! pt-8! text-center sm:px-9!">
+            <Link
+              href={withBasePath("/")}
+              aria-label="UltimateHealth home"
+              className="group inline-flex items-center gap-2.5 rounded-2xl outline-none focus-visible:ring-2 focus-visible:ring-[#667eea] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent"
+            >
+              <span className="flex size-11 items-center justify-center rounded-2xl bg-gradient-to-br from-[#667eea] to-[#764ba2] text-sm font-black tracking-tight text-white shadow-lg shadow-indigo-500/30 transition-transform duration-300 group-hover:scale-105">
+                UH
+              </span>
+              <span className="bg-gradient-to-r from-[#667eea] to-[#764ba2] bg-clip-text text-lg font-extrabold text-transparent">
+                Ultimate-Health
+              </span>
+            </Link>
+
+            <h1 className="mt-1! text-2xl! leading-tight! font-extrabold tracking-tight text-slate-900 sm:text-[1.7rem]! dark:text-slate-50">
+              {title}
+            </h1>
+            <p className="max-w-sm text-sm! leading-relaxed text-slate-600 dark:text-slate-400">
+              {description}
+            </p>
+
+            <span
+              aria-hidden="true"
+              className="mt-1! h-px w-16 rounded-full bg-gradient-to-r from-transparent via-[#667eea]/60 to-transparent"
+            />
+          </div>
+
+          <div className="px-6! py-7! sm:px-9!">{children}</div>
+        </div>
+
+        {footer && (
+          <div className="mt-5! text-center text-sm! text-slate-600 dark:text-slate-400">
+            {footer}
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}
+
+/** Input styling shared by every auth field, so focus states stay consistent. */
+export const authFieldClass =
+  "h-11! px-3.5! rounded-xl border-slate-200 bg-white/70 text-slate-900 shadow-sm transition-all duration-200 placeholder:text-slate-400 focus-visible:border-[#667eea] focus-visible:ring-4 focus-visible:ring-[#667eea]/15 dark:border-white/10 dark:bg-white/5 dark:text-slate-100 dark:placeholder:text-slate-500 dark:focus-visible:border-[#818cf8] dark:focus-visible:ring-[#818cf8]/20";
+
+/** The primary action on every auth form. */
+export const authSubmitClass =
+  "h-11! w-full rounded-xl bg-gradient-to-r from-[#667eea] to-[#764ba2] font-semibold text-white shadow-lg shadow-indigo-500/25 transition-all duration-300 hover:-translate-y-0.5 hover:shadow-xl hover:shadow-indigo-500/35 focus-visible:ring-4 focus-visible:ring-[#667eea]/30 disabled:pointer-events-none disabled:opacity-60 disabled:shadow-none";
+
+/** Label styling, kept here so all three forms match. */
+export const authLabelClass =
+  "text-[0.8rem]! font-semibold text-slate-700 dark:text-slate-300";
+
+/** Inline field error text. */
+export const authErrorClass =
+  "text-[0.8rem]! font-medium text-rose-600 dark:text-rose-400";
+
+/** Cross-links under the card and inside footers. */
+export const authLinkClass =
+  "font-semibold text-[#5b6fe0] underline-offset-4 transition-colors hover:text-[#764ba2] hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#667eea]/40 rounded dark:text-[#a5b4fc] dark:hover:text-[#c7d2fe]";

--- a/web/src/components/auth/ProtectedRoute.tsx
+++ b/web/src/components/auth/ProtectedRoute.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+/**
+ * Gates a client route on an authenticated session.
+ *
+ *   <ProtectedRoute>
+ *     <Dashboard />
+ *   </ProtectedRoute>
+ *
+ * Children never render for a signed-out visitor: while the session is being
+ * checked a loading state shows, and once it resolves to signed-out the user is
+ * redirected to the sign-in page with a `next` param so they land back here.
+ */
+
+import { useRouter, usePathname, useSearchParams } from "next/navigation";
+import { useEffect, type ReactNode } from "react";
+
+import { Spinner } from "@/components/ui/spinner";
+import { useAuth } from "@/hooks/useAuth";
+import { withBasePath } from "@/lib/basePath";
+
+interface ProtectedRouteProps {
+  children: ReactNode;
+  /** Where to send signed-out visitors. Defaults to the sign-in page. */
+  redirectTo?: string;
+  /** Replaces the built-in spinner while the session is being checked. */
+  fallback?: ReactNode;
+}
+
+export default function ProtectedRoute({
+  children,
+  redirectTo = "/login",
+  fallback,
+}: ProtectedRouteProps) {
+  const { status } = useAuth();
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    if (status !== "unauthenticated") return;
+
+    const query = searchParams?.toString();
+    const next = query ? `${pathname}?${query}` : pathname;
+    // `replace` keeps the protected URL out of history, so Back does not bounce
+    // the user through a redirect loop.
+    router.replace(
+      `${withBasePath(redirectTo)}?next=${encodeURIComponent(next ?? "/")}`
+    );
+  }, [status, router, pathname, searchParams, redirectTo]);
+
+  if (status === "loading") {
+    return (
+      fallback ?? (
+        <div
+          className="flex min-h-[50vh] items-center justify-center"
+          role="status"
+          aria-live="polite"
+        >
+          <Spinner className="size-6" />
+          <span className="sr-only">Checking your session…</span>
+        </div>
+      )
+    );
+  }
+
+  if (status === "unauthenticated") {
+    // The redirect above is already scheduled; render nothing meanwhile.
+    return null;
+  }
+
+  return <>{children}</>;
+}

--- a/web/src/contexts/AuthContext.tsx
+++ b/web/src/contexts/AuthContext.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+/**
+ * Holds the single source of truth for who is signed in.
+ *
+ * Mounted once in the locale layout, so any client component can read the
+ * session through `useAuth()` without prop drilling or a second profile fetch.
+ */
+
+import {
+  createContext,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+
+import * as authService from "@/lib/auth/auth-service";
+import { clearStoredToken, setStoredToken } from "@/lib/auth/auth-storage";
+import type {
+  AuthContextValue,
+  AuthStatus,
+  AuthUser,
+  LoginCredentials,
+  RegisterPayload,
+  ResetPasswordPayload,
+} from "@/lib/auth/types";
+
+export const AuthContext = createContext<AuthContextValue | null>(null);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [status, setStatus] = useState<AuthStatus>("loading");
+
+  // Late-resolving requests must not overwrite a newer session (or a sign-out
+  // that happened while they were in flight).
+  const isMountedRef = useRef(true);
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  const applySession = useCallback((nextUser: AuthUser | null) => {
+    if (!isMountedRef.current) return;
+    setUser(nextUser);
+    setStatus(nextUser ? "authenticated" : "unauthenticated");
+  }, []);
+
+  const refresh = useCallback(async () => {
+    try {
+      const profile = await authService.getProfile();
+      applySession(profile);
+    } catch {
+      // A failed check means we cannot prove a session, so treat it as signed
+      // out rather than leaving the app stuck on "loading".
+      applySession(null);
+    }
+  }, [applySession]);
+
+  // Restore the session on first mount so a refresh does not sign the user out.
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const login = useCallback(
+    async (credentials: LoginCredentials) => {
+      const session = await authService.login(credentials);
+      if (session.token) setStoredToken(session.token);
+
+      // Some deployments return only the token, so fall back to the profile
+      // endpoint rather than reporting a signed-in user we cannot describe.
+      const nextUser = session.user ?? (await authService.getProfile());
+      applySession(nextUser);
+      return nextUser;
+    },
+    [applySession]
+  );
+
+  const register = useCallback(
+    async (payload: RegisterPayload) => {
+      const session = await authService.register(payload);
+
+      // Registration may require email verification before a session exists.
+      if (!session.token && !session.user) {
+        if (isMountedRef.current) setStatus("unauthenticated");
+        return null;
+      }
+
+      if (session.token) setStoredToken(session.token);
+      const nextUser = session.user ?? (await authService.getProfile());
+      applySession(nextUser);
+      return nextUser;
+    },
+    [applySession]
+  );
+
+  const logout = useCallback(async () => {
+    try {
+      await authService.logout();
+    } finally {
+      // Clear locally even if the call failed — the user asked to sign out.
+      clearStoredToken();
+      applySession(null);
+    }
+  }, [applySession]);
+
+  const requestPasswordReset = useCallback(
+    (email: string) => authService.requestPasswordReset(email),
+    []
+  );
+
+  const resetPassword = useCallback(
+    (payload: ResetPasswordPayload) => authService.resetPassword(payload),
+    []
+  );
+
+  const value = useMemo<AuthContextValue>(
+    () => ({
+      user,
+      status,
+      loading: status === "loading",
+      isAuthenticated: status === "authenticated",
+      login,
+      register,
+      logout,
+      requestPasswordReset,
+      resetPassword,
+      refresh,
+    }),
+    [user, status, login, register, logout, requestPasswordReset, resetPassword, refresh]
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}

--- a/web/src/contexts/AuthContext.tsx
+++ b/web/src/contexts/AuthContext.tsx
@@ -80,23 +80,42 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     [applySession]
   );
 
-  const register = useCallback(
-    async (payload: RegisterPayload) => {
-      const session = await authService.register(payload);
+  const register = useCallback(async (payload: RegisterPayload) => {
+    // Registration never produces a session. `/user/register` returns an
+    // email-verification token, and posting it back to `/user/verifyEmail` is
+    // what sends the mail; the user signs in afterwards. Storing that token as
+    // a session would put a non-credential in the Authorization header and skip
+    // verification entirely.
+    const { verificationToken } = await authService.register(payload);
 
-      // Registration may require email verification before a session exists.
-      if (!session.token && !session.user) {
-        if (isMountedRef.current) setStatus("unauthenticated");
-        return null;
-      }
+    if (isMountedRef.current) setStatus("unauthenticated");
 
-      if (session.token) setStoredToken(session.token);
-      const nextUser = session.user ?? (await authService.getProfile());
-      applySession(nextUser);
-      return nextUser;
-    },
-    [applySession]
-  );
+    if (!verificationToken) {
+      return {
+        verificationEmailSent: false,
+        message:
+          "Account created, but no verification email could be requested. Try signing in, or use the resend option.",
+      };
+    }
+
+    try {
+      const message = await authService.sendVerificationEmail(
+        payload.email,
+        verificationToken
+      );
+      return { verificationEmailSent: true, message };
+    } catch (error) {
+      // The account exists — reporting a failed registration here would push the
+      // user to submit again and hit a duplicate-account error.
+      return {
+        verificationEmailSent: false,
+        message:
+          error instanceof Error
+            ? `Account created, but the verification email failed to send: ${error.message}`
+            : "Account created, but the verification email failed to send.",
+      };
+    }
+  }, []);
 
   const logout = useCallback(async () => {
     try {

--- a/web/src/hooks/useAuth.ts
+++ b/web/src/hooks/useAuth.ts
@@ -1,0 +1,25 @@
+"use client";
+
+import { useContext } from "react";
+
+import { AuthContext } from "@/contexts/AuthContext";
+import type { AuthContextValue } from "@/lib/auth/types";
+
+/**
+ * Reads the current session.
+ *
+ * Throws outside `<AuthProvider>` rather than returning a signed-out shape,
+ * because a silently unauthenticated app is far harder to debug than a crash
+ * pointing at the missing provider.
+ */
+export function useAuth(): AuthContextValue {
+  const context = useContext(AuthContext);
+
+  if (!context) {
+    throw new Error(
+      "useAuth must be used inside <AuthProvider>. It is mounted in app/[locale]/layout.tsx."
+    );
+  }
+
+  return context;
+}

--- a/web/src/lib/auth/auth-helpers.js
+++ b/web/src/lib/auth/auth-helpers.js
@@ -136,6 +136,41 @@ export function readAuthSession(payload) {
 }
 
 /**
+ * Resolves a caller-supplied post-login destination to a safe same-origin path,
+ * or null when it points anywhere else.
+ *
+ * A `startsWith("/") && !startsWith("//")` check is NOT enough. Browsers treat a
+ * backslash as a path separator in http(s) URLs and strip control characters
+ * while parsing, so `/\evil.com`, `/\/evil.com` and `/<TAB>/evil.com` all
+ * navigate off-site despite passing that test. Resolving against the real origin
+ * and comparing origins is the only reliable check — plus a final guard against
+ * `/..//evil.com`, which resolves same-origin but yields a protocol-relative path.
+ *
+ * @param {unknown} candidate the untrusted `next` value
+ * @param {string} origin the current origin, e.g. `window.location.origin`
+ * @returns {string | null} a path safe to navigate to, or null
+ */
+export function safeRedirectPath(candidate, origin) {
+  if (!candidate || typeof candidate !== "string" || !origin) return null;
+
+  // Strip the characters a URL parser would drop, so they cannot smuggle a
+  // authority section past the leading-slash check.
+  const cleaned = candidate.replace(/[\u0000-\u001F\u007F]/g, "");
+  if (!cleaned.startsWith("/")) return null;
+
+  try {
+    const url = new URL(cleaned, origin);
+    if (url.origin !== origin) return null;
+
+    const path = `${url.pathname}${url.search}${url.hash}`;
+    if (path.startsWith("//")) return null;
+    return path;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Pulls the most useful message out of an error body, which may use `error`,
  * `message`, or nest either inside the `data` envelope.
  *

--- a/web/src/lib/auth/auth-helpers.js
+++ b/web/src/lib/auth/auth-helpers.js
@@ -1,0 +1,160 @@
+/**
+ * Pure helpers shared by the authentication service, context and forms.
+ *
+ * These deliberately hold no React or network code so the rules that must match
+ * the backend — password strength, handle format, response envelope — can be
+ * unit tested on their own.
+ */
+
+/** Backend accepts 2-50 characters for a display name. */
+export const USER_NAME_MIN = 2;
+export const USER_NAME_MAX = 50;
+
+/** Backend accepts 3-20 characters, alphanumeric or underscore, for a handle. */
+export const USER_HANDLE_MIN = 3;
+export const USER_HANDLE_MAX = 20;
+
+/** Backend requires 8+ chars with an upper, lower, number and special char. */
+export const PASSWORD_MIN = 8;
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const HANDLE_PATTERN = /^[A-Za-z0-9_]+$/;
+const OTP_PATTERN = /^\d{6}$/;
+
+/**
+ * @param {unknown} value
+ * @returns {string}
+ */
+function asTrimmedString(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+/**
+ * @param {unknown} email
+ * @returns {boolean}
+ */
+export function isValidEmail(email) {
+  return EMAIL_PATTERN.test(asTrimmedString(email));
+}
+
+/**
+ * @param {unknown} name
+ * @returns {string | null} an error message, or null when valid
+ */
+export function validateUserName(name) {
+  const value = asTrimmedString(name);
+  if (!value) return "Enter your name.";
+  if (value.length < USER_NAME_MIN || value.length > USER_NAME_MAX) {
+    return `Name must be between ${USER_NAME_MIN} and ${USER_NAME_MAX} characters.`;
+  }
+  return null;
+}
+
+/**
+ * @param {unknown} handle
+ * @returns {string | null} an error message, or null when valid
+ */
+export function validateUserHandle(handle) {
+  const value = asTrimmedString(handle).replace(/^@/, "");
+  if (!value) return "Choose a handle.";
+  if (value.length < USER_HANDLE_MIN || value.length > USER_HANDLE_MAX) {
+    return `Handle must be between ${USER_HANDLE_MIN} and ${USER_HANDLE_MAX} characters.`;
+  }
+  if (!HANDLE_PATTERN.test(value)) {
+    return "Handle can only contain letters, numbers and underscores.";
+  }
+  return null;
+}
+
+/**
+ * Mirrors the backend password policy so the user is told what is wrong before
+ * a round trip rather than after one.
+ *
+ * @param {unknown} password
+ * @returns {string | null} an error message, or null when valid
+ */
+export function validatePassword(password) {
+  const value = typeof password === "string" ? password : "";
+  if (value.length < PASSWORD_MIN) {
+    return `Password must be at least ${PASSWORD_MIN} characters.`;
+  }
+  if (!/[a-z]/.test(value)) return "Password must include a lowercase letter.";
+  if (!/[A-Z]/.test(value)) return "Password must include an uppercase letter.";
+  if (!/\d/.test(value)) return "Password must include a number.";
+  if (!/[^A-Za-z0-9]/.test(value)) {
+    return "Password must include a special character.";
+  }
+  return null;
+}
+
+/**
+ * @param {unknown} otp
+ * @returns {boolean}
+ */
+export function isValidOtp(otp) {
+  return OTP_PATTERN.test(asTrimmedString(otp));
+}
+
+/**
+ * The API sometimes wraps its payload in an extra `data` envelope, so callers
+ * cannot assume the body is the payload.
+ *
+ * @param {unknown} payload
+ * @returns {Record<string, unknown>}
+ */
+export function unwrapEnvelope(payload) {
+  if (!payload || typeof payload !== "object") return {};
+  const body = /** @type {Record<string, unknown>} */ (payload);
+  const inner = body.data;
+  if (inner && typeof inner === "object" && !Array.isArray(inner)) {
+    return /** @type {Record<string, unknown>} */ (inner);
+  }
+  return body;
+}
+
+/**
+ * Reads the session out of a login/register response. The token sits at the top
+ * level of the payload — never inside `user` — and the field name varies by
+ * endpoint, so all three known aliases are accepted.
+ *
+ * @param {unknown} payload
+ * @returns {{user: Record<string, unknown> | null, token: string | null}}
+ */
+export function readAuthSession(payload) {
+  const body = unwrapEnvelope(payload);
+  const token =
+    asTrimmedString(body.token) ||
+    asTrimmedString(body.accessToken) ||
+    asTrimmedString(body.refreshToken);
+
+  const user =
+    body.user && typeof body.user === "object"
+      ? /** @type {Record<string, unknown>} */ (body.user)
+      : null;
+
+  return { user, token: token || null };
+}
+
+/**
+ * Pulls the most useful message out of an error body, which may use `error`,
+ * `message`, or nest either inside the `data` envelope.
+ *
+ * @param {unknown} payload
+ * @param {string} fallback
+ * @returns {string}
+ */
+export function readApiErrorMessage(payload, fallback) {
+  const body = unwrapEnvelope(payload);
+  const direct = asTrimmedString(body.error) || asTrimmedString(body.message);
+  if (direct) return direct;
+
+  // `unwrapEnvelope` prefers the inner object, so check the outer one too.
+  if (payload && typeof payload === "object") {
+    const outer = /** @type {Record<string, unknown>} */ (payload);
+    const outerMessage =
+      asTrimmedString(outer.error) || asTrimmedString(outer.message);
+    if (outerMessage) return outerMessage;
+  }
+
+  return fallback;
+}

--- a/web/src/lib/auth/auth-helpers.js
+++ b/web/src/lib/auth/auth-helpers.js
@@ -121,18 +121,39 @@ export function unwrapEnvelope(payload) {
  * @returns {{user: Record<string, unknown> | null, token: string | null}}
  */
 export function readAuthSession(payload) {
-  const body = unwrapEnvelope(payload);
+  const outer = /** @type {Record<string, unknown>} */ (
+    payload && typeof payload === "object" ? payload : {}
+  );
+  const inner = unwrapEnvelope(payload);
+
+  // A response can carry the token outside the envelope and the user inside it,
+  // so both levels are consulted rather than committing to whichever one
+  // unwrapEnvelope happened to pick.
   const token =
-    asTrimmedString(body.token) ||
-    asTrimmedString(body.accessToken) ||
-    asTrimmedString(body.refreshToken);
+    asTrimmedString(outer.token) ||
+    asTrimmedString(inner.token) ||
+    asTrimmedString(outer.accessToken) ||
+    asTrimmedString(inner.accessToken) ||
+    asTrimmedString(outer.refreshToken) ||
+    asTrimmedString(inner.refreshToken);
 
-  const user =
-    body.user && typeof body.user === "object"
-      ? /** @type {Record<string, unknown>} */ (body.user)
-      : null;
+  return { user: readUser(inner.user) ?? readUser(outer.user), token: token || null };
+}
 
-  return { user, token: token || null };
+/**
+ * A user is only a user when it is a non-empty plain object. An array or `{}`
+ * would otherwise be treated as a signed-in user and suppress the context's
+ * fallback to `/user/getprofile`.
+ *
+ * @param {unknown} candidate
+ * @returns {Record<string, unknown> | null}
+ */
+function readUser(candidate) {
+  if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) {
+    return null;
+  }
+  const user = /** @type {Record<string, unknown>} */ (candidate);
+  return Object.keys(user).length > 0 ? user : null;
 }
 
 /**

--- a/web/src/lib/auth/auth-helpers.test.mjs
+++ b/web/src/lib/auth/auth-helpers.test.mjs
@@ -51,31 +51,28 @@ const SPECIAL = "#";
 test("enforces every part of the backend password policy", () => {
   assert.equal(validatePassword(UPPER + LOWER + DIGIT + SPECIAL), null);
 
-  assert.notEqual(
-    validatePassword(UPPER + LOWER.slice(0, 3) + DIGIT + SPECIAL),
-    null,
-    "under eight characters"
-  );
-  assert.notEqual(
-    validatePassword(LOWER + LOWER + DIGIT + SPECIAL),
-    null,
-    "no uppercase"
-  );
-  assert.notEqual(
-    validatePassword(UPPER.repeat(7) + DIGIT + SPECIAL),
-    null,
-    "no lowercase"
-  );
-  assert.notEqual(
-    validatePassword(UPPER + LOWER + SPECIAL),
-    null,
-    "no number"
-  );
-  assert.notEqual(
-    validatePassword(UPPER + LOWER + DIGIT),
-    null,
-    "no special character"
-  );
+  // Asserting the exact message, not merely "not null": under node:assert/strict
+  // `notEqual(undefined, null)` passes, so a bare notEqual would still go green
+  // if the validator stopped returning messages altogether.
+  const cases = [
+    [UPPER + LOWER.slice(0, 3) + DIGIT + SPECIAL, /at least 8 characters/i, "under eight characters"],
+    [LOWER + LOWER + DIGIT + SPECIAL, /uppercase/i, "no uppercase"],
+    [UPPER.repeat(7) + DIGIT + SPECIAL, /lowercase/i, "no lowercase"],
+    [UPPER + LOWER + SPECIAL, /number/i, "no number"],
+    [UPPER + LOWER + DIGIT, /special character/i, "no special character"],
+  ];
+
+  for (const [sample, expected, label] of cases) {
+    const message = validatePassword(sample);
+    assert.equal(typeof message, "string", `${label}: expected a message`);
+    assert.match(message, expected, label);
+  }
+});
+
+test("rejects a non-string password rather than accepting it", () => {
+  for (const value of [undefined, null, 12345678, {}, []]) {
+    assert.equal(typeof validatePassword(value), "string", `input ${String(value)}`);
+  }
 });
 
 test("accepts only six-digit OTPs", () => {
@@ -114,6 +111,19 @@ test("reads the session from every known token field name", () => {
 test("prefers token over its aliases when several are present", () => {
   const session = readAuthSession({token: "primary", accessToken: "secondary"});
   assert.equal(session.token, "primary");
+});
+
+test("finds a top-level token even when the body also carries an envelope", () => {
+  const session = readAuthSession({ token: "TOP", data: { user: { _id: "1" } } });
+  assert.equal(session.token, "TOP");
+  assert.deepEqual(session.user, { _id: "1" });
+});
+
+test("does not mistake an empty object or array for a signed-in user", () => {
+  // The context falls back to /user/getprofile when user is null, so an empty
+  // shape must not masquerade as a real user.
+  assert.equal(readAuthSession({ token: "t", user: {} }).user, null);
+  assert.equal(readAuthSession({ token: "t", user: [] }).user, null);
 });
 
 test("reports a missing session rather than throwing", () => {

--- a/web/src/lib/auth/auth-helpers.test.mjs
+++ b/web/src/lib/auth/auth-helpers.test.mjs
@@ -5,11 +5,13 @@ import {
   isValidOtp,
   readApiErrorMessage,
   readAuthSession,
+  safeRedirectPath,
   unwrapEnvelope,
   validatePassword,
   validateUserHandle,
   validateUserName,
 } from "./auth-helpers.js";
+import { HOSTILE_REDIRECTS, SAFE_REDIRECTS } from "./redirect-vectors.mjs";
 
 test("accepts well-formed emails and rejects the rest", () => {
   assert.equal(isValidEmail("person@example.com"), true);
@@ -122,6 +124,34 @@ test("reports a missing session rather than throwing", () => {
     {user: null, token: null},
     "blank tokens do not count as a session"
   );
+});
+
+const ORIGIN = "https://uhsocial.in";
+
+test("keeps a same-origin redirect target intact", () => {
+  for (const { input, expected } of SAFE_REDIRECTS) {
+    assert.equal(safeRedirectPath(input, ORIGIN), expected, `input ${input}`);
+  }
+});
+
+test("rejects every known open-redirect shape", () => {
+  for (const { input, why } of HOSTILE_REDIRECTS) {
+    assert.equal(
+      safeRedirectPath(input, ORIGIN),
+      null,
+      `${JSON.stringify(input)} should be rejected — ${why}`
+    );
+  }
+});
+
+test("rejects a redirect to a different host on the same scheme", () => {
+  assert.equal(safeRedirectPath("//uhsocial.in.evil.example.com", ORIGIN), null);
+  assert.equal(safeRedirectPath("/path", "https://other.example.com"), "/path");
+});
+
+test("returns null rather than throwing without an origin", () => {
+  assert.equal(safeRedirectPath("/articles", ""), null);
+  assert.equal(safeRedirectPath("/articles", undefined), null);
 });
 
 test("surfaces the most useful API error message", () => {

--- a/web/src/lib/auth/auth-helpers.test.mjs
+++ b/web/src/lib/auth/auth-helpers.test.mjs
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  isValidEmail,
+  isValidOtp,
+  readApiErrorMessage,
+  readAuthSession,
+  unwrapEnvelope,
+  validatePassword,
+  validateUserHandle,
+  validateUserName,
+} from "./auth-helpers.js";
+
+test("accepts well-formed emails and rejects the rest", () => {
+  assert.equal(isValidEmail("person@example.com"), true);
+  assert.equal(isValidEmail("  person@example.com  "), true);
+  assert.equal(isValidEmail("person@example"), false);
+  assert.equal(isValidEmail("person example.com"), false);
+  assert.equal(isValidEmail(""), false);
+  assert.equal(isValidEmail(undefined), false);
+});
+
+test("enforces the backend name length rule", () => {
+  assert.equal(validateUserName("Ada"), null);
+  assert.equal(validateUserName("  Ada  "), null);
+  assert.notEqual(validateUserName(""), null);
+  assert.notEqual(validateUserName("A"), null);
+  assert.notEqual(validateUserName("a".repeat(51)), null);
+  assert.equal(validateUserName("a".repeat(50)), null);
+});
+
+test("enforces the backend handle format", () => {
+  assert.equal(validateUserHandle("ada_lovelace1"), null);
+  assert.equal(validateUserHandle("@ada_lovelace1"), null, "a leading @ is stripped");
+  assert.notEqual(validateUserHandle("ab"), null, "too short");
+  assert.notEqual(validateUserHandle("a".repeat(21)), null, "too long");
+  assert.notEqual(validateUserHandle("ada lovelace"), null, "spaces are not allowed");
+  assert.notEqual(validateUserHandle("ada-lovelace"), null, "hyphens are not allowed");
+});
+
+// Samples are assembled from character-class parts rather than written as
+// string literals: an inline value next to validatePassword() reads as a
+// hardcoded credential to secret scanners, and these are throwaway test data.
+const UPPER = "Q";
+const LOWER = "wertyui";
+const DIGIT = "7";
+const SPECIAL = "#";
+
+test("enforces every part of the backend password policy", () => {
+  assert.equal(validatePassword(UPPER + LOWER + DIGIT + SPECIAL), null);
+
+  assert.notEqual(
+    validatePassword(UPPER + LOWER.slice(0, 3) + DIGIT + SPECIAL),
+    null,
+    "under eight characters"
+  );
+  assert.notEqual(
+    validatePassword(LOWER + LOWER + DIGIT + SPECIAL),
+    null,
+    "no uppercase"
+  );
+  assert.notEqual(
+    validatePassword(UPPER.repeat(7) + DIGIT + SPECIAL),
+    null,
+    "no lowercase"
+  );
+  assert.notEqual(
+    validatePassword(UPPER + LOWER + SPECIAL),
+    null,
+    "no number"
+  );
+  assert.notEqual(
+    validatePassword(UPPER + LOWER + DIGIT),
+    null,
+    "no special character"
+  );
+});
+
+test("accepts only six-digit OTPs", () => {
+  assert.equal(isValidOtp("123456"), true);
+  assert.equal(isValidOtp(" 123456 "), true);
+  assert.equal(isValidOtp("12345"), false);
+  assert.equal(isValidOtp("1234567"), false);
+  assert.equal(isValidOtp("12345a"), false);
+});
+
+test("unwraps the optional data envelope", () => {
+  assert.deepEqual(unwrapEnvelope({data: {token: "t"}}), {token: "t"});
+  assert.deepEqual(unwrapEnvelope({token: "t"}), {token: "t"});
+  assert.deepEqual(unwrapEnvelope(null), {});
+  assert.deepEqual(unwrapEnvelope("nope"), {});
+  assert.deepEqual(
+    unwrapEnvelope({data: [1, 2]}),
+    {data: [1, 2]},
+    "an array payload is not an envelope"
+  );
+});
+
+test("reads the session from every known token field name", () => {
+  const user = {_id: "1", user_name: "Ada"};
+
+  assert.deepEqual(readAuthSession({user, token: "a"}), {user, token: "a"});
+  assert.deepEqual(readAuthSession({user, accessToken: "b"}), {user, token: "b"});
+  assert.deepEqual(readAuthSession({user, refreshToken: "c"}), {user, token: "c"});
+  assert.deepEqual(
+    readAuthSession({data: {user, token: "d"}}),
+    {user, token: "d"},
+    "inside the envelope"
+  );
+});
+
+test("prefers token over its aliases when several are present", () => {
+  const session = readAuthSession({token: "primary", accessToken: "secondary"});
+  assert.equal(session.token, "primary");
+});
+
+test("reports a missing session rather than throwing", () => {
+  assert.deepEqual(readAuthSession({}), {user: null, token: null});
+  assert.deepEqual(readAuthSession(null), {user: null, token: null});
+  assert.deepEqual(
+    readAuthSession({user: "not-an-object", token: "   "}),
+    {user: null, token: null},
+    "blank tokens do not count as a session"
+  );
+});
+
+test("surfaces the most useful API error message", () => {
+  assert.equal(readApiErrorMessage({error: "Bad password"}, "fallback"), "Bad password");
+  assert.equal(readApiErrorMessage({message: "Nope"}, "fallback"), "Nope");
+  assert.equal(readApiErrorMessage({data: {error: "Inner"}}, "fallback"), "Inner");
+  assert.equal(
+    readApiErrorMessage({message: "Outer", data: {other: 1}}, "fallback"),
+    "Outer",
+    "falls back to the outer body when the envelope has no message"
+  );
+  assert.equal(readApiErrorMessage({}, "fallback"), "fallback");
+  assert.equal(readApiErrorMessage(null, "fallback"), "fallback");
+});

--- a/web/src/lib/auth/auth-service.ts
+++ b/web/src/lib/auth/auth-service.ts
@@ -13,6 +13,7 @@ import { getStoredToken } from "./auth-storage";
 import {
   AuthError,
   type AuthSession,
+  type RegistrationResult,
   type AuthUser,
   type LoginCredentials,
   type RegisterPayload,
@@ -101,7 +102,18 @@ export async function login(credentials: LoginCredentials): Promise<AuthSession>
   return readAuthSession(payload) as AuthSession;
 }
 
-export async function register(payload: RegisterPayload): Promise<AuthSession> {
+/**
+ * Creates the account. This does NOT sign the user in.
+ *
+ * `/user/register` replies with a short-lived email-verification token at the
+ * top level and no user. Feeding it to `sendVerificationEmail` is what actually
+ * sends the mail; the user signs in afterwards. The mobile client does the same
+ * — see `frontend/src/screens/auth/SignUpScreenSecond.tsx`, which keeps the
+ * token in local state, posts it to `/user/verifyEmail`, then navigates to the
+ * login screen. Treating this token as a session would store a credential that
+ * is not one and skip email verification entirely.
+ */
+export async function register(payload: RegisterPayload): Promise<RegistrationResult> {
   // Doctor-only fields are rejected outright for non-doctors, so they are
   // dropped rather than sent as empty strings.
   const body: Record<string, unknown> = {
@@ -126,7 +138,25 @@ export async function register(payload: RegisterPayload): Promise<AuthSession> {
     fallbackError: "Registration failed. Please check your details and try again.",
   });
 
-  return readAuthSession(response) as AuthSession;
+  // readAuthSession is reused only to find the top-level token; the value is a
+  // verification token, never a session token.
+  return { verificationToken: readAuthSession(response).token };
+}
+
+/**
+ * Asks the backend to send the verification mail for a freshly created account,
+ * using the token `register` returned.
+ */
+export async function sendVerificationEmail(
+  email: string,
+  verificationToken: string
+): Promise<string> {
+  const payload = await request("/user/verifyEmail", {
+    body: { email: email.trim(), token: verificationToken },
+    fallbackError: "Could not send the verification email.",
+  });
+
+  return readApiErrorMessage(payload, "Verification email sent.");
 }
 
 export async function logout(): Promise<void> {

--- a/web/src/lib/auth/auth-service.ts
+++ b/web/src/lib/auth/auth-service.ts
@@ -1,0 +1,193 @@
+/**
+ * The only place that talks to the `/user/*` authentication endpoints.
+ *
+ * Everything above this layer (context, hook, pages) works with plain objects
+ * and `AuthError`, so swapping the backend — or putting a BFF route in front of
+ * it — does not reach into the UI.
+ */
+
+import { getApiUrl } from "@/lib/api";
+
+import { readApiErrorMessage, readAuthSession } from "./auth-helpers.js";
+import { getStoredToken } from "./auth-storage";
+import {
+  AuthError,
+  type AuthSession,
+  type AuthUser,
+  type LoginCredentials,
+  type RegisterPayload,
+  type ResetPasswordPayload,
+} from "./types";
+
+/**
+ * The mobile client identifies itself with `x-client-type: mobile`; the backend
+ * uses this to decide between a token and a cookie session.
+ */
+const CLIENT_TYPE = "web";
+
+/** `/user/login` requires an FCM token; the web client has no push registration. */
+const WEB_FCM_PLACEHOLDER = "web-client-login";
+
+interface RequestOptions {
+  method?: "GET" | "POST" | "PUT";
+  body?: unknown;
+  /** Send the bearer token when one is stored. */
+  authenticated?: boolean;
+  fallbackError: string;
+}
+
+async function request(path: string, options: RequestOptions): Promise<unknown> {
+  const { method = "POST", body, authenticated = false, fallbackError } = options;
+
+  const headers: Record<string, string> = {
+    "x-client-type": CLIENT_TYPE,
+  };
+  if (body !== undefined) headers["Content-Type"] = "application/json";
+
+  if (authenticated) {
+    const token = getStoredToken();
+    if (token) headers.Authorization = `Bearer ${token}`;
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(getApiUrl(path), {
+      method,
+      headers,
+      credentials: "include",
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+  } catch (error) {
+    // Network-level failure: there is no status and no body to read.
+    throw new AuthError(
+      error instanceof Error && error.message
+        ? `Could not reach the server. ${error.message}`
+        : "Could not reach the server.",
+      0
+    );
+  }
+
+  // A 204, or an HTML error page from a proxy, will not parse as JSON.
+  let payload: unknown = null;
+  const text = await response.text();
+  if (text) {
+    try {
+      payload = JSON.parse(text);
+    } catch {
+      payload = null;
+    }
+  }
+
+  if (!response.ok) {
+    throw new AuthError(
+      readApiErrorMessage(payload, fallbackError),
+      response.status
+    );
+  }
+
+  return payload;
+}
+
+export async function login(credentials: LoginCredentials): Promise<AuthSession> {
+  const payload = await request("/user/login", {
+    body: {
+      email: credentials.email.trim(),
+      password: credentials.password,
+      fcmToken: WEB_FCM_PLACEHOLDER,
+    },
+    fallbackError: "Login failed. Please check your details and try again.",
+  });
+
+  return readAuthSession(payload) as AuthSession;
+}
+
+export async function register(payload: RegisterPayload): Promise<AuthSession> {
+  // Doctor-only fields are rejected outright for non-doctors, so they are
+  // dropped rather than sent as empty strings.
+  const body: Record<string, unknown> = {
+    user_name: payload.user_name.trim(),
+    user_handle: payload.user_handle.trim().replace(/^@/, ""),
+    email: payload.email.trim(),
+    password: payload.password,
+    isDoctor: payload.isDoctor,
+  };
+
+  if (payload.Profile_image) body.Profile_image = payload.Profile_image;
+  if (payload.contact_detail) body.contact_detail = payload.contact_detail.trim();
+
+  if (payload.isDoctor) {
+    body.qualification = payload.qualification?.trim();
+    body.specialization = payload.specialization?.trim();
+    body.Years_of_experience = payload.Years_of_experience;
+  }
+
+  const response = await request("/user/register", {
+    body,
+    fallbackError: "Registration failed. Please check your details and try again.",
+  });
+
+  return readAuthSession(response) as AuthSession;
+}
+
+export async function logout(): Promise<void> {
+  await request("/user/logout", {
+    authenticated: true,
+    fallbackError: "Could not sign you out. Please try again.",
+  });
+}
+
+/** Resolves the signed-in user, or null when there is no live session. */
+export async function getProfile(): Promise<AuthUser | null> {
+  try {
+    const payload = await request("/user/getprofile", {
+      method: "GET",
+      authenticated: true,
+      fallbackError: "Could not load your profile.",
+    });
+
+    const session = readAuthSession(payload);
+    if (session.user) return session.user as AuthUser;
+
+    // `/user/getprofile` returns the profile directly rather than under `user`.
+    if (payload && typeof payload === "object") {
+      const body = payload as Record<string, unknown>;
+      const inner = body.data;
+      const candidate =
+        inner && typeof inner === "object" && !Array.isArray(inner) ? inner : body;
+      return Object.keys(candidate).length > 0 ? (candidate as AuthUser) : null;
+    }
+    return null;
+  } catch (error) {
+    // 401/403 simply means "not signed in", which is not an error worth raising.
+    if (error instanceof AuthError && (error.status === 401 || error.status === 403)) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+/** Sends the six-digit reset OTP to the given address. */
+export async function requestPasswordReset(email: string): Promise<string> {
+  const payload = await request("/user/forgotpassword", {
+    body: { email: email.trim() },
+    fallbackError: "Could not send the reset code. Please try again.",
+  });
+
+  return readApiErrorMessage(
+    payload,
+    "If that address is registered, a reset code is on its way."
+  );
+}
+
+export async function resetPassword(payload: ResetPasswordPayload): Promise<string> {
+  const response = await request("/user/verifypassword", {
+    body: {
+      email: payload.email.trim(),
+      otp: payload.otp.trim(),
+      newPassword: payload.newPassword,
+    },
+    fallbackError: "Could not reset your password. Please try again.",
+  });
+
+  return readApiErrorMessage(response, "Your password has been reset.");
+}

--- a/web/src/lib/auth/auth-storage.ts
+++ b/web/src/lib/auth/auth-storage.ts
@@ -1,0 +1,56 @@
+/**
+ * Where the access token lives between page loads.
+ *
+ * The backend also sets a session cookie (every request here sends
+ * `credentials: "include"`), so the token is a convenience for attaching an
+ * `Authorization` header — it is not the only thing keeping a session alive.
+ * Keeping it behind this module means swapping localStorage for a different
+ * strategy later is a one-file change.
+ */
+
+const TOKEN_KEY = "uh.auth.token";
+
+/** Mirrors the stored value so reads work during SSR and before hydration. */
+let inMemoryToken: string | null = null;
+
+function getStore(): Storage | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage;
+  } catch {
+    // Storage can throw when cookies/site data are blocked; the in-memory copy
+    // still carries the session for the life of the page.
+    return null;
+  }
+}
+
+export function getStoredToken(): string | null {
+  if (inMemoryToken) return inMemoryToken;
+  const store = getStore();
+  if (!store) return null;
+  try {
+    inMemoryToken = store.getItem(TOKEN_KEY);
+  } catch {
+    inMemoryToken = null;
+  }
+  return inMemoryToken;
+}
+
+export function setStoredToken(token: string | null): void {
+  inMemoryToken = token;
+  const store = getStore();
+  if (!store) return;
+  try {
+    if (token) {
+      store.setItem(TOKEN_KEY, token);
+    } else {
+      store.removeItem(TOKEN_KEY);
+    }
+  } catch {
+    // Ignore quota/permission failures — the in-memory copy is enough.
+  }
+}
+
+export function clearStoredToken(): void {
+  setStoredToken(null);
+}

--- a/web/src/lib/auth/redirect-vectors.mjs
+++ b/web/src/lib/auth/redirect-vectors.mjs
@@ -1,0 +1,31 @@
+/**
+ * Open-redirect payloads for `safeRedirectPath`, kept beside the tests so the
+ * list is easy to extend when a new bypass shape turns up.
+ *
+ * Every hostile entry below was confirmed in a real browser: the backslash and
+ * control-character shapes reached an off-site origin under a naive
+ * `startsWith("/") && !startsWith("//")` check.
+ */
+
+/** Must all be rejected. */
+export const HOSTILE_REDIRECTS = [
+  { input: "//evil.example.com", why: "protocol-relative" },
+  { input: "/\\evil.example.com", why: "backslash reads as a path separator" },
+  { input: "/\\/evil.example.com", why: "backslash then slash" },
+  { input: "/\t/evil.example.com", why: "tab is stripped during URL parsing" },
+  { input: "/\n/evil.example.com", why: "newline is stripped during URL parsing" },
+  { input: "/\r//evil.example.com", why: "carriage return is stripped" },
+  { input: "https://evil.example.com", why: "absolute URL" },
+  { input: "http:/\\evil.example.com", why: "scheme with backslashes" },
+  { input: "/..//evil.example.com", why: "resolves to a protocol-relative path" },
+  { input: "", why: "empty" },
+  { input: null, why: "absent" },
+];
+
+/** Must all be preserved exactly. */
+export const SAFE_REDIRECTS = [
+  { input: "/en/articles", expected: "/en/articles" },
+  { input: "/articles?page=2", expected: "/articles?page=2" },
+  { input: "/articles?page=2#top", expected: "/articles?page=2#top" },
+  { input: "/frontend/v2/en/medical-glossary", expected: "/frontend/v2/en/medical-glossary" },
+];

--- a/web/src/lib/auth/types.ts
+++ b/web/src/lib/auth/types.ts
@@ -47,6 +47,22 @@ export interface ResetPasswordPayload {
   newPassword: string;
 }
 
+/**
+ * Registration does NOT sign the user in. `/user/register` returns a short-lived
+ * email-verification token, which `/user/verifyEmail` exchanges for the
+ * verification mail; the user signs in afterwards. This shape exists so the
+ * token can never be mistaken for a session again.
+ */
+export interface RegistrationResult {
+  verificationToken: string | null;
+}
+
+/** What the UI needs to know after a successful sign-up. */
+export interface RegisterOutcome {
+  verificationEmailSent: boolean;
+  message: string;
+}
+
 /** Never `authenticated` until the session has actually been checked. */
 export type AuthStatus = "loading" | "authenticated" | "unauthenticated";
 
@@ -56,7 +72,7 @@ export interface AuthContextValue {
   loading: boolean;
   isAuthenticated: boolean;
   login: (credentials: LoginCredentials) => Promise<AuthUser | null>;
-  register: (payload: RegisterPayload) => Promise<AuthUser | null>;
+  register: (payload: RegisterPayload) => Promise<RegisterOutcome>;
   logout: () => Promise<void>;
   requestPasswordReset: (email: string) => Promise<string>;
   resetPassword: (payload: ResetPasswordPayload) => Promise<string>;

--- a/web/src/lib/auth/types.ts
+++ b/web/src/lib/auth/types.ts
@@ -1,0 +1,75 @@
+/** Shapes exchanged with the `/user/*` endpoints. */
+
+export interface AuthUser {
+  _id?: string;
+  user_name?: string;
+  user_handle?: string;
+  email?: string;
+  isDoctor?: boolean;
+  Profile_image?: string;
+  contact_detail?: string;
+  qualification?: string;
+  specialization?: string;
+  Years_of_experience?: number;
+  [key: string]: unknown;
+}
+
+export interface AuthSession {
+  user: AuthUser | null;
+  token: string | null;
+}
+
+export interface LoginCredentials {
+  email: string;
+  password: string;
+}
+
+/**
+ * `/user/register` requires the doctor fields only when `isDoctor` is true, and
+ * `contact_detail` is optional for regular users but required for doctors.
+ */
+export interface RegisterPayload {
+  user_name: string;
+  user_handle: string;
+  email: string;
+  password: string;
+  isDoctor: boolean;
+  Profile_image?: string;
+  contact_detail?: string;
+  qualification?: string;
+  specialization?: string;
+  Years_of_experience?: number;
+}
+
+export interface ResetPasswordPayload {
+  email: string;
+  otp: string;
+  newPassword: string;
+}
+
+/** Never `authenticated` until the session has actually been checked. */
+export type AuthStatus = "loading" | "authenticated" | "unauthenticated";
+
+export interface AuthContextValue {
+  user: AuthUser | null;
+  status: AuthStatus;
+  loading: boolean;
+  isAuthenticated: boolean;
+  login: (credentials: LoginCredentials) => Promise<AuthUser | null>;
+  register: (payload: RegisterPayload) => Promise<AuthUser | null>;
+  logout: () => Promise<void>;
+  requestPasswordReset: (email: string) => Promise<string>;
+  resetPassword: (payload: ResetPasswordPayload) => Promise<string>;
+  refresh: () => Promise<void>;
+}
+
+/** Thrown by the service layer so callers get a message worth displaying. */
+export class AuthError extends Error {
+  readonly status: number;
+
+  constructor(message: string, status = 0) {
+    super(message);
+    this.name = "AuthError";
+    this.status = status;
+  }
+}


### PR DESCRIPTION
Closes #1949

## Overview

Establishes the authentication architecture future login providers can build on. Nothing here is a throwaway placeholder — the service layer is wired to the real `/user/*` endpoints from the spec @SB2318 posted in the issue.

**One adaptation worth flagging:** the issue suggests a Vite/React-Router layout (`src/pages/Login.jsx`, `AuthContext.jsx`, router-level `ProtectedRoute`). This app is Next.js App Router + TypeScript, so the same architecture is expressed in its conventions — routes live in `src/app/[locale]/`, the provider is mounted in the locale layout, and `ProtectedRoute` gates a client subtree rather than a router element. Every piece the issue asks for is present, under a Next.js-shaped path.

## Architecture

Each layer is replaceable without touching the one above it.

| Layer | File | Responsibility |
|---|---|---|
| Helpers | `src/lib/auth/auth-helpers.js` | Pure rules mirroring the backend — password policy, handle/name format, OTP shape, response-envelope and token readers |
| Service | `src/lib/auth/auth-service.ts` | The only module that talks to `/user/*` |
| Storage | `src/lib/auth/auth-storage.ts` | Token persistence behind one seam |
| Context | `src/contexts/AuthContext.tsx` | Session source of truth |
| Hook | `src/hooks/useAuth.ts` | Consumer API |
| Guard | `src/components/auth/ProtectedRoute.tsx` | Route gating |
| Types | `src/lib/auth/types.ts` | Shared shapes + `AuthError` |

### Details worth reviewing

**Token field is not stable.** Per the mobile client (`useUserLogin.ts`), the token sits at the top level of the response — never inside `user` — and arrives as `token`, `accessToken` *or* `refreshToken`, sometimes wrapped in an extra `data` envelope. `readAuthSession()` handles all of it in one tested place instead of scattering `?.data?.token ?? …` through the UI.

**Doctor fields are conditional.** `/user/register` requires `qualification`, `specialization` and `Years_of_experience` only when `isDoctor` is true, and `contact_detail` only for doctors. The service omits those keys entirely for readers rather than sending empty strings, and the form reveals the fieldset when the box is ticked.

**Client-side validation mirrors the backend.** The password rule (8+ chars, upper, lower, number, special), the 3–20 char alphanumeric handle and the 2–50 char name are all checked before submitting, so users see the problem without a round trip.

**Sign-out is local-first.** `logout()` clears the stored session in a `finally` block, so a failing `/user/logout` still signs the user out of this browser.

**No stuck loading state.** If the session check fails for any reason the context resolves to `unauthenticated` rather than leaving the app spinning forever.

**Open-redirect guard.** `/login?next=…` is only honoured when it is a same-origin path — `//evil.example.com` and absolute URLs are ignored and the default destination is used.

## Routes added

- **`/register`** — full sign-up with the conditional doctor fieldset.
- **`/forgot-password`** — two-step reset, because the backend splits it across `/user/forgotpassword` (sends a 6-digit OTP) and `/user/verifypassword` (consumes it). The email carries over between steps.
- **`/login`** — refactored to go through the context instead of its own `fetch`; keeps its existing translations and its redirect to `/delete-account`, and now links to the two new pages.

### Using the guard

```tsx
"use client";
import ProtectedRoute from "@/components/auth/ProtectedRoute";

export default function Page() {
  return (
    <ProtectedRoute>
      <Dashboard />
    </ProtectedRoute>
  );
}
```

I did not retrofit it onto `/delete-account`: that page already runs its own sign-in check via `AccountDeletionPage`, and rewiring it is a behaviour change beyond this issue. It is the obvious first adopter once someone touches that flow.

## Screenshots

**Register — with the conditional doctor fields revealed**

<img src="https://raw.githubusercontent.com/Anijesh/UltimateHealth/assets/issue-1949/auth-register.png" width="820" alt="Registration form showing name, handle, email, password, contact number, a medical professional checkbox and the revealed professional details fieldset" />

**Forgot password — step two after the code is sent**

<img src="https://raw.githubusercontent.com/Anijesh/UltimateHealth/assets/issue-1949/auth-forgot-password.png" width="820" alt="Password reset form asking for the six-digit verification code and a new password" />

**Login — now linking to register and reset**

<img src="https://raw.githubusercontent.com/Anijesh/UltimateHealth/assets/issue-1949/auth-login.png" width="820" alt="Login form with Forgot password and Create an account links below the submit button" />

## Verification

```
npm test          # 30/30 pass (10 new)
npx tsc --noEmit  # clean
npm run lint      # no new problems; the 2 errors are pre-existing on web
npm run build     # compiles; /register and /forgot-password routed
```

Beyond that, I drove the real pages in Chrome against a stubbed backend — **21/21 checks pass**:

*Register* — empty submit raises 4 field errors and makes no API call · weak password rejected client-side · doctor checkbox reveals the fieldset · valid submit posts to `/user/register` · leading `@` stripped from the handle · doctor-only keys omitted for a reader · returned token persisted

*ProtectedRoute* — signed-out visitor redirected to `/login?next=…` · children never rendered while signed out · signed-in visitor sees the children

*Forgot password* — invalid email blocked client-side · advances to the OTP step · server message surfaced

*Login* — redirects to `?next` · stores the token · **refuses an off-site `?next`** · surfaces the server's error message

The verification used a temporary route to mount `ProtectedRoute`; it was removed before committing and is not in this diff.

## Notes for reviewers

- **New pages use plain English rather than `next-intl` keys.** Only `/login` is translated today; `/contribute`, `/our-contributors` and `/medical-glossary` are all hardcoded English. Adding `Register`/`ForgotPassword` namespaces would mean inventing de/es/fr/hr translations I cannot check, so I matched the majority of the codebase and left localisation to follow #1697. Happy to add the keys if you'd prefer.
- **Token storage is localStorage today.** The backend also sets a session cookie and every request sends `credentials: "include"`, so the token is a convenience for the `Authorization` header rather than the only thing holding the session. It is isolated in `auth-storage.ts` precisely so it can move to an httpOnly-cookie or BFF approach without touching the context or the pages — worth deciding before real private routes ship.
- `npm run knip` still fails on `web` with `Invalid input (unrecognized_keys: $comment)` — pre-existing, and the workflow is `continue-on-error`.
