### PR TITLE
fix(podcast): cancel resume prompt once user interacts with playback

### DIFF
--- a/frontend/src/__tests__/screens/podcast/PodcastDetail.test.tsx
+++ b/frontend/src/__tests__/screens/podcast/PodcastDetail.test.tsx
@@ -1,5 +1,6 @@
  
 import React from 'react';
+import {Alert} from 'react-native';
 import {render, fireEvent, act} from '@testing-library/react-native';
 import PodcastDetail from '../../../screens/podcast/PodcastDetail';
 
@@ -143,6 +144,11 @@ jest.mock('../../../components/common/LoadingSpinner', () => {
   MockSpinner.displayName = 'LoadingSpinner';
   return MockSpinner;
 });
+
+jest.mock('../../../lib/platform/PlaybackManager', () => ({
+  getPlaybackPosition: jest.fn(),
+  savePlaybackPosition: jest.fn(),
+}));
 
 const mockPodcast = {
   _id: 'podcast-1',
@@ -511,6 +517,65 @@ describe('PodcastDetail', () => {
     });
     expect(getByText('1x')).toBeTruthy();
     expect(mockPlayer.setRateAsync).toHaveBeenCalledWith(1.0, true, 'high');
+  });
+
+  describe('resume prompt', () => {
+    const mockGetPlaybackPosition =
+      require('../../../lib/platform/PlaybackManager').getPlaybackPosition as jest.Mock;
+
+    beforeEach(() => {
+      jest.useFakeTimers();
+      jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+      (Alert.alert as jest.Mock).mockRestore();
+    });
+
+    it('shows the resume prompt on normal screen entry when saved progress exists', async () => {
+      mockGetPlaybackPosition.mockResolvedValue({position: 120, duration: 245});
+
+      renderScreen();
+
+      await act(async () => {
+        jest.advanceTimersByTime(500);
+      });
+
+      expect(Alert.alert).toHaveBeenCalledWith(
+        'Resume Podcast',
+        expect.stringContaining('Do you want to resume from'),
+        expect.anything(),
+      );
+    });
+
+    it('does not show the resume prompt when the user starts playback before the delayed check', async () => {
+      mockGetPlaybackPosition.mockResolvedValue({position: 120, duration: 245});
+
+      const {getByLabelText} = renderScreen();
+
+      fireEvent.press(getByLabelText('podcast-play-pause-button'));
+
+      await act(async () => {
+        jest.advanceTimersByTime(500);
+      });
+
+      expect(Alert.alert).not.toHaveBeenCalled();
+    });
+
+    it('does not show the resume prompt when the user seeks before the delayed check', async () => {
+      mockGetPlaybackPosition.mockResolvedValue({position: 120, duration: 245});
+
+      const {getByLabelText} = renderScreen();
+
+      fireEvent.press(getByLabelText('podcast-back-button'));
+
+      await act(async () => {
+        jest.advanceTimersByTime(500);
+      });
+
+      expect(Alert.alert).not.toHaveBeenCalled();
+    });
   });
 });
 

--- a/frontend/src/screens/podcast/PodcastDetail.tsx
+++ b/frontend/src/screens/podcast/PodcastDetail.tsx
@@ -90,6 +90,8 @@ const PodcastDetail = ({navigation, route}: PodcastDetailScreenProp) => {
   const [isWaitingForNetwork, setIsWaitingForNetwork] = useState(false);
   const [resumePosition, setResumePosition] = useState<number | null>(null);
   const resumeAttemptedRef = useRef(false);
+  const resumePromptSkippedRef = useRef(false);
+  const resumePromptTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const [isLike, setLike] = useState(false);
   const [likeCount, setLikeCount] = useState(0);
@@ -269,7 +271,12 @@ useEffect(() => {
   const checkResume = async () => {
     const saved = await getPlaybackPosition(trackId);
 
-    if (!isCancelled && saved && saved.position > 5) {
+    if (
+      !isCancelled &&
+      !resumePromptSkippedRef.current &&
+      saved &&
+      saved.position > 5
+    ) {
       Alert.alert(
         'Resume Podcast',
         `Do you want to resume from ${formatSecTime(saved.position)}?`,
@@ -296,13 +303,16 @@ useEffect(() => {
     }
   };
 
-  const timeout = setTimeout(() => {
+  resumePromptTimerRef.current = setTimeout(() => {
     void checkResume();
   }, 500);
 
   return () => {
     isCancelled = true;
-    clearTimeout(timeout);
+    if (resumePromptTimerRef.current) {
+      clearTimeout(resumePromptTimerRef.current);
+      resumePromptTimerRef.current = null;
+    }
   };
 }, [player, trackId]);
 
@@ -314,7 +324,17 @@ useEffect(() => {
     }
   }, [podcast, user_id])
 
+  const cancelResumePrompt = () => {
+    // Once the user interacts with playback, never interrupt with the resume prompt.
+    resumePromptSkippedRef.current = true;
+    if (resumePromptTimerRef.current) {
+      clearTimeout(resumePromptTimerRef.current);
+      resumePromptTimerRef.current = null;
+    }
+  };
+
   const handleSpeedChange = React.useCallback(async () => {
+    cancelResumePrompt();
     if (!player) return;
 
     const currentIndex = PLAYBACK_SPEEDS.indexOf(speed);
@@ -336,6 +356,7 @@ useEffect(() => {
   const SKIP_TIME = 5; // seconds
 
   const handleForward = async () => {
+    cancelResumePrompt();
     if (!player) return;
 
     let next = position + SKIP_TIME;
@@ -349,6 +370,7 @@ useEffect(() => {
   };
 
   const handleBackward = async () => {
+    cancelResumePrompt();
     if (!player) return;
 
     let next = position - SKIP_TIME;
@@ -402,6 +424,7 @@ useEffect(() => {
   };
 
   const handlePlay = async () => {
+    cancelResumePrompt();
     if (!player || !isConnected) {
       return;
     }
@@ -427,6 +450,7 @@ useEffect(() => {
   };
 
  const handlePause = async () => {
+  cancelResumePrompt();
   if (!player) return;
 
   try {
@@ -575,6 +599,7 @@ useEffect(() => {
         maximumTrackTintColor="#ccc"
         thumbTintColor={PRIMARY_COLOR}
         onSlidingComplete={async v => {
+          cancelResumePrompt();
           if (player) {
             await player.seekTo(v);
             setPosition(v);


### PR DESCRIPTION
## Problem

\PodcastDetail\ schedules the resume-position prompt 500ms after mount. If the user starts playback, pauses, or seeks before that timeout runs, the delayed resume alert can still appear and interrupt the action just taken.

## Changes

- Track user playback interaction with a ref (\esumePromptSkippedRef\).
- Clear the pending prompt timer via \cancelResumePrompt()\ in all playback handlers: play, pause, forward, backward, speed change, and slider seek.
- Skip showing the alert once the user has interacted, while still checking the saved position after the pending \getPlaybackPosition\ await.

## Acceptance criteria

- Resume prompt appears only when the user has not already chosen a playback action.
- The timeout is cleared/ignored once playback controls are used.
- Saved-position resume behavior still works on normal screen entry (covered by test).

## Tests

Added tests to \PodcastDetail.test.tsx\:
- Prompt shows on normal screen entry when saved progress exists.
- Prompt is skipped when the user presses play before the delayed check.
- Prompt is skipped when the user seeks before the delayed check.

All 14 PodcastDetail tests pass.

Closes #2003