### PR TITLE
fix: stop logging full user payload from getuserprofile in production (#2352)

### DIFF
--- a/frontend/src/hooks/profile/useGetAuthorProfile.ts
+++ b/frontend/src/hooks/profile/useGetAuthorProfile.ts
@@ -23,7 +23,20 @@ export const useGetAuthorProfile = (
         url = `${PROD_URL}/user/getuserprofile?id=${user_id}`;
       }
       const response = await axios.get(url);
-      console.log("Fetched author profile:", response.data);
+      if (__DEV__) {
+        // Log only safe profile metadata. The full User payload can contain
+        // email, password, refreshToken, otp and contact_detail.phone_no, so
+        // it must never be dumped to logs in any build.
+        const profile = response.data?.data as User | undefined;
+        console.log('[useGetAuthorProfile] user_id:', profile?._id);
+        console.log('[useGetAuthorProfile] user_handle:', profile?.user_handle);
+        console.log('[useGetAuthorProfile] user_name:', profile?.user_name);
+        console.log(
+          '[useGetAuthorProfile] hasProfileImage:',
+          typeof profile?.Profile_image === 'string' &&
+            profile.Profile_image.length > 0,
+        );
+      }
       return response.data.data as User;
     },
     enabled: !!isConnected


### PR DESCRIPTION
Closes #2352

## Summary

Stops `useGetAuthorProfile` from dumping the entire user payload to the console in production.

## Before

`frontend/src/hooks/profile/useGetAuthorProfile.ts:26` called `console.log("Fetched author profile:", response.data)` with **no `__DEV__` guard**. `console.log` is not stripped from release builds, so opening any author/user profile printed the raw `/user/getuserprofile` response to device logs (logcat/console) and crash-reporting breadcrumbs in production. The `User` schema this hook casts to includes `email`, `password`, `otp`, `verificationToken`, `refreshToken` and `contact_detail.phone_no` — i.e. PII and credential fields.

## After

- The log is gated behind `__DEV__`.
- In debug builds it logs only safe profile metadata (`_id`, `user_handle`, `user_name`, whether a profile image exists) — never the raw payload.
- Mirrors the established pattern from `useUserLogin.ts`.

## Verification

- `tsc --noEmit` — clean
- `eslint` on the changed file — 0 errors
- Full jest suite passing
