### PR TITLE
fix: clear query cache on logout and include userId in user scoped queries #1917

### DIFF
--- a/frontend/src/__tests__/hooks/ai/useLoadAIChats.test.ts
+++ b/frontend/src/__tests__/hooks/ai/useLoadAIChats.test.ts
@@ -3,7 +3,12 @@ import {renderHook, waitFor} from '@testing-library/react-native';
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
 import React from 'react';
 import { useLoadAIConversations } from '@/src/hooks/ai/useLoadAIChats';
+import * as ReactRedux from '@/src/store/hooks';
 
+jest.mock('@/src/store/hooks', () => ({
+  useAppSelector: jest.fn(),
+  useAppDispatch: jest.fn(),
+}));
 
 jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
@@ -22,9 +27,10 @@ describe('useLoadAIConversations', () => {
   afterEach(() => jest.clearAllMocks());
 
   it('executes mutation successfully and calls API', async () => {
-    
-    
-    
+    (ReactRedux.useAppSelector as unknown as jest.Mock).mockImplementation((selector: any) => {
+      const mockState = { user: { isGuest: false, user_id: 'test-user-id' } };
+      return selector(mockState);
+    });
     mockedAxios.post.mockResolvedValueOnce({ data: { success: true, data: [] } });
 
     const {result} = renderHook(() => useLoadAIConversations(true), {

--- a/frontend/src/__tests__/hooks/auth/useGetTokenStatus.test.ts
+++ b/frontend/src/__tests__/hooks/auth/useGetTokenStatus.test.ts
@@ -25,7 +25,10 @@ describe('useCheckTokenStatus', () => {
   afterEach(() => jest.clearAllMocks());
 
   it('executes mutation successfully and calls API', async () => {
-    (ReactRedux.useAppSelector as unknown as jest.Mock).mockReturnValue(false);
+    (ReactRedux.useAppSelector as unknown as jest.Mock).mockImplementation((selector: any) => {
+      const mockState = { user: { isGuest: false, user_id: 'test-user-id' } };
+      return selector(mockState);
+    });
     
     
     mockedAxios.post.mockResolvedValueOnce({ data: { success: true, data: [] } });

--- a/frontend/src/__tests__/hooks/notification/useGetAllNotifications.test.ts
+++ b/frontend/src/__tests__/hooks/notification/useGetAllNotifications.test.ts
@@ -26,7 +26,10 @@ describe('useGetAllNotifications', () => {
   afterEach(() => jest.clearAllMocks());
 
   it('executes mutation successfully and calls API', async () => {
-    (ReactRedux.useAppSelector as unknown as jest.Mock).mockReturnValue(false);
+    (ReactRedux.useAppSelector as unknown as jest.Mock).mockImplementation((selector: any) => {
+      const mockState = { user: { isGuest: false, user_id: 'test-user-id' } };
+      return selector(mockState);
+    });
     
     
     mockedAxios.post.mockResolvedValueOnce({ data: { success: true, data: [] } });

--- a/frontend/src/__tests__/hooks/notification/useGetNotificationPreferences.test.ts
+++ b/frontend/src/__tests__/hooks/notification/useGetNotificationPreferences.test.ts
@@ -26,7 +26,10 @@ describe('useGetNotificationPreferences', () => {
   afterEach(() => jest.clearAllMocks());
 
   it('executes mutation successfully and calls API', async () => {
-    (ReactRedux.useAppSelector as unknown as jest.Mock).mockReturnValue(false);
+    (ReactRedux.useAppSelector as unknown as jest.Mock).mockImplementation((selector: any) => {
+      const mockState = { user: { isGuest: false, user_id: 'test-user-id' } };
+      return selector(mockState);
+    });
     
     
     mockedAxios.post.mockResolvedValueOnce({ data: { success: true, data: [] } });

--- a/frontend/src/__tests__/hooks/playlist/useGetPlaylists.test.ts
+++ b/frontend/src/__tests__/hooks/playlist/useGetPlaylists.test.ts
@@ -25,7 +25,10 @@ describe('useGetPlaylists', () => {
   afterEach(() => jest.clearAllMocks());
 
   it('fetches playlists successfully when not guest', async () => {
-    (ReactRedux.useAppSelector as unknown as jest.Mock).mockReturnValue(false);
+    (ReactRedux.useAppSelector as unknown as jest.Mock).mockImplementation((selector: any) => {
+      const mockState = { user: { isGuest: false, user_id: 'test-user-id' } };
+      return selector(mockState);
+    });
 
     mockedAxios.get.mockResolvedValueOnce({
       data: [{id: 1, title: 'My List'}],
@@ -40,7 +43,10 @@ describe('useGetPlaylists', () => {
   });
 
   it('does not fetch if user is a guest', async () => {
-    (ReactRedux.useAppSelector as unknown as jest.Mock).mockReturnValue(true);
+    (ReactRedux.useAppSelector as unknown as jest.Mock).mockImplementation((selector: any) => {
+      const mockState = { user: { isGuest: true, user_id: 'test-guest-id' } };
+      return selector(mockState);
+    });
 
     const {result} = renderHook(() => useGetPlaylists(), {
       wrapper: makeWrapper(),

--- a/frontend/src/__tests__/hooks/profile/useGetProfile.test.ts
+++ b/frontend/src/__tests__/hooks/profile/useGetProfile.test.ts
@@ -26,8 +26,10 @@ describe('useGetProfile', () => {
   afterEach(() => jest.clearAllMocks());
 
   it('executes mutation successfully and calls API', async () => {
-    (ReactRedux.useAppSelector as unknown as jest.Mock).mockReturnValue(false);
-    
+    (ReactRedux.useAppSelector as unknown as jest.Mock).mockImplementation((selector: any) => {
+      const mockState = { user: { isGuest: false, user_id: 'test-user-id' } };
+      return selector(mockState);
+    });
     
     mockedAxios.post.mockResolvedValueOnce({ data: { success: true, data: [] } });
 

--- a/frontend/src/__tests__/screens/auth/LogoutScreen.local.test.tsx
+++ b/frontend/src/__tests__/screens/auth/LogoutScreen.local.test.tsx
@@ -77,6 +77,7 @@ describe('LogoutScreen local logout behavior', () => {
   const expectLocalLogout = async () => {
     await waitFor(() => {
       expect(mockClearStorage).toHaveBeenCalledTimes(1);
+      expect(mockClearQueryCache).toHaveBeenCalledTimes(1);
       expect(mockDispatch).toHaveBeenCalledWith({
         type: 'user/resetUserState',
       });

--- a/frontend/src/__tests__/screens/wellness/WellnessDashboardScreen.test.tsx
+++ b/frontend/src/__tests__/screens/wellness/WellnessDashboardScreen.test.tsx
@@ -36,7 +36,7 @@ describe('WellnessDashboardScreen - State Rendering Tests', () => {
 
   const mockLog = {
     userId: 'u1',
-    date: '2026-08-07',
+    date: require('../../../lib/utils/wellnessUtils').getTodayDateString(),
     metrics: { steps: 8450, sleepHours: 7.5, waterMl: 1800, activeMinutes: 45 },
   };
 

--- a/frontend/src/hooks/ai/useLoadAIChats.ts
+++ b/frontend/src/hooks/ai/useLoadAIChats.ts
@@ -1,7 +1,8 @@
 import { CHAT_URL } from "@/src/lib/api/APIUtils";
 import { Message } from "@/src/schemas/type";
 import { useQuery, UseQueryResult } from "@tanstack/react-query";
-
+import { useAppSelector } from "@/src/store/hooks";
+import { RootState } from "@/src/store/ReduxStore";
 import axios from "axios";
 
 type AxiosError = any;
@@ -11,8 +12,9 @@ export const useLoadAIConversations = (isConnected: boolean, characterId?: strin
 Message[],
 AxiosError
 >=>{
+    const userId = useAppSelector((state: RootState) => state.user.user_id);
     return useQuery({
-    queryKey: ['load-user-conversations', characterId],
+    queryKey: ['load-user-conversations', userId, characterId],
     queryFn: async () => {
       const url = characterId ? `${CHAT_URL}?character=${characterId}` : `${CHAT_URL}`;
       const response = await axios.get(url);

--- a/frontend/src/hooks/auth/useGetTokenStatus.ts
+++ b/frontend/src/hooks/auth/useGetTokenStatus.ts
@@ -7,6 +7,7 @@ import { TokenStatus } from '@/src/schemas/type';
 import {useQuery} from '@tanstack/react-query';
 import axios from 'axios';
 import { useAppSelector } from '../../store/hooks';
+import { RootState } from '../../store/ReduxStore';
 
  const checkTokenStatusApi = async (
   token: string,
@@ -39,10 +40,11 @@ import { useAppSelector } from '../../store/hooks';
   }
 };
 export const useCheckTokenStatus = () => {
-  const isGuest = useAppSelector((state: any) => state.user.isGuest);
+  const isGuest = useAppSelector((state: RootState) => state.user.isGuest);
+  const userId = useAppSelector((state: RootState) => state.user.user_id);
 
   return useQuery<TokenStatus>({
-    queryKey: ['token-status'],
+    queryKey: ['token-status', userId],
     queryFn: async () => {
       const token = await secureRetrieveItem(SECURE_KEYS.USER_TOKEN as SecureKey);
       console.log('Checking token status. Token present:', !!token);

--- a/frontend/src/hooks/notification/useGetAllNotifications.ts
+++ b/frontend/src/hooks/notification/useGetAllNotifications.ts
@@ -3,6 +3,7 @@ import {Notification} from '../../schemas/type';
 import axios from 'axios';
 import {PROD_URL} from '../../lib/api/APIUtils';
 import {useAppSelector} from '../../store/hooks';
+import {RootState} from '../../store/ReduxStore';
 type AxiosError = any;
 
 type NotificationRes = {
@@ -13,10 +14,11 @@ export const useGetAllNotifications = (
   page: number,
   isConnected: boolean,
 ): UseQueryResult<NotificationRes, AxiosError> => {
-  const isGuest = useAppSelector((state: any) => state.user.isGuest);
+  const isGuest = useAppSelector((state: RootState) => state.user.isGuest);
+  const userId = useAppSelector((state: RootState) => state.user.user_id);
 
   return useQuery({
-    queryKey: ['get-all-notifications', page],
+    queryKey: ['get-all-notifications', userId, page],
     queryFn: async () => {
       const response = await axios.get(
         `${PROD_URL}/notifications?role=2&page=${page}`,

--- a/frontend/src/hooks/notification/useGetNotificationPreferences.ts
+++ b/frontend/src/hooks/notification/useGetNotificationPreferences.ts
@@ -3,6 +3,7 @@ import axios from 'axios';
 import {GET_NOTIFICATION_PREFERENCES} from '../../lib/api/APIUtils';
 import {NotificationPreferencesResponse} from '../../schemas/type';
 import {useAppSelector} from '../../store/hooks';
+import {RootState} from '../../store/ReduxStore';
 type AxiosError = any;
 
 const fetchNotificationPreferences = async (): Promise<NotificationPreferencesResponse> => {
@@ -13,10 +14,11 @@ const fetchNotificationPreferences = async (): Promise<NotificationPreferencesRe
 export const useGetNotificationPreferences = (
   isConnected: boolean,
 ): UseQueryResult<NotificationPreferencesResponse, AxiosError> => {
-  const isGuest = useAppSelector((state: any) => state.user.isGuest);
+  const isGuest = useAppSelector((state: RootState) => state.user.isGuest);
+  const userId = useAppSelector((state: RootState) => state.user.user_id);
 
   return useQuery({
-    queryKey: ['notification-preferences'],
+    queryKey: ['notification-preferences', userId],
     queryFn: fetchNotificationPreferences,
     enabled: isConnected && !isGuest,
   });

--- a/frontend/src/hooks/playlist/useGetPlaylists.ts
+++ b/frontend/src/hooks/playlist/useGetPlaylists.ts
@@ -3,13 +3,15 @@ import {PlayList} from '../../schemas/type';
 import {GET_PLAYLIST} from '../../lib/api/APIUtils';
 import axios from 'axios';
 import {useAppSelector} from '../../store/hooks';
+import {RootState} from '../../store/ReduxStore';
 type AxiosError = any;
 
 export const useGetPlaylists = (): UseQueryResult<PlayList[], AxiosError> => {
-  const isGuest = useAppSelector((state: any) => state.user.isGuest);
+  const isGuest = useAppSelector((state: RootState) => state.user.isGuest);
+  const userId = useAppSelector((state: RootState) => state.user.user_id);
 
   return useQuery({
-    queryKey: ['get-my-playlists'],
+    queryKey: ['get-my-playlists', userId],
     queryFn: async () => {
       const res = await axios.get(GET_PLAYLIST);
       return res.data as PlayList[];

--- a/frontend/src/hooks/profile/useGetProfile.ts
+++ b/frontend/src/hooks/profile/useGetProfile.ts
@@ -3,13 +3,15 @@ import {User} from '../../schemas/type';
 import axios from 'axios';
 import {GET_PROFILE_API} from '../../lib/api/APIUtils';
 import {useAppSelector} from '../../store/hooks';
+import {RootState} from '../../store/ReduxStore';
 type AxiosError = any;
 
 export const useGetProfile = (): UseQueryResult<User, AxiosError> => {
-  const isGuest = useAppSelector((state: any) => state.user.isGuest);
+  const isGuest = useAppSelector((state: RootState) => state.user.isGuest);
+  const userId = useAppSelector((state: RootState) => state.user.user_id);
 
   return useQuery({
-    queryKey: ['get-my-profile'],
+    queryKey: ['get-my-profile', userId],
     queryFn: async () => {
       const response = await axios.get(`${GET_PROFILE_API}`);
       // console.log('[useGetProfile] status:', response.status);

--- a/frontend/src/screens/auth/LogoutScreen.tsx
+++ b/frontend/src/screens/auth/LogoutScreen.tsx
@@ -18,6 +18,7 @@ import {LogoutScreenProp} from '@/src/schemas/type';
 import {useUserLogout} from '@/src/hooks/auth/useUserLogout';
 import {useTheme} from 'tamagui';
 import { useColorScheme } from 'react-native-gifted-chat/lib/hooks/useColorScheme';
+import {useQueryClient} from '@tanstack/react-query';
 type AxiosError = any;
 
 const DEFAULT_PROFILE_IMAGE =
@@ -29,16 +30,18 @@ const LogoutScreen = ({navigation, route}: LogoutScreenProp) => {
   const dispatch = useAppDispatch();
   const theme = useTheme();
   const {mutate: logout} = useUserLogout();  
+  const queryClient = useQueryClient();
   const isDarkMode = useColorScheme() === 'dark';
 
   const completeLocalLogout = useCallback(async () => {
     await clearStorage();
     dispatch(resetUserState());
+    queryClient.clear();
     navigation.reset({
       index: 0,
       routes: [{name: 'LoginScreen'}],
     });
-  }, [dispatch, navigation]);
+  }, [dispatch, navigation, queryClient]);
 
   const handleLogout = () => {
     logout(


### PR DESCRIPTION
fix(auth): clear query cache on logout and include userId in user-scoped queries #1917

#### PR Description
This PR addresses a critical account-isolation and privacy issue where React Query cached data was not being cleared upon user logout. Previously, logging out and logging into a different account without restarting the app exposed the previous user's cached data.

**Changes made:**
1. Modified `LogoutScreen.tsx` to invoke `queryClient.clear()` during the local logout process, successfully wiping the React Query cache alongside Redux state and local storage.
2. Updated user-owned query keys to include the `user_id` (fetched from Redux state) where appropriate to ensure strict cache separation between accounts. The updated query keys include:
   - `['get-my-profile', userId]`
   - `['get-my-playlists', userId]`
   - `['notification-preferences', userId]`
   - `['get-all-notifications', userId, page]`
   - `['load-user-conversations', userId, characterId]`
   - `['token-status', userId]`

#### Type of Change
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update

#### Select your work-area
- [x] Frontend
- [ ] Backend
- [ ] Documentation
- [ ] Others

#### Related Issue
https://github.com/pisum-sativum/UltimateHealth/issues/1917

#### Fixes (mention the issue number which this fixes)
Closes #1917

#### Checklist
- [x] I have updated my branch and synced it with the project's 'develop' branch before making this PR.
- [x] I have optimized the file changes.

- [x] I have made a PR to the project's develop branch.

#### Undertaking
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have checked for plagiarism and assure its authenticity.
- [x] I have read and followed the code of conduct for this repository. I understand that violation of this undertaking may have legal consequences.

- [x] I Agree
