### PR TITLE
fix: stop wiping the recorded podcast on screen focus (#1838)

### DIFF
--- a/frontend/src/__tests__/screens/podcast/PodcastRecorder.test.tsx
+++ b/frontend/src/__tests__/screens/podcast/PodcastRecorder.test.tsx
@@ -1,0 +1,183 @@
+// @ts-nocheck
+import React from 'react';
+import {render, fireEvent, waitFor, act} from '@testing-library/react-native';
+import RNFS from 'react-native-fs';
+
+import PodcastRecorder from '../../../screens/podcast/PodcastRecorder';
+
+// Drive focus manually so a "return to this screen" can be simulated. Jest only
+// allows `mock`-prefixed names to be referenced from a mock factory.
+let mockFocusCallback: (() => void | (() => void)) | null = null;
+
+jest.mock('@react-navigation/native', () => ({
+  useFocusEffect: jest.fn(cb => {
+    const React = require('react');
+    mockFocusCallback = cb;
+    // The real hook runs the callback on focus and its return value on blur,
+    // and re-runs whenever the callback identity changes.
+    React.useEffect(cb, [cb]);
+  }),
+}));
+
+const RECORDED_URI = '/mock/caches/take-1.m4a';
+
+const mockRecorder = {
+  prepareToRecordAsync: jest.fn(() => Promise.resolve()),
+  record: jest.fn(),
+  stop: jest.fn(() => Promise.resolve()),
+  uri: RECORDED_URI,
+};
+
+jest.mock('expo-audio', () => ({
+  useAudioRecorder: jest.fn(() => mockRecorder),
+  useAudioRecorderState: jest.fn(() => ({durationMillis: 0})),
+  setAudioModeAsync: jest.fn(),
+  RecordingPresets: {HIGH_QUALITY: {}},
+  AudioModule: {
+    requestRecordingPermissionsAsync: jest.fn(() =>
+      Promise.resolve({granted: true}),
+    ),
+  },
+}));
+
+jest.mock('@/modules/audio-module', () => ({}));
+
+jest.mock('../../../lib/utils/Utils', () => ({
+  requestStoragePermissions: jest.fn(() => Promise.resolve(true)),
+}));
+
+jest.mock('lottie-react-native', () => 'LottieView');
+
+jest.mock('@expo/vector-icons/MaterialCommunityIcons', () => {
+  const React = require('react');
+  const {Text} = require('react-native');
+  return ({name}: any) => React.createElement(Text, null, name);
+});
+
+jest.mock('tamagui', () => {
+  const React = require('react');
+  const {View, Text: RNText} = require('react-native');
+  const passthrough =
+    (Comp: any) =>
+    ({children, onPress, ...rest}: any) =>
+      React.createElement(
+        Comp,
+        {onPress, accessible: true, ...(onPress ? {onStartShouldSetResponder: () => true} : {})},
+        children,
+      );
+  return {
+    Theme: passthrough(View),
+    XStack: passthrough(View),
+    YStack: passthrough(View),
+    Circle: passthrough(View),
+    Text: ({children}: any) => React.createElement(RNText, null, children),
+  };
+});
+
+const route = {
+  params: {
+    title: 'Sleep hygiene',
+    description: 'A short episode',
+    selectedGenres: [],
+    imageUtils: null,
+  },
+};
+
+const navigation = {navigate: jest.fn(), goBack: jest.fn()};
+
+const renderScreen = () =>
+  render(<PodcastRecorder navigation={navigation} route={route} />);
+
+// The visible labels ("RECORD", "PLAY", ...) are siblings of the pressable
+// circles, not children, so presses have to target the icon inside each circle.
+// The Icon mock renders the icon name as text.
+const ICON = {
+  record: 'record-circle',
+  stop: 'stop',
+  play: 'play',
+  retry: 'refresh',
+};
+
+const press = async (screen: any, icon: string) => {
+  await act(async () => {
+    fireEvent.press(screen.getByText(icon));
+  });
+};
+
+/** Records a take so the screen sits in its "review" state. */
+const recordATake = async (screen: any) => {
+  await press(screen, ICON.record);
+  await press(screen, ICON.stop);
+};
+
+describe('PodcastRecorder', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFocusCallback = null;
+    RNFS.exists.mockResolvedValue(true);
+    RNFS.unlink.mockResolvedValue(undefined);
+  });
+
+  it('reaches the review state after recording and stopping', async () => {
+    const screen = renderScreen();
+    await recordATake(screen);
+
+    // PLAY and RETRY only exist in the review state.
+    await waitFor(() => expect(screen.getByText('PLAY')).toBeTruthy());
+    expect(screen.getByText('RETRY')).toBeTruthy();
+  });
+
+  // The regression this file exists for: previewing a take used to destroy it.
+  it('keeps the recording when the screen is refocused after previewing', async () => {
+    const screen = renderScreen();
+    await recordATake(screen);
+    await waitFor(() => expect(screen.getByText('PLAY')).toBeTruthy());
+
+    // Preview it, which navigates away…
+    await press(screen, ICON.play);
+    expect(navigation.navigate).toHaveBeenCalledWith(
+      'PodcastPlayer',
+      expect.objectContaining({filePath: RECORDED_URI}),
+    );
+
+    RNFS.unlink.mockClear();
+
+    // …and come back. The file is still on disk.
+    await act(async () => {
+      mockFocusCallback?.();
+    });
+
+    // The take survives and is not deleted.
+    await waitFor(() => expect(screen.getByText('PLAY')).toBeTruthy());
+    expect(screen.getByText('RETRY')).toBeTruthy();
+    expect(RNFS.unlink).not.toHaveBeenCalled();
+  });
+
+  it('clears the review state when the take is gone from disk', async () => {
+    const screen = renderScreen();
+    await recordATake(screen);
+    await waitFor(() => expect(screen.getByText('PLAY')).toBeTruthy());
+
+    // The player unlinks the file after a successful upload, so on return the
+    // review controls would point at a path that no longer exists.
+    RNFS.exists.mockResolvedValue(false);
+
+    await act(async () => {
+      mockFocusCallback?.();
+    });
+
+    await waitFor(() => expect(screen.queryByText('PLAY')).toBeNull());
+    expect(screen.queryByText('RETRY')).toBeNull();
+  });
+
+  it('discards the take when the user presses RETRY', async () => {
+    const screen = renderScreen();
+    await recordATake(screen);
+    await waitFor(() => expect(screen.getByText('RETRY')).toBeTruthy());
+
+    await press(screen, ICON.retry);
+
+    await waitFor(() => expect(RNFS.unlink).toHaveBeenCalledWith(RECORDED_URI));
+    expect(screen.queryByText('PLAY')).toBeNull();
+  });
+});

--- a/frontend/src/screens/podcast/PodcastRecorder.tsx
+++ b/frontend/src/screens/podcast/PodcastRecorder.tsx
@@ -204,25 +204,6 @@ const stopRecording = async () => {
     setUiState('review');
   };
 
-  const handleReRecord = async () => {
-    if (filePath) {
-      try {
-        const exists = await RNFS.exists(filePath);
-        if (exists) {
-          await RNFS.unlink(filePath);
-          console.log('File deleted:', filePath);
-        }
-      } catch (err) {
-        console.warn('Error deleting file:', err);
-      }
-    }
-    setFilePath(null);
-    // unlink file path
-    setAmplitudes([]);
-    setRecordTime('00:00:00');
-    setUiState('idle');
-  };
-
   const unlinkFile = useCallback(async () => {
     if (filePath) {
       try {
@@ -237,20 +218,55 @@ const stopRecording = async () => {
     }
   }, [filePath]);
 
-  const handleUpload = useCallback(async () => {
-    setUploading(false);
-    setUiState('idle');
-    setFilePath(null);
-    setAmplitudes([]);
-    setRecordTime('00:00:00');
-    await unlinkFile();
-  }, [unlinkFile]);
+  /**
+   * Returns the screen to its empty state.
+   *
+   * `deleteFile` must be false when the take is already gone from disk —
+   * otherwise this would try to unlink a path that no longer exists.
+   */
+  const resetRecording = useCallback(
+    async ({deleteFile}: {deleteFile: boolean}) => {
+      if (deleteFile) {
+        await unlinkFile();
+      }
+      setUploading(false);
+      setUiState('idle');
+      setFilePath(null);
+      setAmplitudes([]);
+      setRecordTime('00:00:00');
+    },
+    [unlinkFile],
+  );
+
+  // RETRY: the user explicitly wants to throw this take away.
+  const handleReRecord = useCallback(
+    () => resetRecording({deleteFile: true}),
+    [resetRecording],
+  );
 
   useFocusEffect(
     useCallback(() => {
-      handleUpload();
+      // Previewing a take navigates to PodcastPlayer, so coming back here is a
+      // normal part of the flow and must NOT discard the recording. The only
+      // reason to clear on focus is that the file is genuinely gone — the
+      // player unlinks it after a successful upload — in which case the review
+      // controls would be pointing at a path that no longer exists.
+      let cancelled = false;
+
+      if (filePath) {
+        RNFS.exists(filePath)
+          .then(exists => {
+            if (!cancelled && !exists) {
+              resetRecording({deleteFile: false});
+            }
+          })
+          .catch(err =>
+            console.warn('Could not verify the recording still exists:', err),
+          );
+      }
 
       return () => {
+        cancelled = true;
         stopTimer();
 
         if (isRecordingRef.current) {
@@ -263,7 +279,7 @@ const stopRecording = async () => {
           isRecordingRef.current = false;
         }
       };
-    }, [audioRecorder, handleUpload]),
+    }, [audioRecorder, filePath, resetRecording]),
   );
 
   // useEffect(() => {


### PR DESCRIPTION
Closes #1838

## The bug

`PodcastRecorder` ran a full reset from `useFocusEffect`:

```tsx
useFocusEffect(
  useCallback(() => {
    handleUpload();   // clears filePath, resets uiState, unlinks the file
    ...
  }, [audioRecorder, handleUpload]),
);
```

Despite the name, `handleUpload()` uploads nothing — it sets `filePath` to `null`, resets `uiState` to `idle` and `await unlinkFile()`s the take off disk. It was also its **only** caller, so the screen's entire use of that function was to destroy the user's recording.

## It is worse than reported

The report covers the preview round trip: record → **PLAY** (navigates to `PodcastPlayer`) → back → focus fires → take gone.

There is a second path. The effect lists `handleUpload` in its dependencies, and that identity is derived from `filePath`:

```
handleUpload  →  unlinkFile  →  [filePath]
```

`stopRecording()` sets `filePath`, which changes `unlinkFile`, which changes `handleUpload`, which re-runs the focus effect — wiping the take the moment recording stops, without leaving the screen at all. My regression tests fail on the old code for *both* reasons.

## Why resetting on focus protected nothing

I traced where the reset could possibly be needed and there is no such case:

- **On a fresh mount** the state is already at its initial values, so the reset is a no-op.
- **The upload is not on this screen.** `PodcastPlayer.handlePostSubmit` does the upload, unlinks the file itself, and then `navigation.navigate('TabNavigation')` — it never returns to the recorder.

The one real hazard is the *aftermath* of that upload: the file is gone, but if the user reaches the recorder again its `uiState` may still be `review`, leaving PLAY and RETRY pointing at a path that no longer exists.

## The fix

The focus effect now clears only when the take is genuinely missing from disk:

```tsx
useFocusEffect(
  useCallback(() => {
    let cancelled = false;
    if (filePath) {
      RNFS.exists(filePath).then(exists => {
        if (!cancelled && !exists) resetRecording({deleteFile: false});
      }).catch(...);
    }
    return () => { cancelled = true; /* stop timer + recorder */ };
  }, [audioRecorder, filePath, resetRecording]),
);
```

Returning from a preview keeps the recording; a stale post-upload state still gets cleaned up. The `cancelled` flag stops a late `exists` resolution from resetting a screen the user has already left.

Two tidy-ups that fall out of it:

- `handleUpload` → **`resetRecording({deleteFile})`**, because a function called "upload" that silently deletes a recording is what invited this bug. `deleteFile: false` covers the case where the file is already gone.
- **RETRY** (`handleReRecord`) now reuses `resetRecording` instead of repeating the `exists`/`unlink` block verbatim.

## Tests

New `src/__tests__/screens/podcast/PodcastRecorder.test.tsx`, four cases:

| Test | Guards |
|---|---|
| reaches the review state after recording and stopping | the take survives being made |
| **keeps the recording when refocused after previewing** | the reported bug |
| clears the review state when the take is gone from disk | post-upload stale state still cleans up |
| discards the take when the user presses RETRY | explicit reset still deletes the file |

**All four fail against the previous implementation** — I checked out the old file and re-ran them to confirm the suite actually catches the regression rather than just passing alongside it.

## Verification

```
yarn test        # 462/462 pass, 131 suites (up from 458 — 4 new)
yarn type-check  # clean
yarn lint        # 0 errors; the 5 warnings are the require()-in-jest-mock
                 # pattern every existing test file in this repo uses
```

## Note on the automated review

The reviewer asked whether the `RNFS.exists` `catch` should also reset the UI to `idle`, since an I/O or permissions error leaves the screen in `review` with an unverified path.

I deliberately kept it as "log and leave the take alone". Resetting on a *failed check* would delete the user's recording on the strength of an error that usually means "we could not tell", and the file is most likely still there — which is the exact failure mode this PR exists to remove. Losing a take is unrecoverable; showing PLAY for a file that turns out to be missing is not, and the player already handles a bad path. If the check genuinely fails the user can still press RETRY.
