### PR TITLE
fix(web): remove decorative emojis on landing page

### DIFF
--- a/web/src/components/home/ContactSection.tsx
+++ b/web/src/components/home/ContactSection.tsx
@@ -17,7 +17,10 @@ export default function ContactSection() {
 
         <div className="contact-dark-card">
           <div className="contact-dark-left">
-            <div className="contact-left-badge">✦ UltimateHealth</div>
+            <div className="contact-left-badge">
+              <i className="fas fa-heart-pulse" aria-hidden="true" />
+              UltimateHealth
+            </div>
             <h3 className="contact-dark-title">Let&apos;s Talk<br />Health Together</h3>
             <p className="contact-dark-subtitle">
               Questions about our platform? We&apos;re here to help. Reach out and we&apos;ll respond promptly.

--- a/web/src/components/home/FeaturesSection.tsx
+++ b/web/src/components/home/FeaturesSection.tsx
@@ -14,7 +14,7 @@ const features = [
 
 const upcoming = [
   {
-    emoji: '🤖',
+    icon: 'fa-robot',
     title: 'AI Personal Chat',
     sub: 'Characters Chat',
     desc: 'Chat with AI-powered health personas — a compassionate doctor, a mindful therapist, or a wellness coach — available anytime, completely free.',
@@ -22,7 +22,7 @@ const upcoming = [
     glow: 'rgba(102,126,234,0.15)',
   },
   {
-    emoji: '🏥',
+    icon: 'fa-hospital',
     title: 'Hospital Learning System',
     sub: 'Structured Health Education',
     desc: 'A modular learning platform bringing hospital-grade health education directly to patients, students, and caregivers — no fees, no barriers.',
@@ -30,7 +30,7 @@ const upcoming = [
     glow: 'rgba(34,197,94,0.12)',
   },
   {
-    emoji: '👨‍⚕️',
+    icon: 'fa-user-doctor',
     title: 'Connect with a Doctor',
     sub: 'Voluntary Suggestions Only',
     desc: 'Doctors who choose to volunteer their time can offer health suggestions to the community. No one is forced — only those who genuinely want to help.',
@@ -38,7 +38,7 @@ const upcoming = [
     glow: 'rgba(245,158,11,0.12)',
   },
   {
-    emoji: '🧬',
+    icon: 'fa-dna',
     title: 'AI Health Analytics',
     sub: 'Personalized Wellness Insights',
     desc: 'Track your health patterns with AI-driven insights — personalized reports, trend analysis, and proactive wellness recommendations, built open-source.',
@@ -128,9 +128,9 @@ export default function FeaturesSection() {
                     background: `linear-gradient(135deg, ${f.accent}33, ${f.accent}18)`,
                     border: `1px solid ${f.accent}44`,
                     display: 'flex', alignItems: 'center', justifyContent: 'center',
-                    fontSize: '1.5rem',
+                    color: f.accent, fontSize: '1.3rem',
                   }}>
-                    {f.emoji}
+                    <i className={`fas ${f.icon}`} aria-hidden="true" />
                   </div>
                   <span style={{
                     fontSize: '0.65rem', fontWeight: 800, letterSpacing: '0.1em',

--- a/web/src/components/home/TestFlightCta.tsx
+++ b/web/src/components/home/TestFlightCta.tsx
@@ -80,13 +80,15 @@ export default function TestFlightCta() {
       {appleModal && (
         <div className="modal-overlay active" onClick={closeAppleModal} role="dialog" aria-modal="true" aria-labelledby="testflight-modal-title">
           <div className="modal-content" onClick={(e) => e.stopPropagation()}>
-            <div style={{ fontSize: "3.5rem", marginBottom: 16 }}>✈️</div>
+            <div style={{ width: 72, height: 72, margin: "0 auto 16px", borderRadius: "50%", background: "rgba(0,122,255,0.12)", border: "1px solid rgba(0,122,255,0.25)", display: "flex", alignItems: "center", justifyContent: "center", color: "#007aff", fontSize: "1.8rem" }}>
+              <i className="fas fa-plane" aria-hidden="true" />
+            </div>
             <h2 id="testflight-modal-title">Join the iOS TestFlight</h2>
             <p style={{ color: "var(--text-muted)", marginBottom: 24 }}>Help us build the ultimate experience</p>
             <div style={{ textAlign: "left", fontSize: "0.95rem", color: "var(--text-dark)", background: "#f8fafc", padding: 24, borderRadius: 16, marginBottom: 24, borderLeft: "4px solid #007aff" }}>
               <p style={{ marginBottom: 12 }}>We have decided to release via <strong>TestFlight</strong> first before moving to a full App Store launch.</p>
-              <p style={{ marginBottom: 12 }}><strong>🔹 Why TestFlight?</strong> Early feedback, real-world testing, and faster iteration.</p>
-              <p style={{ marginBottom: 12 }}><strong>🔹 What this means:</strong> The app will be available to invited testers only via TestFlight.</p>
+              <p style={{ marginBottom: 12 }}><strong><i className="fas fa-circle" style={{ fontSize: "0.45rem", color: "#007aff", marginRight: 6 }} aria-hidden="true" />Why TestFlight?</strong> Early feedback, real-world testing, and faster iteration.</p>
+              <p style={{ marginBottom: 12 }}><strong><i className="fas fa-circle" style={{ fontSize: "0.45rem", color: "#007aff", marginRight: 6 }} aria-hidden="true" />What this means:</strong> The app will be available to invited testers only via TestFlight.</p>
               <p><strong>Are you ready to test?</strong> Enter your email below to request an invitation.</p>
             </div>
             {!testerSuccess ? (
@@ -103,7 +105,7 @@ export default function TestFlightCta() {
               </div>
             ) : (
               <div style={{ padding: 24, color: "#059669", background: "#d1fae5", borderRadius: 12 }}>
-                <p style={{ margin: 0, fontWeight: 600 }}>✅ <strong>Request Sent!</strong> We&apos;ll notify you as soon as the test link is ready.</p>
+                <p style={{ margin: 0, fontWeight: 600 }}><i className="fas fa-check-circle" style={{ marginRight: 6 }} aria-hidden="true" /><strong>Request Sent!</strong> We&apos;ll notify you as soon as the test link is ready.</p>
               </div>
             )}
             <button type="button" className="close-modal-btn" onClick={closeAppleModal}>


### PR DESCRIPTION
Replaces emoji used as decorative icons on the landing page with the site's existing Font Awesome icon set for visual consistency.

- FeaturesSection: upcoming cards use fa-robot / fa-hospital / fa-user-doctor / fa-dna instead of emoji.
- ContactSection: badge icon uses fa-heart-pulse.
- TestFlightCta: modal header, bullet markers and success state use fa-plane / fa-circle / fa-check-circle (emoji removed).