### PR TITLE
fix: dedupe newsletter form logic, use shared component in footer (#1…

### DIFF
--- a/frontend/src/components/home/NewsletterForm.tsx
+++ b/frontend/src/components/home/NewsletterForm.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useState } from "react";
+
+import { API_BASE_URL, isValidEmail } from "@/lib/site-config";
+
+/**
+ * Footer newsletter signup — the only interactive part of the footer, so it is
+ * split out and the rest of the footer renders on the server.
+ */
+export default function NewsletterForm() {
+  const [newsletterEmail, setNewsletterEmail] = useState("");
+  const [newsletterStatus, setNewsletterStatus] = useState<
+    "idle" | "sending" | "success" | "error" | "invalid" | "empty" | "duplicate"
+  >("idle");
+
+  const handleNewsletterSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmedNewsletterEmail = newsletterEmail.trim();
+
+    if (!trimmedNewsletterEmail) {
+      setNewsletterStatus("empty");
+      return;
+    }
+    if (!isValidEmail(trimmedNewsletterEmail)) {
+      setNewsletterStatus("invalid");
+      return;
+    }
+    setNewsletterStatus("sending");
+    try {
+      const res = await fetch(`${API_BASE_URL}/api/newsletter/subscribe`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: trimmedNewsletterEmail }),
+      });
+
+      if (res.status === 409) {
+        setNewsletterStatus("duplicate");
+        return;
+      }
+      if (!res.ok) throw new Error("Failed");
+
+      setNewsletterStatus("success");
+      setNewsletterEmail("");
+    } catch {
+      setNewsletterStatus("error");
+    }
+  };
+
+  return (
+    <form className="footer-subscribe-form" onSubmit={handleNewsletterSubmit} noValidate>
+      {newsletterStatus === "success" ? (
+        <div className="newsletter-success">
+          <i className="fas fa-check-circle"></i> You have successfully subscribed!
+        </div>
+      ) : (
+        <>
+          <div className="footer-subscribe-row">
+            <input
+              type="email"
+              placeholder="Enter your email"
+              className="footer-subscribe-input"
+              maxLength={120}
+              value={newsletterEmail}
+              required
+              aria-label="Newsletter email address"
+              aria-describedby="newsletter-feedback"
+              onChange={(e) => {
+                setNewsletterEmail(e.target.value);
+                if (newsletterStatus !== "idle" && newsletterStatus !== "sending") {
+                  setNewsletterStatus("idle");
+                }
+              }}
+            />
+            <button
+              type="submit"
+              className="footer-subscribe-btn"
+              aria-label="Subscribe to UltimateHealth newsletter"
+              disabled={newsletterStatus === "sending"}
+            >
+              {newsletterStatus === "sending" ? "Subscribing..." : "Subscribe"}
+            </button>
+          </div>
+
+          <div id="newsletter-feedback" aria-live="polite">
+            {newsletterStatus === "empty" && (
+              <p className="newsletter-error">
+                <i className="fas fa-exclamation-circle"></i> Please enter a valid email address.
+              </p>
+            )}
+            {newsletterStatus === "invalid" && (
+              <p className="newsletter-error">
+                <i className="fas fa-exclamation-circle"></i> Invalid email format.
+              </p>
+            )}
+            {newsletterStatus === "duplicate" && (
+              <p className="newsletter-error">
+                <i className="fas fa-info-circle"></i> This email is already subscribed.
+              </p>
+            )}
+            {newsletterStatus === "error" && (
+              <p className="newsletter-error">
+                <i className="fas fa-exclamation-circle"></i> Could not subscribe. Please try again.
+              </p>
+            )}
+          </div>
+
+          <small className="footer-subscribe-note">
+            We respect your privacy. Unsubscribe at any time.
+          </small>
+        </>
+      )}
+    </form>
+  );
+}

--- a/frontend/src/components/ui/footer.tsx
+++ b/frontend/src/components/ui/footer.tsx
@@ -1,0 +1,131 @@
+'use client'
+
+import Link from 'next/link'
+
+import { PageWrapper } from '../layout'
+import NewsletterForm from '../home/NewsletterForm'
+
+import { withBasePath } from '@/lib/basePath'
+
+export const Footer = () => {
+  // Owner-configurable frontend URLs (set in deployment env when needed)
+  const HELP_CENTER_URL =
+    process.env.NEXT_PUBLIC_HELP_CENTER_URL || 'https://uhsocial.in/docs'
+  const FEEDBACK_URL =
+    process.env.NEXT_PUBLIC_FEEDBACK_URL ||
+    'https://github.com/SB2318/UltimateHealth/issues'
+  const TELEGRAM_URL = process.env.NEXT_PUBLIC_TELEGRAM_URL || ''
+  const INSTAGRAM_URL = process.env.NEXT_PUBLIC_INSTAGRAM_URL || ''
+  const PRIVACY_POLICY_URL = process.env.NEXT_PUBLIC_PRIVACY_POLICY_URL || '#'
+  const TERMS_OF_USE_URL = process.env.NEXT_PUBLIC_TERMS_OF_USE_URL || '#'
+
+  return (
+    <footer >
+      <PageWrapper className="footer-grid">
+        {/* Brand column */}
+        <div className="footer-brand">
+          <h2>UltimateHealth</h2>
+          <p className="footer-note">
+            Open-source health and wellness for everyone.
+          </p>
+
+          {/* Newsletter — shared component, wired to API */}
+          <NewsletterForm />
+          {/* Social icons */}
+          <div style={{ marginTop: 20 }}>
+            <span className="footer-follow-label">Follow Us</span>
+            <div className="footer-social-links">
+              <a
+                href="https://github.com/SB2318"
+                className="footer-social-icon"
+                target="_blank"
+                rel="noopener noreferrer"
+                title="GitHub"
+                aria-label="Open UltimateHealth GitHub profile"
+              >
+                <i className="fab fa-github"></i>
+              </a>
+              <a
+                href="https://www.linkedin.com/in/ultimate-health-9290873a8/"
+                className="footer-social-icon"
+                target="_blank"
+                rel="noopener noreferrer"
+                title="LinkedIn"
+                aria-label="Open UltimateHealth LinkedIn profile"
+              >
+                <i className="fab fa-linkedin-in"></i>
+              </a>
+              {TELEGRAM_URL && (
+                <a
+                  href={TELEGRAM_URL}
+                  className="footer-social-icon"
+                  target="_blank"
+                  rel="noreferrer"
+                  title="Telegram"
+                  aria-label="Open UltimateHealth Telegram link"
+                >
+                  <i className="fab fa-telegram-plane"></i>
+                </a>
+              )}
+              {INSTAGRAM_URL && (
+                <a
+                  href={INSTAGRAM_URL}
+                  className="footer-social-icon"
+                  target="_blank"
+                  rel="noreferrer"
+                  title="Instagram"
+                  aria-label="Open UltimateHealth Instagram link"
+                >
+                  <i className="fab fa-instagram"></i>
+                </a>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Quick Links */}
+        <div className="footer-links-col">
+          <h3>Quick Links</h3>
+          <Link href={withBasePath('/')}>Home</Link>
+          <a href={withBasePath('#features')}>Features</a>
+          <a href={withBasePath('#programs')}>Programs</a>
+          <a href={withBasePath('#screenshots')}>Screenshots</a>
+          <a href={withBasePath('#contact')}>Contact</a>
+          <Link href="/contribute">Join Us &amp; Contribute</Link>
+        </div>
+
+        {/* Support */}
+        <div className="footer-links-col">
+          <h3>Support</h3>
+          <a href={HELP_CENTER_URL} target="_blank" rel="noopener noreferrer">
+            Help Center
+          </a>
+          <a href="mailto:ultimate.health25@gmail.com">Contact Us</a>
+          <a href={FEEDBACK_URL} target="_blank" rel="noopener noreferrer">
+            Feedback
+          </a>
+          <a
+            href="https://uhsocial.in/docs"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            API Docs
+          </a>
+        </div>
+      </PageWrapper>
+
+      {/* Bottom bar */}
+      <div className="footer-bottom">
+        <div className="footer-bottom-inner">
+          <p>
+            © 2026 UltimateHealth. Built with passion for a healthier community.
+          </p>
+          <div className="footer-bottom-links">
+            <a href={PRIVACY_POLICY_URL}>Privacy Policy</a>
+            <a href={TERMS_OF_USE_URL}>Terms of Use</a>
+          </div>
+        </div>
+      </div>
+    </footer>
+  )
+}


### PR DESCRIPTION
#### PR Description
The footer newsletter subscribe form (`ui/footer.tsx`) had a full duplicate
copy of the state/handler logic that already existed in
`home/NewsletterForm.tsx`. This duplication meant that fixes to one copy
(loading state, inline validation errors, success/error messaging, duplicate
detection) could drift out of sync with the other, which is consistent with
the "no feedback after Subscribe" symptom reported in #1978.

This PR removes the duplicated ~70 lines from `ui/footer.tsx` and has it
render the shared `<NewsletterForm />` component instead, so there is a
single source of truth for subscribe behavior across both footer usages.

No behavior change for end users — the form still validates, shows a
loading state, and displays success/error/duplicate messages exactly as
before, just from one shared implementation instead of two.

#### Type of Change
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update

#### Select your work-area
- [x] Frontend
- [ ] Backend
- [ ] Documentation
- [ ] Others

#### Related Issue
https://github.com/SB2318/UltimateHealth/issues/1978

#### Add your Work Example
📷 *(attach a screenshot/GIF of the footer subscribe form — success, error, and loading states — before submitting)*

#### Fixes (mention the issue number which this fixes)
Fixes #1978

#### Checklist
- [x] I have updated my branch and synced it with the project's 'web' branch before making this PR.
- [x] I have optimized the file changes.
- [ ] I have added a snapshot of my work example.
- [x] I have made a PR to the project's web branch.

#### Undertaking
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have checked for plagiarism and assure its authenticity.
- [x] I have read and followed the code of conduct for this repository. I understand that violation of this undertaking may have legal consequences.
- [x] I Agree