### PR TITLE
fix: await session teardown before rejecting on 401 (#1392)

### DIFF
--- a/frontend/src/__tests__/lib/api/SessionExpiry.test.ts
+++ b/frontend/src/__tests__/lib/api/SessionExpiry.test.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import {Alert} from 'react-native';
 import * as SecureStore from 'expo-secure-store';
+import authAxios from '../../../lib/api/authAxios';
 import store from '../../../store/ReduxStore';
 import {setUserHandle, setUserId, setUserToken} from '../../../store/UserSlice';
 import {SECURE_KEYS} from '../../../lib/storage/SecureStorageUtils';
@@ -136,6 +137,32 @@ describe('401 session teardown', () => {
     // interceptor read the not-yet-cleared credentials and re-attached the dead
     // token, producing another 401 and another teardown in a loop.
     const configPromise = onRequest({headers: {} as any});
+
+    releaseDeletion();
+    await rejection;
+
+    const config = await configPromise;
+    expect(config.headers.Authorization).toBeUndefined();
+  });
+
+  it('gates the authAxios request interceptor on an in-flight teardown', async () => {
+    let releaseDeletion: () => void = () => {};
+    deleteGate = new Promise<void>(resolve => {
+      releaseDeletion = resolve;
+    });
+
+    setupAxiosInterceptor();
+    const onError = getResponseErrorHandler();
+
+    // authAxios registers its own request interceptor at module load and reads
+    // the token straight from secure storage, so it needs the same gate as the
+    // global instance.
+    const authHandlers = (authAxios.interceptors.request as any).handlers;
+    const authRequest = authHandlers.find((h: any) => h && h.fulfilled);
+    expect(authRequest).toBeDefined();
+
+    const rejection = onError(unauthorizedError()).catch(() => {});
+    const configPromise = authRequest.fulfilled({headers: {} as any});
 
     releaseDeletion();
     await rejection;

--- a/frontend/src/__tests__/lib/api/SessionExpiry.test.ts
+++ b/frontend/src/__tests__/lib/api/SessionExpiry.test.ts
@@ -1,0 +1,191 @@
+import axios from 'axios';
+import {Alert} from 'react-native';
+import * as SecureStore from 'expo-secure-store';
+import store from '../../../store/ReduxStore';
+import {setUserHandle, setUserId, setUserToken} from '../../../store/UserSlice';
+import {SECURE_KEYS} from '../../../lib/storage/SecureStorageUtils';
+import {
+  resetSessionExpiredNotification,
+  setupAxiosInterceptor,
+} from '../../../lib/api/setupAxiosInterceptor';
+
+/**
+ * Regression tests for the 401 session teardown race (#1392).
+ *
+ * The interceptor used to fire `secureRemoveItem()` / `removeItem()` without
+ * awaiting them, so the rejection reached the caller — which then navigates to
+ * the login / guest screen — while the token deletions were still in flight.
+ */
+
+/** In-memory stand-in for the device secure store so deletions are observable. */
+let secureStoreData: Record<string, string> = {};
+
+/** Lets a test hold a deletion open to reproduce the mid-teardown window. */
+let deleteGate: Promise<void> | null = null;
+
+const unauthorizedError = () => ({response: {status: 401}});
+
+const flushMicrotasks = () => new Promise(resolve => setImmediate(resolve));
+
+const getResponseErrorHandler = () => {
+  const handlers = (axios.interceptors.response as any).handlers;
+  const handler = handlers.find((h: any) => h && h.rejected);
+  expect(handler).toBeDefined();
+  return handler.rejected;
+};
+
+const getRequestHandler = () => {
+  const handlers = (axios.interceptors.request as any).handlers;
+  const handler = handlers.find((h: any) => h && h.fulfilled);
+  expect(handler).toBeDefined();
+  return handler.fulfilled;
+};
+
+describe('401 session teardown', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (axios.interceptors.request as any).handlers = [];
+    (axios.interceptors.response as any).handlers = [];
+
+    secureStoreData = {};
+    deleteGate = null;
+    resetSessionExpiredNotification();
+
+    (SecureStore.getItemAsync as jest.Mock).mockImplementation(
+      async (key: string) => secureStoreData[key] ?? null,
+    );
+    (SecureStore.deleteItemAsync as jest.Mock).mockImplementation(
+      async (key: string) => {
+        if (deleteGate) {
+          await deleteGate;
+        }
+        delete secureStoreData[key];
+      },
+    );
+
+    jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+
+    // Start each test from a signed-in session.
+    secureStoreData[SECURE_KEYS.USER_TOKEN] = 'stale-token';
+    store.dispatch(setUserToken('stale-token'));
+    store.dispatch(setUserId('user-1'));
+    store.dispatch(setUserHandle('@user'));
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('does not reject to the caller until secure storage deletion resolves', async () => {
+    let releaseDeletion: () => void = () => {};
+    deleteGate = new Promise<void>(resolve => {
+      releaseDeletion = resolve;
+    });
+
+    setupAxiosInterceptor();
+    const onError = getResponseErrorHandler();
+
+    let rejected = false;
+    const rejection = onError(unauthorizedError()).catch(() => {
+      rejected = true;
+    });
+
+    await flushMicrotasks();
+
+    // The deletion is still pending, so the caller must not have been told to
+    // navigate away yet. This is the exact ordering the bug violated.
+    expect(rejected).toBe(false);
+
+    releaseDeletion();
+    await rejection;
+
+    expect(rejected).toBe(true);
+    expect(secureStoreData[SECURE_KEYS.USER_TOKEN]).toBeUndefined();
+  });
+
+  it('clears the persisted token and switches Redux to guest mode', async () => {
+    setupAxiosInterceptor();
+    const onError = getResponseErrorHandler();
+
+    await expect(onError(unauthorizedError())).rejects.toBeDefined();
+
+    expect(SecureStore.deleteItemAsync).toHaveBeenCalledWith(
+      SECURE_KEYS.USER_TOKEN,
+    );
+
+    const state = store.getState().user;
+    expect(state.user_token).toBe('');
+    expect(state.user_id).toBe('');
+    expect(state.user_handle).toBe('');
+    expect(state.isGuest).toBe(true);
+  });
+
+  it('never re-attaches the stale token to a request issued mid-teardown', async () => {
+    let releaseDeletion: () => void = () => {};
+    deleteGate = new Promise<void>(resolve => {
+      releaseDeletion = resolve;
+    });
+
+    setupAxiosInterceptor();
+    const onError = getResponseErrorHandler();
+    const onRequest = getRequestHandler();
+
+    const rejection = onError(unauthorizedError()).catch(() => {});
+
+    // Fired while the teardown is still deleting the token. Before the fix the
+    // interceptor read the not-yet-cleared credentials and re-attached the dead
+    // token, producing another 401 and another teardown in a loop.
+    const configPromise = onRequest({headers: {} as any});
+
+    releaseDeletion();
+    await rejection;
+
+    const config = await configPromise;
+    expect(config.headers.Authorization).toBeUndefined();
+  });
+
+  it('tears down once when several requests fail with 401 together', async () => {
+    setupAxiosInterceptor();
+    const onError = getResponseErrorHandler();
+
+    await Promise.all([
+      onError(unauthorizedError()).catch(() => {}),
+      onError(unauthorizedError()).catch(() => {}),
+      onError(unauthorizedError()).catch(() => {}),
+    ]);
+
+    expect(
+      (SecureStore.deleteItemAsync as jest.Mock).mock.calls.filter(
+        ([key]) => key === SECURE_KEYS.USER_TOKEN,
+      ),
+    ).toHaveLength(1);
+  });
+
+  it('propagates the original error even if storage cleanup fails', async () => {
+    (SecureStore.deleteItemAsync as jest.Mock).mockRejectedValue(
+      new Error('keystore busy'),
+    );
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    setupAxiosInterceptor();
+    const onError = getResponseErrorHandler();
+
+    const error = unauthorizedError();
+    await expect(onError(error)).rejects.toBe(error);
+
+    // A storage failure must still leave the app in guest mode rather than
+    // stranding it in a half-authenticated state.
+    expect(store.getState().user.isGuest).toBe(true);
+  });
+
+  it('leaves non-401 errors untouched', async () => {
+    setupAxiosInterceptor();
+    const onError = getResponseErrorHandler();
+
+    const error = {response: {status: 500}};
+    await expect(onError(error)).rejects.toBe(error);
+
+    expect(SecureStore.deleteItemAsync).not.toHaveBeenCalled();
+    expect(store.getState().user.user_token).toBe('stale-token');
+  });
+});

--- a/frontend/src/lib/api/authAxios.ts
+++ b/frontend/src/lib/api/authAxios.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import {SECURE_KEYS, secureRetrieveItem} from '../storage/SecureStorageUtils';
+import {awaitPendingSessionTeardown} from './sessionTeardown';
 import {PROD_URL} from './APIUtils';
 
 // Centralized Axios instance with authentication handling.
@@ -19,6 +20,13 @@ const authAxios = axios.create({
 authAxios.interceptors.request.use(
   async (config: any) => {
     config.headers ??= {} as typeof config.headers;
+
+    // If a 401 teardown is in flight, let it finish before reading the token.
+    // This instance reads straight from secure storage, so without the gate a
+    // request issued mid-teardown would re-attach the token that is currently
+    // being deleted, earning another 401 in a loop.
+    await awaitPendingSessionTeardown();
+
     const token = await secureRetrieveItem(SECURE_KEYS.USER_TOKEN);
     if (token) {
       config.headers.Authorization = `Bearer ${token}`;

--- a/frontend/src/lib/api/sessionTeardown.ts
+++ b/frontend/src/lib/api/sessionTeardown.ts
@@ -1,0 +1,96 @@
+import store from '../../store/ReduxStore';
+import {
+  setGuestMode,
+  setUserHandle,
+  setUserId,
+  setUserToken,
+} from '../../store/UserSlice';
+import {KEYS, removeItem} from '../utils/Utils';
+import {SECURE_KEYS, secureRemoveItem} from '../storage/SecureStorageUtils';
+
+/**
+ * Shared session-teardown state for the 401 handling in the axios layer.
+ *
+ * This lives in its own module because *both* axios instances need it: the
+ * global instance and `authAxios` each attach a token in their own request
+ * interceptor, so both must gate on the same in-flight teardown. Keeping the
+ * state here also avoids an import cycle, since `authAxios` cannot import
+ * from `setupAxiosInterceptor` (which imports `authAxios`).
+ */
+
+/**
+ * Holds the in-flight session teardown promise triggered by a 401 response.
+ *
+ * Two things depend on this handle:
+ * 1. Concurrent 401s (several in-flight requests expiring at once) share a
+ *    single teardown instead of each firing their own storage writes.
+ * 2. Request interceptors await it before reading credentials, so a request
+ *    issued mid-teardown can never observe a half-cleared session.
+ *
+ * It is reset to `null` once the teardown settles, so a future session that
+ * expires later gets a fresh teardown.
+ */
+let sessionTeardownPromise: Promise<void> | null = null;
+
+/**
+ * Erases every persisted trace of the expired session and *then* flips the
+ * app into guest mode.
+ *
+ * Ordering matters. Persisted credentials are removed before the Redux
+ * dispatches so that components re-rendering in response to the state change
+ * cannot read a half-cleared session (token gone from Redux but still on
+ * disk, or vice versa). This mirrors `completeLocalLogout` in LogoutScreen,
+ * which already awaits `clearStorage()` before dispatching and navigating.
+ *
+ * This function is deliberately non-throwing: the underlying helpers swallow
+ * their own errors, and the extra guard here ensures a storage failure can
+ * never surface as an unhandled rejection or mask the original API error.
+ */
+const clearExpiredSession = async (): Promise<void> => {
+  try {
+    await Promise.all([
+      secureRemoveItem(SECURE_KEYS.USER_TOKEN),
+      removeItem(KEYS.USER_TOKEN_EXPIRY_DATE),
+      removeItem(KEYS.USER_ID),
+      removeItem(KEYS.USER_HANDLE),
+    ]);
+  } catch (storageError) {
+    console.error('Failed to clear auth storage safely:', storageError);
+  }
+
+  store.dispatch(setUserToken(''));
+  store.dispatch(setUserId(''));
+  store.dispatch(setUserHandle(''));
+  store.dispatch(setGuestMode(true));
+};
+
+/**
+ * Starts a session teardown, or joins the one already running.
+ *
+ * When a token expires it is common for several in-flight requests to fail
+ * with 401 at nearly the same moment. Without this guard each of them would
+ * launch its own set of concurrent storage deletions for the same keys.
+ */
+export const teardownExpiredSession = (): Promise<void> => {
+  if (!sessionTeardownPromise) {
+    sessionTeardownPromise = clearExpiredSession().finally(() => {
+      sessionTeardownPromise = null;
+    });
+  }
+  return sessionTeardownPromise;
+};
+
+/**
+ * Awaited by request interceptors before they read any credentials.
+ *
+ * Without this gate a request issued mid-teardown could read the token that
+ * is currently being deleted and re-attach it — earning another 401 and
+ * kicking off another teardown in a loop. Resolves immediately when no
+ * teardown is running, so the happy path is unaffected.
+ */
+export const awaitPendingSessionTeardown = async (): Promise<void> => {
+  const pendingTeardown = sessionTeardownPromise;
+  if (pendingTeardown) {
+    await pendingTeardown;
+  }
+};

--- a/frontend/src/lib/api/setupAxiosInterceptor.ts
+++ b/frontend/src/lib/api/setupAxiosInterceptor.ts
@@ -4,17 +4,14 @@ import authAxios from './authAxios';
 import {Alert, Platform, ToastAndroid} from 'react-native';
 import store from '../../store/ReduxStore';
 import {
-  setGuestMode,
-  setUserHandle,
-  setUserId,
-  setUserToken,
-} from '../../store/UserSlice';
-import {
   API_REQUEST_TIMEOUT_MS,
   API_TIMEOUT_ERROR_MESSAGE,
 } from './ApiTimeout';
-import {KEYS, removeItem} from '../utils/Utils';
-import {SECURE_KEYS, secureRemoveItem, secureRetrieveItem} from '../storage/SecureStorageUtils';
+import {SECURE_KEYS, secureRetrieveItem} from '../storage/SecureStorageUtils';
+import {
+  awaitPendingSessionTeardown,
+  teardownExpiredSession,
+} from './sessionTeardown';
 import {logApiError} from '../services/monitoring/networkLogger';
 
 /**
@@ -26,20 +23,6 @@ import {logApiError} from '../services/monitoring/networkLogger';
  * session starts (i.e., after a successful login).
  */
 let sessionExpiredNotified = false;
-
-/**
- * Holds the in-flight session teardown promise triggered by a 401 response.
- *
- * Two things depend on this handle:
- * 1. Concurrent 401s (several in-flight requests expiring at once) share a
- *    single teardown instead of each firing their own storage writes.
- * 2. The request interceptor awaits it before reading credentials, so a
- *    request issued mid-teardown can never observe a half-cleared session.
- *
- * It is reset to `null` once the teardown settles, so a future session that
- * expires later gets a fresh teardown.
- */
-let sessionTeardownPromise: Promise<void> | null = null;
 
 /**
  * Module-scoped interceptor IDs.
@@ -64,54 +47,6 @@ let _authAxiosResId: number | null = null;
  */
 export const resetSessionExpiredNotification = (): void => {
   sessionExpiredNotified = false;
-};
-
-/**
- * Erases every persisted trace of the expired session and *then* flips the
- * app into guest mode.
- *
- * Ordering matters. Persisted credentials are removed before the Redux
- * dispatches so that components re-rendering in response to the state change
- * cannot read a half-cleared session (token gone from Redux but still on
- * disk, or vice versa). This mirrors `completeLocalLogout` in LogoutScreen,
- * which already awaits `clearStorage()` before dispatching and navigating.
- *
- * This function is deliberately non-throwing: the underlying helpers swallow
- * their own errors, and the extra guard here ensures a storage failure can
- * never surface as an unhandled rejection or mask the original API error.
- */
-const clearExpiredSession = async (): Promise<void> => {
-  try {
-    await Promise.all([
-      secureRemoveItem(SECURE_KEYS.USER_TOKEN),
-      removeItem(KEYS.USER_TOKEN_EXPIRY_DATE),
-      removeItem(KEYS.USER_ID),
-      removeItem(KEYS.USER_HANDLE),
-    ]);
-  } catch (storageError) {
-    console.error('Failed to clear auth storage safely:', storageError);
-  }
-
-  store.dispatch(setUserToken(''));
-  store.dispatch(setUserId(''));
-  store.dispatch(setUserHandle(''));
-  store.dispatch(setGuestMode(true));
-};
-
-/**
- * Starts a session teardown, or joins the one already running.
- *
- * When a token expires it is common for several in-flight requests to fail
- * with 401 at nearly the same moment. Without this guard each of them would
- * launch its own set of concurrent storage deletions for the same keys.
- */
-const teardownExpiredSession = (): Promise<void> => {
-  if (!sessionTeardownPromise) {
-    sessionTeardownPromise = clearExpiredSession().finally(() => {
-      sessionTeardownPromise = null;
-    });
-  }
-  return sessionTeardownPromise;
 };
 
 /**
@@ -216,10 +151,7 @@ export const setupAxiosInterceptor = () => {
       // without this gate a request could fall through to secure storage,
       // read the token currently being deleted, and re-attach it — earning
       // another 401 and kicking off another teardown in a loop.
-      const pendingTeardown = sessionTeardownPromise;
-      if (pendingTeardown) {
-        await pendingTeardown;
-      }
+      await awaitPendingSessionTeardown();
 
       let token = store.getState().user.user_token;
       if (!token) {

--- a/frontend/src/lib/api/setupAxiosInterceptor.ts
+++ b/frontend/src/lib/api/setupAxiosInterceptor.ts
@@ -28,6 +28,20 @@ import {logApiError} from '../services/monitoring/networkLogger';
 let sessionExpiredNotified = false;
 
 /**
+ * Holds the in-flight session teardown promise triggered by a 401 response.
+ *
+ * Two things depend on this handle:
+ * 1. Concurrent 401s (several in-flight requests expiring at once) share a
+ *    single teardown instead of each firing their own storage writes.
+ * 2. The request interceptor awaits it before reading credentials, so a
+ *    request issued mid-teardown can never observe a half-cleared session.
+ *
+ * It is reset to `null` once the teardown settles, so a future session that
+ * expires later gets a fresh teardown.
+ */
+let sessionTeardownPromise: Promise<void> | null = null;
+
+/**
  * Module-scoped interceptor IDs.
  *
  * Storing the numeric IDs returned by `.use()` lets us call `.eject()` before
@@ -53,24 +67,74 @@ export const resetSessionExpiredNotification = (): void => {
 };
 
 /**
+ * Erases every persisted trace of the expired session and *then* flips the
+ * app into guest mode.
+ *
+ * Ordering matters. Persisted credentials are removed before the Redux
+ * dispatches so that components re-rendering in response to the state change
+ * cannot read a half-cleared session (token gone from Redux but still on
+ * disk, or vice versa). This mirrors `completeLocalLogout` in LogoutScreen,
+ * which already awaits `clearStorage()` before dispatching and navigating.
+ *
+ * This function is deliberately non-throwing: the underlying helpers swallow
+ * their own errors, and the extra guard here ensures a storage failure can
+ * never surface as an unhandled rejection or mask the original API error.
+ */
+const clearExpiredSession = async (): Promise<void> => {
+  try {
+    await Promise.all([
+      secureRemoveItem(SECURE_KEYS.USER_TOKEN),
+      removeItem(KEYS.USER_TOKEN_EXPIRY_DATE),
+      removeItem(KEYS.USER_ID),
+      removeItem(KEYS.USER_HANDLE),
+    ]);
+  } catch (storageError) {
+    console.error('Failed to clear auth storage safely:', storageError);
+  }
+
+  store.dispatch(setUserToken(''));
+  store.dispatch(setUserId(''));
+  store.dispatch(setUserHandle(''));
+  store.dispatch(setGuestMode(true));
+};
+
+/**
+ * Starts a session teardown, or joins the one already running.
+ *
+ * When a token expires it is common for several in-flight requests to fail
+ * with 401 at nearly the same moment. Without this guard each of them would
+ * launch its own set of concurrent storage deletions for the same keys.
+ */
+const teardownExpiredSession = (): Promise<void> => {
+  if (!sessionTeardownPromise) {
+    sessionTeardownPromise = clearExpiredSession().finally(() => {
+      sessionTeardownPromise = null;
+    });
+  }
+  return sessionTeardownPromise;
+};
+
+/**
  * Shared error handler used by both axios instances.
  * Logs API errors safely and handles 401 Unauthorized specifically.
+ *
+ * The handler is async and awaits the session teardown before rejecting, so
+ * by the time a caller's `catch` block runs — and navigates to the login /
+ * guest screen — secure storage and Redux are already consistent. Previously
+ * the storage clears were fired without `await`, letting navigation and
+ * re-renders race the deletions.
  */
-const handleError = (error: any) => {
+const handleError = async (error: any) => {
   // Log the API error securely without exposing secrets
   logApiError(error, undefined, {handler: 'axiosInterceptor'});
 
   if (error?.response?.status === 401) {
-    store.dispatch(setUserToken(''));
-    store.dispatch(setUserId(''));
-    store.dispatch(setUserHandle(''));
-    store.dispatch(setGuestMode(true));
-
-    // Clear token from secure storage to prevent re-attachment by request interceptor.
-    secureRemoveItem(SECURE_KEYS.USER_TOKEN);
-    removeItem(KEYS.USER_TOKEN_EXPIRY_DATE);
-    removeItem(KEYS.USER_ID);
-    removeItem(KEYS.USER_HANDLE);
+    try {
+      await teardownExpiredSession();
+    } catch (teardownError) {
+      // Never let a teardown failure replace the original API error.
+      console.error('Failed to clear the expired session safely:', teardownError);
+    }
 
     // Notify once to avoid alert/toast spam if multiple calls fail simultaneously.
     if (!sessionExpiredNotified) {
@@ -146,7 +210,17 @@ export const setupAxiosInterceptor = () => {
   _axiosReqId = axios.interceptors.request.use(
     async config => {
       config.headers ??= {} as typeof config.headers;
-      
+
+      // If a 401 teardown is in flight, let it finish before reading any
+      // credentials. Redux is cleared only at the end of the teardown, so
+      // without this gate a request could fall through to secure storage,
+      // read the token currently being deleted, and re-attach it — earning
+      // another 401 and kicking off another teardown in a loop.
+      const pendingTeardown = sessionTeardownPromise;
+      if (pendingTeardown) {
+        await pendingTeardown;
+      }
+
       let token = store.getState().user.user_token;
       if (!token) {
         token = await secureRetrieveItem(SECURE_KEYS.USER_TOKEN);


### PR DESCRIPTION
Fixes #1392

## Verified code reference

As requested in the issue thread, here is the confirmed code path — this is a real defect in the current codebase, not a theoretical race.

`frontend/src/lib/api/setupAxiosInterceptor.ts`, in the shared `handleError` used by both axios instances ([L59-L90 before this change](https://github.com/SB2318/UltimateHealth/blob/main/frontend/src/lib/api/setupAxiosInterceptor.ts#L59-L90)):

```ts
const handleError = (error: any) => {           // not async
  if (error?.response?.status === 401) {
    store.dispatch(setUserToken(''));           // state cleared synchronously
    ...
    secureRemoveItem(SECURE_KEYS.USER_TOKEN);   // floating promise — never awaited
    removeItem(KEYS.USER_TOKEN_EXPIRY_DATE);    // floating
    removeItem(KEYS.USER_ID);                   // floating
    removeItem(KEYS.USER_HANDLE);               // floating
  }
  return Promise.reject(error);                 // rejects while deletions are in flight
};
```

`secureRemoveItem` awaits `SecureStore.deleteItemAsync()` internally (`lib/storage/SecureStorageUtils.ts:58`), but the interceptor never awaits the returned promise. The rejection reaches the caller — which then navigates to the login / guest screen — while the deletions are still running.

Note this repo uses Redux guest mode + React Navigation rather than `expo-router`, so the fix follows the existing local-logout convention instead of the `router.replace()` snippet in the issue.

## Two concrete consequences

**1. Half-cleared session during the logout transition.** Callers navigate and screens re-render while the token deletions are still pending, so anything re-reading storage mid-transition can see partially cleared credentials.

**2. Stale-token re-attachment loop.** This one defeats a guard the code already intended to have. The removed line was commented *"Clear token from secure storage to prevent re-attachment by request interceptor"* — but without `await` it does not prevent that. Redux is cleared synchronously, so a request issued mid-teardown finds an empty token in state and falls through to secure storage:

```ts
let token = store.getState().user.user_token;      // '' — already cleared
if (!token) {
  token = await secureRetrieveItem(SECURE_KEYS.USER_TOKEN);  // reads the token being deleted
}
```

It re-attaches the dead token, earns another 401, and kicks off another teardown.

Separately, `sessionExpiredNotified` deduplicates the toast when several requests fail at once, but nothing deduplicated the *storage* work — every concurrent 401 fired its own deletions for the same keys.

## Changes

- `handleError` is now `async` and awaits the teardown before rejecting, so storage and Redux are consistent by the time a caller's `catch` block runs.
- Persisted credentials are cleared **before** dispatching to guest mode, matching the ordering `completeLocalLogout()` already uses in `LogoutScreen.tsx:34-41` (`await clearStorage()` → dispatch → navigate).
- Concurrent 401s share a single teardown promise instead of each firing duplicate deletions.
- The request interceptor awaits any in-flight teardown before reading credentials, closing the re-attachment window completely.
- A storage failure is logged and never replaces the original API error, so callers still receive the actual axios error.

Public behaviour is otherwise unchanged: the same error still propagates to callers, the session-expired notification still fires once, and interceptor idempotency is untouched.

## Both axios instances are affected

`handleError` is shared by the global `axios` instance **and** `authAxios`, and each attaches a token in its own request interceptor. `authAxios` (`lib/api/authAxios.ts`) reads straight from secure storage with no Redux check:

```ts
const token = await secureRetrieveItem(SECURE_KEYS.USER_TOKEN);
```

so it is if anything more exposed to the re-attachment race than the global instance. This path is live — `useGetWeeklyWellness`, `useLogWellness`, and `BreathingTool` all use `authAxios`.

The teardown state therefore lives in a small shared module, `lib/api/sessionTeardown.ts`, that both instances gate on. That module placement also avoids an import cycle: `authAxios` cannot import from `setupAxiosInterceptor`, which already imports `authAxios`.

A test covers this specifically — without the gate, `authAxios` re-attaches `"Bearer stale-token"` to a request issued mid-teardown.

## Testing

Added `frontend/src/__tests__/lib/api/SessionExpiry.test.ts` (7 tests) covering the ordering guarantee, the stale-token re-attachment loop on both axios instances, teardown deduplication, error propagation on storage failure, and non-401 pass-through.

These are genuine regression tests — I reverted the source fix and confirmed the three race-specific tests fail without it:

```
✕ does not reject to the caller until secure storage deletion resolves
✕ never re-attaches the stale token to a request issued mid-teardown
✕ tears down once when several requests fail with 401 together
```

With the fix applied, all pass.

- `npx jest src/__tests__/lib/api/` → 16/16 pass (new suite + existing `ApiTimeout` suite)
- Full suite → 505 passed, 1 failed. The failure is `WellnessDashboardScreen.test.tsx › renders data-driven dashboard when weekly logs exist`, which is **pre-existing and unrelated** — I confirmed it fails identically on a clean checkout with my changes stashed.
- `npx tsc --noEmit` → no errors in the touched files; `npx eslint` → clean.

## Note on the two red checks

Neither relates to this change:

**`Unit Tests`** — the only failing test is `WellnessDashboardScreen › renders data-driven dashboard when weekly logs exist`. It is pre-existing on `main`: I re-ran the full suite locally with my changes stashed and it fails identically. The full suite now reports `1 failed, 506 passed, 507 total` — the same single pre-existing failure, with the passing count up by this PR's new tests — so it neither introduces nor fixes that one. Fixing it here would be unrelated scope.

**`PR Governance › Enforce Minimum Label Usage`** — a timing race, not a real violation. The job ran at `06:26:25Z` and failed with *"Please apply at least one meaningful label"*, but the labeling bot applied six labels at `06:26:39Z`, 14 seconds later. The workflow does listen for `labeled`, however the bot labels using `GITHUB_TOKEN`, and GitHub suppresses workflow re-triggers from that token, so no re-run was queued. The PR now carries `gssoc`, `gssoc:approved`, `type:fix`, `type:testing`, `level:frontend`, and `quality:exceptional`; a re-run should pass.
