### PR TITLE
docs: fix installation step order — CLI/SDK setup before running the app

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,7 +430,19 @@ cd frontend
 yarn install
 ```
 
-**4. Run the App**
+**4. Install Expo and EAS CLI**
+```bash
+npm install -g expo-cli eas-cli
+```
+
+**5. Android SDK Setup (Linux/macOS)**
+```bash
+chmod +x setup-android.sh
+./setup-android.sh
+```
+> Skip this step if you only plan to preview the app via Expo Go (step 6 below) rather than building natively.
+
+**6. Run the App**
 
 ```bash
 # Android
@@ -443,17 +455,6 @@ npx expo run:ios
 
 # Quick preview via Expo Go
 npx expo start
-```
-
-**Android SDK Setup (Linux/macOS)**
-```bash
-chmod +x setup-android.sh
-./setup-android.sh
-```
-
-**Install Expo and EAS CLI**
-```bash
-npm install -g expo-cli eas-cli
 ```
 
 ---


### PR DESCRIPTION
## Description
Checked the entire README for typos with an actual spellcheck — found none; the doc appears to already be clean on that front. Found a real clarity issue instead: the Installation steps told new contributors to run the app (`npx expo run:android`) before ever reaching the "Install Expo and EAS CLI" or "Android SDK Setup" steps below it — meaning anyone following the steps in order would hit an SDK-not-found or missing-CLI error on step 4.

Reordered so CLI install and SDK setup happen before running the app, and added a note that SDK setup can be skipped for Expo Go-only preview.

## Checklist
- [x] Verified no cross-references to the old step numbers elsewhere in the doc
- [x] No code changes, docs only

Resolves #1686.