### PR TITLE
fix: remove hardcoded Vultr API credential from ChatbotScreen (#2351)

### DIFF
--- a/frontend/src/screens/ai/ChatbotScreen.tsx
+++ b/frontend/src/screens/ai/ChatbotScreen.tsx
@@ -58,7 +58,6 @@ const ChatbotScreen = ({navigation, route}: ChatBotScreenProps) => {
   const [showQuotaModal, setShowQuotaModal] = useState<boolean>(false);
   const isMountedRef = useRef(true);
   const {data: user} = useGetProfile();
-  // const token = 'GPMFAQIV2BGXCWYMCVQ3IPVXSOOLI53H5NYA'; //token
 
   const [activeSpeakingId, setActiveSpeakingId] = useState<string | number | null>(null);
 


### PR DESCRIPTION
Closes #2351

## Summary

Removes a live-looking third-party API credential that is committed to the repository.

## Change

Deleted the commented-out hardcoded token in `frontend/src/screens/ai/ChatbotScreen.tsx`:

```ts
// const token = 'GPMFAQIV2BGXCWYMCVQ3IPVXSOOLI53H5NYA'; //token
```

`git grep` confirms no other occurrence of the key remains in the working tree.

## Security note

- The key is compromised (it exists in public git history) and should be **revoked/rotated at the provider** independently of this PR.
- Any future API key must be loaded from environment variables / the backend — never committed. If the repo enables secret scanning, this pattern would be caught at push time.

## Verification

- `tsc --noEmit` — clean
- `eslint` on the changed file — 0 errors
- Full jest suite passing
