### PR TITLE
fix(article): sync like/save/repost UI when article props update

### DIFF
--- a/frontend/src/__tests__/components/article/ArticleCard.test.tsx
+++ b/frontend/src/__tests__/components/article/ArticleCard.test.tsx
@@ -1,0 +1,289 @@
+import React from 'react';
+import {render} from '@testing-library/react-native';
+import ArticleCard from '../../../components/article/ArticleCard';
+
+const mockNavigate = jest.fn();
+
+jest.mock('@expo/vector-icons/AntDesign', () => {
+  const React = require('react');
+  const {Text} = require('react-native');
+  const MockIcon = ({name, color}: any) =>
+    React.createElement(Text, null, `${name}:${color ?? 'none'}`);
+  MockIcon.displayName = 'AntDesign';
+  return MockIcon;
+});
+
+jest.mock('@expo/vector-icons/Ionicons', () => {
+  const React = require('react');
+  const {Text} = require('react-native');
+  const MockIcon = ({name, color}: any) =>
+    React.createElement(Text, null, `${name}:${color ?? 'none'}`);
+  MockIcon.displayName = 'Ionicons';
+  return MockIcon;
+});
+
+jest.mock('@expo/vector-icons/Entypo', () => {
+  const React = require('react');
+  const {Text} = require('react-native');
+  const MockIcon = ({name, color}: any) =>
+    React.createElement(Text, null, `${name}:${color ?? 'none'}`);
+  MockIcon.displayName = 'Entypo';
+  return MockIcon;
+});
+
+jest.mock('@expo/vector-icons', () => {
+  const React = require('react');
+  const {Text} = require('react-native');
+  const MockFontAwesome = ({name, color}: any) =>
+    React.createElement(Text, null, `${name}:${color ?? 'none'}`);
+  const MockFontAwesome6 = ({name, color}: any) =>
+    React.createElement(Text, null, `${name}:${color ?? 'none'}`);
+  MockFontAwesome.displayName = 'FontAwesome';
+  MockFontAwesome6.displayName = 'FontAwesome6';
+  return {
+    FontAwesome: MockFontAwesome,
+    FontAwesome6: MockFontAwesome6,
+  };
+});
+
+jest.mock('react-native-snackbar', () => ({
+  show: jest.fn(),
+  LENGTH_SHORT: 0,
+  LENGTH_LONG: 1,
+}));
+
+jest.mock('react-native-share', () => ({
+  default: jest.fn(),
+}));
+
+jest.mock('react-native-html-to-pdf', () => ({
+  generatePDF: jest.fn(),
+}));
+
+jest.mock('../../../store/hooks', () => ({
+  useAppSelector: jest.fn(),
+  useAppDispatch: jest.fn(() => jest.fn()),
+}));
+
+jest.mock('../../../contexts/SocketContext', () => ({
+  useSocket: jest.fn(() => null),
+}));
+
+jest.mock('../../../hooks/profile/useGetProfile', () => ({
+  useGetProfile: () => ({data: null}),
+}));
+
+jest.mock('../../../hooks/article/useLikeArticle', () => ({
+  useLikeArticle: jest.fn(() => ({mutate: jest.fn(), isPending: false})),
+}));
+
+jest.mock('../../../hooks/article/useSaveArticle', () => ({
+  useSaveArticle: jest.fn(() => ({mutate: jest.fn(), isPending: false})),
+}));
+
+jest.mock('../../../hooks/article/useArticleRepost', () => ({
+  useRepostArticle: jest.fn(() => ({mutate: jest.fn(), isPending: false})),
+}));
+
+jest.mock('../../../hooks/article/useLazyGetArticleContent', () => ({
+  useLazyGetArticleContent: jest.fn(() => ({mutate: jest.fn(), isPending: false})),
+}));
+
+jest.mock('../../../hooks/common/useDoubleTap', () => ({
+  useDoubleTap: (onSingleTap: any) => onSingleTap,
+}));
+
+jest.mock('../../../lib/utils/Utils', () => ({
+  formatCount: (value: number) => String(value),
+  requestStoragePermissions: jest.fn(),
+  StatusEnum: {PUBLISHED: 'PUBLISHED'},
+}));
+
+jest.mock('../../../lib/utils/shareUtils', () => ({
+  generateArticleShareUrl: jest.fn(),
+  copyArticleShareLink: jest.fn(),
+}));
+
+jest.mock('../../../lib/utils/dateUtils', () => ({
+  formatDateShort: jest.fn(() => 'Jan 1'),
+}));
+
+jest.mock('../../../lib/utils/readTime', () => ({
+  getReadTime: jest.fn(() => '5 min read'),
+  calculateReadTime: jest.fn(() => 5),
+}));
+
+jest.mock('../../../lib/ui/Metric', () => ({
+  fp: (value: number) => value,
+}));
+
+jest.mock('../../../lib/ui/Theme', () => ({
+  PRIMARY_COLOR: '#00BFFF',
+  ON_PRIMARY_COLOR: '#F0F8FF',
+}));
+
+jest.mock('../../../lib/api/APIUtils', () => ({
+  GET_IMAGE: 'https://example.com',
+}));
+
+jest.mock('../../../components/article/ArticleFloatingMenu', () => {
+  const React = require('react');
+  const {View} = require('react-native');
+  const MockMenu = () => React.createElement(View, {testID: 'article-floating-menu'});
+  MockMenu.displayName = 'ArticleFloatingMenu';
+  return MockMenu;
+});
+
+jest.mock('../../../components/article/EditRequestModal', () => {
+  const React = require('react');
+  const {View} = require('react-native');
+  const MockModal = () => React.createElement(View, {testID: 'edit-request-modal'});
+  MockModal.displayName = 'EditRequestModal';
+  return MockModal;
+});
+
+jest.mock('../../../assets/images/article_default.jpg', () => 1, {
+  virtual: true,
+});
+
+const baseItem = {
+  _id: 'article-1',
+  title: 'Test Article',
+  authorName: 'Author Name',
+  description: 'A description',
+  authorId: 'author-1',
+  content: '',
+  summary: '',
+  tags: [],
+  lastUpdated: '2026-01-01T00:00:00.000Z',
+  imageUtils: [],
+  viewCount: 10,
+  viewUsers: [],
+  repostUsers: [],
+  likeCount: 0,
+  likedUsers: [],
+  trustUsers: [],
+  savedUsers: [],
+  mentionedUsers: [],
+  language: 'en',
+  assigned_date: null,
+  discardReason: '',
+  status: 'PUBLISHED',
+  reviewer_id: null,
+  contributors: [],
+  pb_recordId: 'pb-1',
+};
+
+const mockuseAppSelector = require('../../../store/hooks').useAppSelector as jest.Mock;
+
+const mockState = {
+  user: {user_id: 'user-1', user_handle: 'user-1', isGuest: false},
+  network: {isConnected: true},
+};
+
+const renderCard = (item: any) =>
+  render(
+    <ArticleCard
+      item={item}
+      navigation={{navigate: mockNavigate} as any}
+      success={() => {}}
+      isSelected={false}
+      setSelectedCardId={jest.fn()}
+      handleRepostAction={jest.fn()}
+      handleReportAction={jest.fn()}
+      handleEditRequestAction={jest.fn()}
+      source="home"
+    />,
+  );
+
+const renderCardWithProps = (item: any) => ({
+  item,
+  navigation: {navigate: mockNavigate} as any,
+  success: () => {},
+  isSelected: false,
+  setSelectedCardId: jest.fn(),
+  handleRepostAction: jest.fn(),
+  handleReportAction: jest.fn(),
+  handleEditRequestAction: jest.fn(),
+  source: 'home',
+});
+
+describe('ArticleCard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockuseAppSelector.mockImplementation((selector: any) => selector(mockState));
+  });
+
+  it('renders the article title', () => {
+    const {getByText} = renderCard(baseItem);
+
+    expect(getByText('Test Article')).toBeTruthy();
+  });
+
+  it('syncs like, save, and repost state when the item prop updates', () => {
+    const {getAllByText, queryAllByText, rerender} = renderCard(baseItem);
+
+    expect(getAllByText(/^heart-o:/).length).toBeGreaterThan(0);
+    expect(queryAllByText(/^heart:#00BFFF/).length).toBe(0);
+    expect(queryAllByText(/^bookmark:#00BFFF/).length).toBe(0);
+
+    const updated = {
+      ...baseItem,
+      likedUsers: [{_id: 'user-1', id: 1, name: 'User One'}],
+      savedUsers: ['user-1'],
+      repostUsers: ['user-1'],
+    };
+
+    rerender(<ArticleCard {...renderCardWithProps(updated)} />);
+
+    expect(getAllByText(/^heart:#00BFFF/).length).toBeGreaterThan(0);
+    expect(queryAllByText(/^heart-o:/).length).toBe(0);
+    expect(getAllByText(/^bookmark:#00BFFF/).length).toBeGreaterThan(0);
+    expect(getAllByText(/^arrows-rotate:#00BFFF/).length).toBeGreaterThan(0);
+  });
+
+  it('updates the like count when the item prop changes', () => {
+    const {getAllByText, getByText, rerender} = renderCard(baseItem);
+
+    expect(getAllByText('0').length).toBe(2);
+
+    const updated = {
+      ...baseItem,
+      likedUsers: [
+        {_id: 'user-1', id: 1, name: 'User One'},
+        {_id: 'user-2', id: 2, name: 'User Two'},
+      ],
+    };
+
+    rerender(<ArticleCard {...renderCardWithProps(updated)} />);
+
+    expect(getByText('2')).toBeTruthy();
+    expect(getAllByText('0').length).toBe(1);
+  });
+
+  it('resets engagement state when the item is replaced with a different article', () => {
+    const likedItem = {
+      ...baseItem,
+      likedUsers: [{_id: 'user-1', id: 1, name: 'User One'}],
+      savedUsers: ['user-1'],
+    };
+
+    const {getAllByText, queryAllByText, rerender} = renderCard(likedItem);
+
+    expect(getAllByText(/^heart:#00BFFF/).length).toBeGreaterThan(0);
+    expect(getAllByText(/^bookmark:#00BFFF/).length).toBeGreaterThan(0);
+
+    const otherItem = {
+      ...baseItem,
+      _id: 'article-2',
+      likedUsers: [],
+      savedUsers: [],
+    };
+
+    rerender(<ArticleCard {...renderCardWithProps(otherItem)} />);
+
+    expect(queryAllByText(/^heart:#00BFFF/).length).toBe(0);
+    expect(queryAllByText(/^bookmark:#00BFFF/).length).toBe(0);
+    expect(getAllByText(/^heart-o:/).length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/components/article/ArticleCard.tsx
+++ b/frontend/src/components/article/ArticleCard.tsx
@@ -57,6 +57,21 @@ import { ReadingDifficulty, getArticleDifficulty } from './ReadingDifficulty';
 import {useDoubleTap} from '../../hooks/common/useDoubleTap';
 import { ImageFallback } from '../common/ImageFallback';
 
+const deriveEngagement = (article: any, uid: any) => ({
+  isLiked: article.likedUsers
+    ? article.likedUsers.some(
+        (it: any) =>
+          (it._id && it._id.toString() === uid) || it.toString() === uid,
+      )
+    : false,
+  likeCount: article.likedUsers ? article.likedUsers.length : 0,
+  saved: !!article.savedUsers && article.savedUsers.includes(uid),
+  reposted: article.repostUsers
+    ? article.repostUsers.some((user: any) => user.toString() === uid)
+    : false,
+  repostCount: article.repostUsers ? article.repostUsers.length : 0,
+});
+
 const ArticleCard = ({
   item,
   navigation,
@@ -83,21 +98,17 @@ const ArticleCard = ({
     useState<boolean>(false);
   const [menuVisible, setMenuVisible] = useState(false);
   const menuTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const prevItemRef = useRef(item);
+  const prevArticleIdRef = useRef(item?._id);
   const {data: user} = useGetProfile();
 
-  const [isLiked, setIsLiked] = useState(
-     item.likedUsers ? item.likedUsers.some(
-      it =>
-        (it._id && it._id.toString() === user_id) || it.toString() === user_id,
-    ): false,
-  );
-  const [likeCount, setLikeCount] = useState(item.likedUsers ? item.likedUsers.length : 0);
-  const [repostCount, setRepostCount] = useState(item.repostUsers ? item.repostUsers.length : 0);
+  const initialEngagement = deriveEngagement(item, user_id);
+  const [isLiked, setIsLiked] = useState(initialEngagement.isLiked);
+  const [likeCount, setLikeCount] = useState(initialEngagement.likeCount);
+  const [repostCount, setRepostCount] = useState(initialEngagement.repostCount);
 
-  const [saved, setSaved] = useState(item.savedUsers && item.savedUsers.includes(user_id));
-  const [reposted, setReposted] = useState(
-    item.repostUsers ? item.repostUsers.some(user => user.toString() === user_id) : false
-  );
+  const [saved, setSaved] = useState(initialEngagement.saved);
+  const [reposted, setReposted] = useState(initialEngagement.reposted);
 
   const {mutate: likeMutation, isPending: likeMutationPending} = useLikeArticle(
     Number(item._id),
@@ -111,6 +122,31 @@ const ArticleCard = ({
    
   const {mutate: getArticleContent, isPending: getArticleContentPending} =
     useLazyGetArticleContent();
+
+  // Keep like/save/repost UI in sync when the parent refetches or replaces `item`.
+  useEffect(() => {
+    const itemRefChanged = prevItemRef.current !== item;
+    const sameArticle = prevArticleIdRef.current === item?._id;
+    prevItemRef.current = item;
+    prevArticleIdRef.current = item?._id;
+
+    if (!itemRefChanged) return;
+
+    const next = deriveEngagement(item, user_id);
+
+    // saved/reposted are only confirmed via server callbacks, so they are
+    // safe to reconcile whenever the item is replaced.
+    setSaved(next.saved);
+    setReposted(next.reposted);
+    setRepostCount(next.repostCount);
+
+    // Preserve an in-flight optimistic like for the same article so the
+    // like state is not reverted by a stale refetch.
+    if (sameArticle && likeMutationPending) return;
+
+    setIsLiked(next.isLiked);
+    setLikeCount(next.likeCount);
+  }, [item, user_id, likeMutationPending]);
 
   // TEMP MOCK DATA — to be replaced by real /content-intel/readability/analyze response
   // Shape mirrors the VeriWise-Content-Check API: { score, level, approved }


### PR DESCRIPTION
## Problem

\ArticleCard\ initializes like/save/repost UI state from the incoming \item\ prop only once. When the parent refetches or replaces the article item, the card can keep showing stale like/save/repost state.

## Changes

- Extract prop-derived engagement values (\isLiked\, \likeCount\, \saved\, \eposted\, \epostCount\) into a shared \deriveEngagement\ helper.
- Add a reconciliation \useEffect\ that re-syncs these values whenever the \item\ reference changes.
- Preserve an in-flight optimistic like for the same article (guarded by \likeMutationPending\) so a stale refetch does not revert it; saved/repost state is always reconciled since it is only ever set by server callbacks.

## Acceptance criteria

- Like count, liked state, saved state, and repost state update when the \item\ prop changes.
- Existing optimistic updates still work.
- Added a component test that rerenders with updated article props.

## Tests

Added \ArticleCard.test.tsx\:
- like/save/repost state updates when the \item\ prop updates
- like count updates when \item.likedUsers\ changes
- engagement state resets when \item\ is replaced with a different article

All 4 ArticleCard tests plus related article/podcast suites pass.

Closes #2005