### PR TITLE
fix: redact JWT access/refresh token from login console logs (#2318)

### DIFF
--- a/frontend/src/hooks/auth/useUserLogin.ts
+++ b/frontend/src/hooks/auth/useUserLogin.ts
@@ -33,11 +33,12 @@ const loginFunc = async ({email, password, fcmToken}: LoginReq): Promise<LoginRe
   });
 
   if (__DEV__) {
-    // Log the raw response shape so we can confirm the token field name
+    // Log only safe response metadata (keys / presence), never credential values,
+    // so auth tokens cannot leak into Metro logs, device logs, or Sentry.
     console.log('[Login] Raw API response keys:', Object.keys(res.data || {}));
-    console.log('[Login] res.data.token:', res.data?.token);
-    console.log('[Login] res.data.refreshToken:', res.data?.refreshToken);
-    console.log('[Login] res.data.user?.refreshToken:', res.data?.user?.refreshToken);
+    console.log('[Login] res.data.token:', res.data?.token ? 'present' : 'absent');
+    console.log('[Login] res.data.refreshToken:', res.data?.refreshToken ? 'present' : 'absent');
+    console.log('[Login] res.data.user?.refreshToken:', res.data?.user?.refreshToken ? 'present' : 'absent');
     console.log('[Login] res.data.data keys:', res.data?.data ? Object.keys(res.data.data) : null);
   }
 


### PR DESCRIPTION
#### PR Description
Stops the JWT access/refresh tokens from being printed to the console on login.

`useUserLogin.ts` logged the **raw** `res.data.token`, `res.data.refreshToken`, and `res.data.user?.refreshToken` values under `__DEV__`. Even in development builds these live credentials leak to Metro logs, `adb logcat`, iOS device logs, Sentry breadcrumbs, and any monitoring tooling that captures console output — anyone with access to dev logs could steal a valid auth session.

**Changes:**
- `frontend/src/hooks/auth/useUserLogin.ts`: replaced raw token logging with safe metadata (response keys + `'present'/'absent'` markers). The debug value of confirming the token field name is preserved, but the credential itself is never logged.

#### Type of Change
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update

#### Select your work-area
- [x] Frontend
- [ ] Backend
- [ ] Documentation
- [ ] Others

#### Related Issue
https://github.com/SB2318/UltimateHealth/issues/2318

#### Fixes (mention the issue number which this fixes)
#2318

#### Checklist
- [x] I have updated my branch and synced it with the project's 'main' branch before making this PR.
- [x] I have optimized the file changes.
- [ ] I have added a snapshot of my work example.
- [x] I have made a PR to the project's main branch.

#### Undertaking
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have checked for plagiarism and assure its authenticity.
- [x] I have read and followed the code of conduct for this repository. I understand that violation of this undertaking may have legal consequences.

- [x] I Agree
