### PR TITLE
fix: declare tokenRes via useCheckTokenStatus in deep-link auth guard

### DIFF
--- a/frontend/src/components/common/AppContent.tsx
+++ b/frontend/src/components/common/AppContent.tsx
@@ -28,6 +28,7 @@ import {
 import { setupAxiosInterceptor } from '../../lib/api/setupAxiosInterceptor';
 import { initMonitoring } from '../../lib/services/monitoring/sentry';
 
+import { useCheckTokenStatus } from '../../hooks/auth/useGetTokenStatus';
 import { setUserToken, setGuestMode, setUserId, setUserHandle } from '../../store/UserSlice';
 import { setConnected } from '../../store/NetworkSlice';
 import { RootState } from '../../store/ReduxStore';
@@ -49,6 +50,8 @@ export default function AppContent() {
   const { user_token, isGuest } = useAppSelector(
     (state: RootState) => state.user,
   );
+
+  const { data: tokenRes } = useCheckTokenStatus();
 
   useNotificationListeners();
 
@@ -127,7 +130,7 @@ export default function AppContent() {
 
   useEffect(() => {
     if (!navigationRef.current || !pendingDeepLinkRef.current) return;
-    if (!isGuest && tokenRes === null && !user_token) return;
+    if (!isGuest && !tokenRes && !user_token) return;
 
     const isAuthenticated = Boolean(tokenRes?.isValid || user_token) && !isGuest;
     const target = resolveDeepLinkTarget(pendingDeepLinkRef.current);


### PR DESCRIPTION
#### PR Description
Fixes the `ReferenceError: tokenRes is not defined` that crashes the deep-link auth guard in `AppContent.tsx`.

`AppContent.tsx` referenced `tokenRes` (lines 130, 132, 146) without ever declaring it. Because the file uses `// @ts-nocheck`, TypeScript never flagged the undeclared identifier, so the guard threw at runtime the first time a deep link was processed. This made deep-link navigation (including restricted-route auth gating) dead/broken.

**Changes:**
- Imported and wired the existing `useCheckTokenStatus` hook (`frontend/src/hooks/auth/useGetTokenStatus.ts`) into `AppContent`, exposing `tokenRes` via `const { data: tokenRes } = useCheckTokenStatus()`.
- Relaxed the pre-navigation guard from `tokenRes === null` to `!tokenRes` so it correctly waits while the token check is still loading (`undefined`) and after it resolves invalid (`null`).

#### Type of Change
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update

#### Select your work-area
- [x] Frontend
- [ ] Backend
- [ ] Documentation
- [ ] Others

#### Related Issue
https://github.com/SB2318/UltimateHealth/issues/2302

#### Fixes (mention the issue number which this fixes)
#2302

#### Checklist
- [x] I have updated my branch and synced it with the project's 'main' branch before making this PR.
- [x] I have optimized the file changes.
- [ ] I have added a snapshot of my work example.
- [x] I have made a PR to the project's main branch.

#### Undertaking
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have checked for plagiarism and assure its authenticity.
- [x] I have read and followed the code of conduct for this repository. I understand that violation of this undertaking may have legal consequences.

- [x] I Agree
