### PR TITLE
test: make wellness dashboard test date-independent

### DIFF
--- a/frontend/src/__tests__/screens/wellness/WellnessDashboardScreen.test.tsx
+++ b/frontend/src/__tests__/screens/wellness/WellnessDashboardScreen.test.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 import WellnessDashboardScreen from '../../../screens/wellness/WellnessDashboardScreen';
+import { getTodayDateString } from '../../../lib/utils/wellnessUtils';
 
 jest.mock('react-native-snackbar', () => ({
   show: jest.fn(),
@@ -36,7 +37,7 @@ describe('WellnessDashboardScreen - State Rendering Tests', () => {
 
   const mockLog = {
     userId: 'u1',
-    date: '2026-08-07',
+    date: getTodayDateString(),
     metrics: { steps: 8450, sleepHours: 7.5, waterMl: 1800, activeMinutes: 45 },
   };
 


### PR DESCRIPTION
#### PR Description
Fixes the date-dependent `WellnessDashboardScreen` unit test so the frontend CI no longer fails.

The test hardcoded the mock wellness log's `date` to `'2026-08-07'`, but the dashboard renders metrics via `getTodayLog()` which matches against the current local date. From `2026-08-08` onward the log never matched "today", so `steps` rendered as `0` and `getByText('8,450')` failed. This broke the `Unit Tests` job in `frontend-ci.yml` on `main` (1 suite failing: 137 passed / 1 failed).

**Changes:**
- `frontend/src/__tests__/screens/wellness/WellnessDashboardScreen.test.tsx`: use `getTodayDateString()` from `wellnessUtils` for the mock log date so the test is deterministic on any run date.

#### Type of Change
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update

#### Select your work-area
- [x] Frontend
- [ ] Backend
- [ ] Documentation
- [ ] Others

#### Related Issue
None — restores the pre-existing `frontend-ci` `Unit Tests` job on `main` (was already failing before this PR's fix, see run https://github.com/SB2318/UltimateHealth/actions/runs/31295222533).

#### Fixes (mention the issue number which this fixes)
#n/a

#### Checklist
- [x] I have updated my branch and synced it with the project's 'main' branch before making this PR.
- [x] I have optimized the file changes.
- [ ] I have added a snapshot of my work example.
- [x] I have made a PR to the project's main branch.

#### Undertaking
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have checked for plagiarism and assure its authenticity.
- [x] I have read and followed the code of conduct for this repository. I understand that violation of this undertaking may have legal consequences.

- [x] I Agree
