### PR TITLE
fix: harden content WebViews against stored XSS and unsafe schemes

### DIFF
--- a/frontend/src/components/article/ImprovementCard.tsx
+++ b/frontend/src/components/article/ImprovementCard.tsx
@@ -12,7 +12,7 @@ import {fp, hp} from '../../lib/ui/Metric';
 import {ImprovementCardProps} from '../../schemas/type';
 import { formatDateShortYear } from '../../lib/utils/dateUtils';
 import {BUTTON_COLOR, PRIMARY_COLOR} from '../../lib/ui/Theme';
-import {handleExternalClick, StatusEnum} from '../../lib/utils/Utils';
+import {handleExternalClick, sanitizeHtml, StatusEnum} from '../../lib/utils/Utils';
 //import io from 'socket.io-client';
 import AntDesign from '@expo/vector-icons/AntDesign';
 import AutoHeightWebView from '@brown-bear/react-native-autoheight-webview';
@@ -81,8 +81,8 @@ const ImprovementCard = ({item, onNavigate}: ImprovementCardProps) => {
                   rel: 'stylesheet',
                 },
               ]}
-              originWhitelist={['*']}
-              source={{html: extractBody(item?.edit_reason) || '<p>No reason provided.</p>'}}
+              originWhitelist={['http://*', 'https://*']}
+              source={{html: sanitizeHtml(extractBody(item?.edit_reason) || '<p>No reason provided.</p>')}}
               scalesPageToFit={true}
               viewportContent={'width=device-width, user-scalable=no'}
               onShouldStartLoadWithRequest={handleExternalClick}

--- a/frontend/src/lib/utils/Utils.ts
+++ b/frontend/src/lib/utils/Utils.ts
@@ -71,13 +71,38 @@ export function formatCount(count: number) {
   else return Math.floor(count / 1000000) + 'M';
 }
 
+// Only safe, externally-openable schemes are allowed to leave the WebView.
+// Anything else (javascript:, data:, vbscript:, file:, custom schemes, ...)
+// is blocked so injected content cannot trigger script execution.
+const SAFE_EXTERNAL_URL = /^(https?|mailto|tel|sms):/i;
+
 export const handleExternalClick = (request: any) => {
   const {url} = request;
-  if (url.startsWith('http')) {
+  if (SAFE_EXTERNAL_URL.test(url ?? '')) {
     Linking.openURL(url);
-    return false;
   }
-  return true;
+  return false;
+};
+
+// Minimal HTML sanitizer for content rendered inside WebViews.
+// Strips executable/embedding tags, event-handler attributes and
+// javascript: URLs while preserving article formatting.
+export const sanitizeHtml = (html: string | null | undefined): string => {
+  if (!html) return '';
+  return html
+    .replace(/<\s*script\b[\s\S]*?<\s*\/\s*script\s*>/gi, '')
+    .replace(/<\s*script\b[^>]*\/?>/gi, '')
+    .replace(/<\s*iframe\b[\s\S]*?<\s*\/\s*iframe\s*>/gi, '')
+    .replace(/<\s*iframe\b[^>]*\/?>/gi, '')
+    .replace(/<\s*object\b[\s\S]*?<\s*\/\s*object\s*>/gi, '')
+    .replace(/<\s*object\b[^>]*\/?>/gi, '')
+    .replace(/<\s*embed\b[^>]*\/?>/gi, '')
+    .replace(/\son\w+\s*=\s*("[^"]*"|'[^']*'|[^\s>]+)/gi, '')
+    .replace(
+      /\s(href|src)\s*=\s*("[^"]*"|'[^']*'|[^\s>]+)/gi,
+      (match, attr, value) =>
+        /javascript:/i.test(value) ? ` ${attr}="#"` : match,
+    );
 };
 
 export function msToTime(ms: number): string {
@@ -154,10 +179,17 @@ export const createHTMLStructure = (
   social_link: string,
   author: string,
 ) => {
+  const safeTitle = sanitizeHtml(title);
+  const safeBody = sanitizeHtml(body);
+  const safeAuthor = sanitizeHtml(author);
+  const safeTags = (tags || []).map(tag => ({
+    ...tag,
+    name: sanitizeHtml(tag?.name ?? ''),
+  }));
   return `<!DOCTYPE html>
 <html>
 <head>
-<title>${title}</title>
+<title>${safeTitle}</title>
 <style>
 body { font-family: Arial, sans-serif; font-size: 18px; line-height: 1.6; color: #333; }
 h1 { color: #00698f; } h2 { color: #008000; } h3 { color: #660066; }
@@ -173,13 +205,13 @@ th { background-color: #f0f0f0; }
 </style>
 </head>
 <body>
-${body}
+${safeBody}
 <hr>
 <ul class="tag-list">
-  ${tags.map(tag => `<li><a class="tag" href="#">#${tag.name}</a></li>`).join('')}
+  ${safeTags.map(tag => `<li><a class="tag" href="#">#${tag.name}</a></li>`).join('')}
 </ul>
 <h3>Author</h3>
-<h4>${author}</h4>
+<h4>${safeAuthor}</h4>
 </body>
 </html>`;
 };

--- a/frontend/src/screens/article/ArticleScreen.tsx
+++ b/frontend/src/screens/article/ArticleScreen.tsx
@@ -39,6 +39,7 @@ import {
   formatCount,
   handleExternalClick,
   retrieveItem,
+  sanitizeHtml,
   StatusEnum,
   storeItem,
 } from '../../lib/utils/Utils';
@@ -1389,8 +1390,8 @@ const ArticleScreen = ({navigation, route}: ArticleScreenProp) => {
                         rel: 'stylesheet',
                       },
                     ]}
-                    originWhitelist={['*']}
-                    source={{html: articleContent}}
+                    originWhitelist={['http://*', 'https://*']}
+                    source={{html: sanitizeHtml(articleContent)}}
                     scalesPageToFit={true}
                     viewportContent={'width=device-width, user-scalable=no'}
                     onShouldStartLoadWithRequest={handleExternalClick}

--- a/frontend/src/screens/article/PreviewScreen.tsx
+++ b/frontend/src/screens/article/PreviewScreen.tsx
@@ -507,7 +507,7 @@ export default function PreviewScreen({navigation, route}: PreviewScreenProp) {
               rel: 'stylesheet',
             },
           ]}
-          originWhitelist={['*']}
+          originWhitelist={['http://*', 'https://*']}
           source={{
             html: createHTMLStructure(
               title,

--- a/frontend/src/screens/article/RenderSuggestion.tsx
+++ b/frontend/src/screens/article/RenderSuggestion.tsx
@@ -75,6 +75,7 @@ export default function RenderSuggestion({
           .complex-sentence { background-color: #fef08a; padding: 2px; border-radius: 4px; border-bottom: 2px solid #ca8a04; }
         `}
         source={{ html: formattedHtml }}
+        originWhitelist={['http://*', 'https://*']}
         scalesPageToFit={false}
         viewportContent={'width=device-width, user-scalable=no'}
         // ✅ Re-added link interceptor so external links safely launch default system browser

--- a/frontend/src/screens/overview/ImprovementReviewScreen.tsx
+++ b/frontend/src/screens/overview/ImprovementReviewScreen.tsx
@@ -24,7 +24,7 @@ import {GET_STORAGE_DATA} from '../../lib/api/APIUtils';
 import {useSocket} from '../../contexts/SocketContext';
 //import CommentScreen from '../CommentScreen';
 import {setUserHandle} from '../../store/UserSlice';
-import {handleExternalClick, StatusEnum} from '../../lib/utils/Utils';
+import {handleExternalClick, sanitizeHtml, StatusEnum} from '../../lib/utils/Utils';
 import ReviewItem from '../../components/article/ReviewItem';
 import {Button, Spinner, TextArea, YStack, Text} from 'tamagui';
 import AutoHeightWebView from '@brown-bear/react-native-autoheight-webview';
@@ -223,8 +223,8 @@ const ImprovementReviewScreen = ({navigation, route}: ImpvReviewScreenProp) => {
                   rel: 'stylesheet',
                 },
               ]}
-              originWhitelist={['*']}
-              source={{html: htmlContent ?? noDataHtml}}
+              originWhitelist={['http://*', 'https://*']}
+              source={{html: sanitizeHtml(htmlContent ?? noDataHtml)}}
               scalesPageToFit={true}
               viewportContent={'width=device-width, user-scalable=no'}
               onShouldStartLoadWithRequest={handleExternalClick}

--- a/frontend/src/screens/overview/ReviewScreen.tsx
+++ b/frontend/src/screens/overview/ReviewScreen.tsx
@@ -22,7 +22,7 @@ import {
 } from '../../lib/api/APIUtils';
 
 import {setUserHandle} from '../../store/UserSlice';
-import {handleExternalClick, StatusEnum} from '../../lib/utils/Utils';
+import {handleExternalClick, sanitizeHtml, StatusEnum} from '../../lib/utils/Utils';
 import ReviewItem from '../../components/article/ReviewItem';
 import {Button, Spinner, Text, YStack, TextArea} from 'tamagui';
 import AutoHeightWebView from '@brown-bear/react-native-autoheight-webview';
@@ -179,8 +179,8 @@ const ReviewScreen = ({navigation, route}: ReviewScreenProp) => {
                   rel: 'stylesheet',
                 },
               ]}
-              originWhitelist={['*']}
-              source={{html: articleContent ?? noDataHtml}}
+              originWhitelist={['http://*', 'https://*']}
+              source={{html: sanitizeHtml(articleContent ?? noDataHtml)}}
               scalesPageToFit={true}
               viewportContent={'width=device-width, user-scalable=no'}
               onShouldStartLoadWithRequest={handleExternalClick}


### PR DESCRIPTION
#### PR Description
Hardens the content WebViews against stored XSS and unsafe URL schemes.

Server-returned article/review HTML was rendered with `originWhitelist={['*']}`, no sanitization, and a navigation handler that allowed non-http(s) schemes — a realistic stored-XSS vector (`<script>` / event-handler / `javascript:` injection) on any device opening affected content.

**Changes:**
- `frontend/src/lib/utils/Utils.ts`:
  - `handleExternalClick` now blocks **all** non-http(s/mailto/tel/sms) schemes (returns `false`), so `javascript:`, `data:`, `vbscript:` and custom schemes can no longer execute/load inside the WebView.
  - Added `sanitizeHtml()`: strips `<script>`/`<iframe>`/`<object>`/`<embed>` tags, `on*` event-handler attributes, and neutralizes `javascript:` URLs in `href`/`src` while preserving article formatting.
  - `createHTMLStructure` now sanitizes the interpolated `title`/`body`/`author`/tag values.
- Tightened `originWhitelist` from `['*']` to `['http://*', 'https://*']` in all content WebViews:
  - `screens/article/ArticleScreen.tsx`
  - `screens/article/PreviewScreen.tsx`
  - `screens/article/RenderSuggestion.tsx`
  - `screens/overview/ReviewScreen.tsx`
  - `screens/overview/ImprovementReviewScreen.tsx`
  - `components/article/ImprovementCard.tsx`
- Raw server HTML is now passed through `sanitizeHtml()` before injection in `ArticleScreen`, `ReviewScreen`, `ImprovementReviewScreen` and `ImprovementCard`.

#### Type of Change
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update

#### Select your work-area
- [x] Frontend
- [ ] Backend
- [ ] Documentation
- [ ] Others

#### Related Issue
https://github.com/SB2318/UltimateHealth/issues/2304

#### Fixes (mention the issue number which this fixes)
#2304

#### Checklist
- [x] I have updated my branch and synced it with the project's 'main' branch before making this PR.
- [x] I have optimized the file changes.
- [ ] I have added a snapshot of my work example.
- [x] I have made a PR to the project's main branch.

#### Undertaking
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have checked for plagiarism and assure its authenticity.
- [x] I have read and followed the code of conduct for this repository. I understand that violation of this undertaking may have legal consequences.

- [x] I Agree
