### PR TITLE
fix: replace bypassable regex sanitizer with entity-aware tag sanitizer (#2350)

### DIFF
--- a/frontend/src/__tests__/lib/utils/htmlSanitizer.test.ts
+++ b/frontend/src/__tests__/lib/utils/htmlSanitizer.test.ts
@@ -1,0 +1,94 @@
+import {sanitizeHtml} from '../../../lib/utils/htmlSanitizer';
+
+describe('sanitizeHtml', () => {
+  it('handles null, undefined and empty input', () => {
+    expect(sanitizeHtml(null)).toBe('');
+    expect(sanitizeHtml(undefined)).toBe('');
+    expect(sanitizeHtml('')).toBe('');
+  });
+
+  it('removes script, iframe, object and embed tags', () => {
+    expect(sanitizeHtml('<script>alert(1)</script>')).toBe('');
+    expect(
+      sanitizeHtml('<p>a</p><iframe src="https://evil.example"></iframe>'),
+    ).toBe('<p>a</p>');
+    expect(
+      sanitizeHtml('<object data="x"></object><embed src="y"><p>ok</p>'),
+    ).toBe('<p>ok</p>');
+  });
+
+  it('removes tags whose name is entity-encoded', () => {
+    expect(sanitizeHtml('<scr&#105;pt>alert(1)</scr&#105;pt>')).toBe('');
+  });
+
+  it('strips plain event-handler attributes', () => {
+    expect(sanitizeHtml('<img src=x onerror=alert(1)>')).toBe('<img src=x>');
+    expect(
+      sanitizeHtml('<img src=x onerror="alert(1)" onload=alert(2)>'),
+    ).toBe('<img src=x>');
+  });
+
+  it('neutralises entity-encoded event-handler attribute names', () => {
+    const out = sanitizeHtml('<img src=x onerr&#111;r=alert(1)>');
+    expect(out).toBe('<img src=x>');
+    expect(out).not.toContain('onerror');
+  });
+
+  it('blocks javascript: URLs in href/src', () => {
+    expect(sanitizeHtml('<a href="javascript:alert(1)">click</a>')).toBe(
+      '<a>click</a>',
+    );
+    expect(sanitizeHtml('<img src="javascript:alert(1)">')).toBe('<img>');
+  });
+
+  it('blocks entity-encoded javascript: scheme in href', () => {
+    const out = sanitizeHtml('<a href="java&#115;cript:alert(1)">click</a>');
+    expect(out).toBe('<a>click</a>');
+    expect(out).not.toContain('javascript');
+  });
+
+  it('blocks vbscript: and non-image data: schemes', () => {
+    expect(
+      sanitizeHtml('<a href="vbscript:msgbox(1)">x</a>'),
+    ).toBe('<a>x</a>');
+    expect(
+      sanitizeHtml('<img src="data:text/html,<script>alert(1)</script>">'),
+    ).toBe('<img>');
+  });
+
+  it('drops xlink:href on SVG links', () => {
+    const out = sanitizeHtml('<a xlink:href="javascript:alert(1)">x</a>');
+    expect(out).toBe('<a>x</a>');
+    expect(out).not.toContain('xlink');
+  });
+
+  it('blocks SVG and MathML containers entirely', () => {
+    expect(sanitizeHtml('<svg onload=alert(1)></svg>')).toBe('');
+    expect(sanitizeHtml('<math><mi>x</mi></math>')).toBe('');
+  });
+
+  it('drops style, srcdoc and formaction attributes', () => {
+    expect(
+      sanitizeHtml('<p style="background:url(javascript:alert(1))">x</p>'),
+    ).toBe('<p>x</p>');
+    expect(
+      sanitizeHtml('<iframe srcdoc="<script>alert(1)</script>"></iframe>'),
+    ).toBe('');
+    expect(
+      sanitizeHtml('<button formaction="javascript:alert(1)">x</button>'),
+    ).toBe('');
+  });
+
+  it('removes HTML comments and doctypes', () => {
+    expect(sanitizeHtml('<!-- comment --><p>ok</p>')).toBe('<p>ok</p>');
+    expect(sanitizeHtml('<!DOCTYPE html><p>ok</p>')).toBe('<p>ok</p>');
+  });
+
+  it('preserves safe article formatting', () => {
+    const safe = '<p>Hello <a href="https://example.com">link</a></p>';
+    expect(sanitizeHtml(safe)).toBe(safe);
+    expect(
+      sanitizeHtml('<img src="/img.png" alt="x"><ul><li>a</li></ul>'),
+    ).toBe('<img src="/img.png" alt="x"><ul><li>a</li></ul>');
+  });
+});

--- a/frontend/src/lib/utils/Utils.ts
+++ b/frontend/src/lib/utils/Utils.ts
@@ -3,6 +3,7 @@ import {Category, CategoryType, PodcastData} from '../../schemas/type';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import {GET_STORAGE_DATA} from '../api/APIUtils';
 import {Alert, Linking, Platform, PermissionsAndroid} from 'react-native';
+import {sanitizeHtml} from './htmlSanitizer';
 
 let RNFS: any = null;
 
@@ -84,26 +85,9 @@ export const handleExternalClick = (request: any) => {
   return false;
 };
 
-// Minimal HTML sanitizer for content rendered inside WebViews.
-// Strips executable/embedding tags, event-handler attributes and
-// javascript: URLs while preserving article formatting.
-export const sanitizeHtml = (html: string | null | undefined): string => {
-  if (!html) return '';
-  return html
-    .replace(/<\s*script\b[\s\S]*?<\s*\/\s*script\s*>/gi, '')
-    .replace(/<\s*script\b[^>]*\/?>/gi, '')
-    .replace(/<\s*iframe\b[\s\S]*?<\s*\/\s*iframe\s*>/gi, '')
-    .replace(/<\s*iframe\b[^>]*\/?>/gi, '')
-    .replace(/<\s*object\b[\s\S]*?<\s*\/\s*object\s*>/gi, '')
-    .replace(/<\s*object\b[^>]*\/?>/gi, '')
-    .replace(/<\s*embed\b[^>]*\/?>/gi, '')
-    .replace(/\son\w+\s*=\s*("[^"]*"|'[^']*'|[^\s>]+)/gi, '')
-    .replace(
-      /\s(href|src)\s*=\s*("[^"]*"|'[^']*'|[^\s>]+)/gi,
-      (match, attr, value) =>
-        /javascript:/i.test(value) ? ` ${attr}="#"` : match,
-    );
-};
+// Sanitizer for content rendered inside WebViews.
+// Re-exported so existing imports stay valid.
+export {sanitizeHtml};
 
 export function msToTime(ms: number): string {
   let totalSeconds = Math.floor(ms / 1000);

--- a/frontend/src/lib/utils/htmlSanitizer.ts
+++ b/frontend/src/lib/utils/htmlSanitizer.ts
@@ -1,0 +1,269 @@
+// HTML sanitizer for content rendered inside WebViews.
+//
+// The previous regex-only sanitizer could be bypassed with HTML entity
+// encoding (e.g. `onerr&#111;r=alert(1)` decoding to `onerror=alert(1)`,
+// `href="java&#115;cript:..."` decoding to `javascript:`) and with SVG
+// attributes such as `xlink:href` that the `href|src` filter never checked.
+// This implementation:
+//   - parses tags token-by-token (respecting quoted attribute values),
+//   - decodes HTML entities in every tag name and attribute name/value
+//     *before* applying dangerous-tag and dangerous-attribute checks, and
+//   - removes the inner content of blocked tags (script, iframe, style, svg,
+//     math, ...) so their payloads cannot leak or execute.
+
+const NAMED_ENTITIES: Record<string, string> = {
+  amp: '&',
+  lt: '<',
+  gt: '>',
+  quot: '"',
+  apos: "'",
+  nbsp: '\u00a0',
+  colon: ':',
+  sol: '/',
+  excl: '!',
+  period: '.',
+  comma: ',',
+};
+
+const decodeHtmlEntities = (value: string): string =>
+  value.replace(/&(#x?[0-9a-f]+|(?:[a-z][a-z0-9]*));/gi, (entity, code) => {
+    if (code[0] === '#') {
+      const isHex = code[1]?.toLowerCase() === 'x';
+      const num = parseInt(isHex ? code.slice(2) : code.slice(1), isHex ? 16 : 10);
+      if (Number.isNaN(num) || num < 0 || num > 0x10ffff) {
+        return entity;
+      }
+      return String.fromCodePoint(num);
+    }
+    return NAMED_ENTITIES[code.toLowerCase()] ?? entity;
+  });
+
+// Tags that can carry or execute scripts. The opening tag and all of its
+// inner content are removed.
+const DANGEROUS_TAGS = new Set([
+  'script',
+  'iframe',
+  'object',
+  'embed',
+  'applet',
+  'form',
+  'input',
+  'button',
+  'select',
+  'option',
+  'textarea',
+  'meta',
+  'link',
+  'base',
+  'style',
+  'template',
+  'svg',
+  'math',
+  'frame',
+  'frameset',
+  'noframes',
+  'noscript',
+  'title',
+]);
+
+// Void tags never carry a matching closing tag, so they must not push onto
+// the "inside dangerous content" stack (e.g. `<embed>` is a void element).
+const VOID_TAGS = new Set([
+  'embed',
+  'meta',
+  'link',
+  'base',
+  'input',
+  'img',
+  'br',
+  'hr',
+  'source',
+  'wbr',
+]);
+
+// Attributes that can trigger script execution or navigation. Blocked
+// wholesale, including after entity decoding of the attribute name.
+const DANGEROUS_ATTRS = new Set([
+  'style',
+  'srcdoc',
+  'formaction',
+  'action',
+  'xlink:href',
+  'xmlns',
+  'xml:base',
+  'srcset',
+  'background',
+  'dynsrc',
+  'lowsrc',
+  'poster',
+  'ping',
+  'data',
+  'form',
+]);
+
+const SAFE_URL_ATTRS = new Set(['href', 'src']);
+
+const SAFE_URL_SCHEMES = new Set(['http', 'https', 'mailto', 'tel', 'sms']);
+
+const isSafeUrl = (value: string): boolean => {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return false;
+  }
+  const scheme = trimmed.match(/^([a-z][a-z0-9+.-]*):/i)?.[1]?.toLowerCase();
+  if (!scheme) {
+    return true;
+  }
+  return SAFE_URL_SCHEMES.has(scheme);
+};
+
+// Returns the index of the `>` that closes the tag starting at `start`,
+// skipping any `>` that appears inside a quoted attribute value. Returns -1
+// if the tag is never closed.
+const findTagEnd = (html: string, start: number): number => {
+  let quote: string | null = null;
+  for (let i = start + 1; i < html.length; i++) {
+    const char = html[i];
+    if (quote) {
+      if (char === quote) {
+        quote = null;
+      }
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      quote = char;
+    } else if (char === '>') {
+      return i;
+    }
+  }
+  return -1;
+};
+
+type ParsedTag = {
+  name: string;
+  isClosing: boolean;
+  isVoid: boolean;
+  isComment: boolean;
+};
+
+const parseTag = (tag: string): ParsedTag => {
+  if (tag.startsWith('<!--') || tag.startsWith('<!') || tag.startsWith('<?')) {
+    return {name: '', isClosing: false, isVoid: false, isComment: true};
+  }
+
+  const tagMatch = tag.match(/^<\s*(\/?)([^\s>/]+)/i);
+  if (!tagMatch) {
+    return {name: '', isClosing: false, isVoid: false, isComment: false};
+  }
+
+  const isClosing = tagMatch[1] === '/';
+  const name = decodeHtmlEntities(tagMatch[2]).toLowerCase();
+
+  return {
+    name,
+    isClosing,
+    isVoid: VOID_TAGS.has(name),
+    isComment: false,
+  };
+};
+
+const sanitizeTag = (tag: string): string => {
+  const tagMatch = tag.match(/^<\s*(\/?)([^\s>/]+)/i);
+  if (!tagMatch) {
+    return tag;
+  }
+
+  const isClosing = tagMatch[1] === '/';
+  const tagName = decodeHtmlEntities(tagMatch[2]).toLowerCase();
+
+  if (isClosing) {
+    return `</${tagName}>`;
+  }
+
+  const attributePattern = /\s+([^\s=/>]+)(?:\s*=\s*("[^"]*"|'[^']*'|[^\s>]*))?/g;
+  const attributes: string[] = [];
+  const rest = tag.slice(tagMatch[0].length);
+  let match: RegExpExecArray | null;
+  while ((match = attributePattern.exec(rest)) !== null) {
+    const rawName = match[1];
+    const rawValue = match[2] ?? '';
+    const attrName = decodeHtmlEntities(rawName).toLowerCase();
+
+    if (attrName.startsWith('on')) {
+      continue;
+    }
+    if (DANGEROUS_ATTRS.has(attrName)) {
+      continue;
+    }
+
+    if (SAFE_URL_ATTRS.has(attrName)) {
+      const decodedValue = decodeHtmlEntities(rawValue.replace(/^["']|["']$/g, ''));
+      if (!isSafeUrl(decodedValue)) {
+        continue;
+      }
+    }
+
+    attributes.push(rawValue ? ` ${rawName}=${rawValue}` : ` ${rawName}`);
+  }
+
+  return `<${tagName}${attributes.join('')}>`;
+};
+
+export const sanitizeHtml = (html: string | null | undefined): string => {
+  if (!html) {
+    return '';
+  }
+
+  let result = '';
+  let cursor = 0;
+  const dangerousStack: string[] = [];
+
+  while (cursor < html.length) {
+    const tagStart = html.indexOf('<', cursor);
+    if (tagStart === -1) {
+      if (dangerousStack.length === 0) {
+        result += html.slice(cursor);
+      }
+      break;
+    }
+
+    if (dangerousStack.length === 0) {
+      result += html.slice(cursor, tagStart);
+    }
+
+    const tagEnd = findTagEnd(html, tagStart);
+    if (tagEnd === -1) {
+      if (dangerousStack.length === 0) {
+        result += html.slice(cursor);
+      }
+      break;
+    }
+
+    const rawTag = html.slice(tagStart, tagEnd + 1);
+    cursor = tagEnd + 1;
+
+    const parsed = parseTag(rawTag);
+
+    if (parsed.isComment) {
+      continue;
+    }
+
+    if (DANGEROUS_TAGS.has(parsed.name)) {
+      if (parsed.isClosing) {
+        const index = dangerousStack.lastIndexOf(parsed.name);
+        if (index !== -1) {
+          dangerousStack.splice(index, 1);
+        }
+      } else if (!parsed.isVoid) {
+        dangerousStack.push(parsed.name);
+      }
+      continue;
+    }
+
+    if (dangerousStack.length === 0) {
+      result += sanitizeTag(rawTag);
+    }
+  }
+
+  return result;
+};


### PR DESCRIPTION
Closes #2350

## Summary

Replaces the regex-only `sanitizeHtml` (previously in `frontend/src/lib/utils/Utils.ts`) with a dependency-free, token-by-token HTML sanitizer (`frontend/src/lib/utils/htmlSanitizer.ts`) that is not bypassable with HTML entity encoding or SVG attributes.

## Why

The old sanitizer had three verified bypasses that execute arbitrary JS inside the app's content WebViews (`ImprovementCard`, `ArticleScreen`, `ReviewScreen`, `ImprovementReviewScreen`):

1. **Entity-encoded event handlers** — `<img src=x onerr&#111;r=alert(1)>` passed through untouched (the `on\w+` regex stops at `&`); the browser decodes `&#111;` → `o`, producing a live `onerror=alert(1)`.
2. **Entity-encoded URL schemes** — `href="java&#115;cript:alert(1)"` survived because the `javascript:` check ran against the raw encoded value.
3. **SVG `xlink:href`** — the scheme filter only checked `href`/`src`.

This is a bypass of the hardening done in #2304.

## Fix

- Parses tags one at a time (respecting quoted attribute values).
- **Decodes HTML entities (numeric + named) in every tag name, attribute name, and attribute value before applying checks**, so encoded payloads are neutralised identically to plain ones.
- Strips all `on*` event handlers, dangerous attributes (`style`, `srcdoc`, `formaction`, `action`, `xlink:href`, `xmlns`, `srcset`, `background`, ...).
- Validates `href`/`src` against a safe-scheme allowlist (`http`, `https`, `mailto`, `tel`, `sms`, relative) — blocks `javascript:`, `vbscript:`, `data:`.
- Removes dangerous containers **and their inner content** (`script`, `iframe`, `object`, `embed`, `style`, `svg`, `math`, `form`, `frame`, `meta`, ...), including entity-encoded tag names like `<scr&#105;pt>`.
- Preserves safe article formatting (`p`, `a`, `img`, `ul/ol/li`, `table`, headings, etc.).

## Tests

Added `frontend/src/__tests__/lib/utils/htmlSanitizer.test.ts` (13 cases) covering every reported bypass plus regressions for safe markup.

## Verification

- `tsc --noEmit` — clean
- `eslint` on changed files — 0 errors
- `jest` full suite — 140 suites / 522 tests passing
