### PR TITLE
fix: never persist auth token in plaintext AsyncStorage fallback

### DIFF
--- a/frontend/src/lib/storage/SecureStorageUtils.ts
+++ b/frontend/src/lib/storage/SecureStorageUtils.ts
@@ -9,6 +9,16 @@ export const SECURE_KEYS = {
 
 export type SecureKey = (typeof SECURE_KEYS)[keyof typeof SECURE_KEYS];
 
+// Only non-sensitive values are allowed to fall back to plaintext AsyncStorage.
+// Sensitive credentials (auth tokens, push tokens) must NEVER be persisted
+// unencrypted — if SecureStore is unavailable they fail the write instead.
+const PLAINTEXT_FALLBACK_KEYS: ReadonlySet<SecureKey> = new Set<SecureKey>([
+  SECURE_KEYS.LANGUAGE_PREFERENCES,
+]);
+
+const isPlaintextFallbackAllowed = (key: SecureKey): boolean =>
+  PLAINTEXT_FALLBACK_KEYS.has(key);
+
 export const secureStoreItem = async (
   key: SecureKey,
   value: string,
@@ -21,7 +31,15 @@ export const secureStoreItem = async (
 
     try {
       await SecureStore.setItemAsync(key, value);
+      await AsyncStorage.removeItem(`FALLBACK_${key}`);
     } catch (e) {
+      if (!isPlaintextFallbackAllowed(key)) {
+        console.error(
+          `[SecureStorage] Refusing to store sensitive key ${key} in plaintext fallback`,
+          e,
+        );
+        return false;
+      }
       console.warn(`[SecureStorage] Failed to store ${key}, falling back to AsyncStorage`, e);
       await AsyncStorage.setItem(`FALLBACK_${key}`, value);
     }
@@ -37,7 +55,7 @@ export const secureRetrieveItem = async (
 ): Promise<string | null> => {
   try {
     let value = await SecureStore.getItemAsync(key);
-    if (!value) {
+    if (!value && isPlaintextFallbackAllowed(key)) {
       value = await AsyncStorage.getItem(`FALLBACK_${key}`);
     }
     if (!value || value.trim().length === 0) {
@@ -47,6 +65,9 @@ export const secureRetrieveItem = async (
   } catch (error) {
     console.error(`[SecureStorage] Error retrieving key "${key}":`, error);
     try {
+      if (!isPlaintextFallbackAllowed(key)) {
+        return null;
+      }
       const fallback = await AsyncStorage.getItem(`FALLBACK_${key}`);
       return fallback || null;
     } catch (e) {


### PR DESCRIPTION
#### PR Description
Prevents the auth bearer token from ever being persisted in plaintext.

`SecureStorageUtils` silently fell back to unencrypted `AsyncStorage` whenever `expo-secure-store` failed, writing `SECURE_USER_TOKEN` (and `SECURE_EXPO_PUSH_TOKEN`) in clear text under a `FALLBACK_...` key. AsyncStorage is backed by an unencrypted SQLite DB and is included in device backups — a leaked bearer token enables session hijacking / account takeover.

**Changes:**
- Added `PLAINTEXT_FALLBACK_KEYS`, allowing the plaintext `AsyncStorage` fallback **only** for non-sensitive values (`SECURE_LANGUAGE_PREFERENCES`).
- `secureStoreItem`: on SecureStore failure, sensitive keys now **fail the write** (return `false`) instead of writing plaintext; after a successful SecureStore write any stale `FALLBACK_*` copy is purged.
- `secureRetrieveItem`: reads of sensitive keys no longer fall back to the plaintext copy.
- `secureRemoveItem` / `secureClearAllItems`: unchanged cleanup behavior (still purges `FALLBACK_*`).

Behavioral note: on devices where SecureStore permanently fails, the auth token is no longer persisted, so the user is required to re-authenticate per session rather than silently storing the token insecurely.

#### Type of Change
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update

#### Select your work-area
- [x] Frontend
- [ ] Backend
- [ ] Documentation
- [ ] Others

#### Related Issue
https://github.com/SB2318/UltimateHealth/issues/2303

#### Fixes (mention the issue number which this fixes)
#2303

#### Checklist
- [x] I have updated my branch and synced it with the project's 'main' branch before making this PR.
- [x] I have optimized the file changes.
- [ ] I have added a snapshot of my work example.
- [x] I have made a PR to the project's main branch.

#### Undertaking
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have checked for plagiarism and assure its authenticity.
- [x] I have read and followed the code of conduct for this repository. I understand that violation of this undertaking may have legal consequences.

- [x] I Agree
