### PR TITLE
feat: add nearby health events

### DIFF
--- a/frontend/app.config.js
+++ b/frontend/app.config.js
@@ -23,6 +23,7 @@ const defaultStaticConfig = {
       NSMicrophoneUsageDescription: "App requires microphone access to record audio.",
       NSPhotoLibraryAddUsageDescription: "App needs access to save recordings.",
       NSPhotoLibraryUsageDescription: "App needs access to select or manage audio files.",
+      NSLocationWhenInUseUsageDescription: "App requires location access to find nearby health events.",
       UIBackgroundModes: ["audio"]
     }
   },
@@ -34,7 +35,9 @@ const defaultStaticConfig = {
       "RECEIVE_BOOT_COMPLETED",
       "POST_NOTIFICATIONS",
       "READ_MEDIA_AUDIO",
-      "MODIFY_AUDIO_SETTINGS"
+      "MODIFY_AUDIO_SETTINGS",
+      "ACCESS_COARSE_LOCATION",
+      "ACCESS_FINE_LOCATION"
     ],
     blockedPermissions: [
       "android.permission.SYSTEM_ALERT_WINDOW",

--- a/frontend/app.json
+++ b/frontend/app.json
@@ -23,6 +23,7 @@
         "NSMicrophoneUsageDescription": "App requires microphone access to record audio.",
         "NSPhotoLibraryAddUsageDescription": "App needs access to save recordings.",
         "NSPhotoLibraryUsageDescription": "App needs access to select or manage audio files.",
+        "NSLocationWhenInUseUsageDescription": "App requires location access to find nearby health events.",
         "UIBackgroundModes": ["audio"]
       }
     },
@@ -34,7 +35,9 @@
         "RECEIVE_BOOT_COMPLETED",
         "POST_NOTIFICATIONS",
         "READ_MEDIA_AUDIO",
-        "MODIFY_AUDIO_SETTINGS"
+        "MODIFY_AUDIO_SETTINGS",
+        "ACCESS_COARSE_LOCATION",
+        "ACCESS_FINE_LOCATION"
       ],
       "blockedPermissions": [
         "android.permission.SYSTEM_ALERT_WINDOW",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -61,6 +61,7 @@
     "expo-linear-gradient": "~57.0.0",
     "expo-linking": "~57.0.4",
     "expo-localization": "~57.0.0",
+    "expo-location": "^57.0.8",
     "expo-notifications": "~57.0.7",
     "expo-secure-store": "~57.0.0",
     "expo-speech": "~57.0.0",

--- a/frontend/src/hooks/events/useGetNearbyEvents.ts
+++ b/frontend/src/hooks/events/useGetNearbyEvents.ts
@@ -1,0 +1,26 @@
+import { useQuery, UseQueryResult } from '@tanstack/react-query';
+import axios, { AxiosError } from 'axios';
+import { NEARBY_EVENTS_API } from '../../lib/api/APIUtils';
+import { HealthEvent, NearbyEventsResponse } from '../../schemas/type';
+
+export const useGetNearbyEvents = (
+  latitude: number | null,
+  longitude: number | null,
+  radius: number,
+): UseQueryResult<HealthEvent[], AxiosError> => {
+  return useQuery({
+    queryKey: ['get-nearby-events', latitude, longitude, radius],
+    queryFn: async () => {
+      const response = await axios.get<NearbyEventsResponse>(NEARBY_EVENTS_API, {
+        params: {
+          latitude,
+          longitude,
+          radius,
+        },
+      });
+      return response.data.data;
+    },
+    enabled: latitude !== null && longitude !== null,
+    staleTime: 1000 * 60 * 5, // 5 minutes
+  });
+};

--- a/frontend/src/lib/api/APIUtils.ts
+++ b/frontend/src/lib/api/APIUtils.ts
@@ -120,6 +120,9 @@ const REGISTER_PUSH_TOKEN = `${PROD_URL}/user/register-device-token`;
 /** Wellness */
 const LOG_WELLNESS_METRICS = `${PROD_URL}/wellness`;
 
+/** Nearby Health Events */
+const NEARBY_EVENTS_API = `${PROD_URL}/events/nearby`;
+
 export {
   LOGIN_API,
   REGISTRATION_API,
@@ -209,4 +212,5 @@ export {
   GET_READ_HISTORY,
   SHARE_BASE_URL,
   LOG_WELLNESS_METRICS,
+  NEARBY_EVENTS_API,
 };

--- a/frontend/src/lib/utils/LocationUtils.ts
+++ b/frontend/src/lib/utils/LocationUtils.ts
@@ -1,0 +1,43 @@
+/**
+ * Calculates the geodesic distance between two points on the Earth's surface
+ * using the Haversine formula.
+ *
+ * @param lat1 Latitude of point 1 in degrees
+ * @param lon1 Longitude of point 1 in degrees
+ * @param lat2 Latitude of point 2 in degrees
+ * @param lon2 Longitude of point 2 in degrees
+ * @returns Distance in meters
+ */
+export function calculateDistance(
+  lat1: number,
+  lon1: number,
+  lat2: number,
+  lon2: number,
+): number {
+  const R = 6371e3; // Earth's radius in meters
+  const φ1 = (lat1 * Math.PI) / 180;
+  const φ2 = (lat2 * Math.PI) / 180;
+  const Δφ = ((lat2 - lat1) * Math.PI) / 180;
+  const Δλ = ((lon2 - lon1) * Math.PI) / 180;
+
+  const a =
+    Math.sin(Δφ / 2) * Math.sin(Δφ / 2) +
+    Math.cos(φ1) * Math.cos(φ2) * Math.sin(Δλ / 2) * Math.sin(Δλ / 2);
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+  return R * c; // distance in meters
+}
+
+/**
+ * Formats a distance in meters to a human-readable string.
+ * E.g., "450 m" or "12.4 km".
+ *
+ * @param meters Distance in meters
+ * @returns Human-readable formatted string
+ */
+export function formatDistance(meters: number): string {
+  if (meters < 1000) {
+    return `${Math.round(meters)} m`;
+  }
+  return `${(meters / 1000).toFixed(1)} km`;
+}

--- a/frontend/src/navigations/StackNavigation.tsx
+++ b/frontend/src/navigations/StackNavigation.tsx
@@ -66,6 +66,8 @@ import RespectGiverScreen from '../screens/social/RespectGiverScreen';
 import GuestPlaceholderScreen from '../components/auth/GuestPlaceholderScreen';
 
 import ChatbotScreen from '../screens/ai/ChatbotScreen';
+import NearbyHealthEventsScreen from '../screens/settings/NearbyHealthEventsScreen';
+import EventDetailsScreen from '../screens/settings/EventDetailsScreen';
 
 const Stack = createStackNavigator<RootStackParamList>();
 
@@ -171,6 +173,16 @@ const StackNavigation = () => {
       <Stack.Screen
         name="NewPasswordScreen"
         component={NewPasswordScreen}
+        options={{headerShown: false}}
+      />
+      <Stack.Screen
+        name="NearbyHealthEventsScreen"
+        component={NearbyHealthEventsScreen}
+        options={{headerShown: false}}
+      />
+      <Stack.Screen
+        name="EventDetailsScreen"
+        component={EventDetailsScreen}
         options={{headerShown: false}}
       />
 

--- a/frontend/src/schemas/type.ts
+++ b/frontend/src/schemas/type.ts
@@ -911,3 +911,35 @@ export type NearbyEventsResponse = {
   message: string;
   data: HealthEvent[];
 };
+
+export type WellnessMetrics = {
+  steps?: number;
+  activeMinutes?: number;
+  sleepHours?: number;
+  waterMl?: number;
+  caloriesBurned?: number;
+  breathingSessionMinutes?: number;
+};
+
+export type WellnessLogPayload = {
+  date: string; // YYYY-MM-DD (required by POST /wellness/log)
+  metrics?: Partial<WellnessMetrics>;
+};
+
+export type WellnessLog = {
+  userId: string;
+  date: string; // YYYY-MM-DD
+  metrics: WellnessMetrics;
+  createdAt?: string;
+};
+
+export type WellnessLogResponse = {
+  success: boolean;
+  message?: string;
+  data?: WellnessLog;
+};
+
+export type WeeklyWellnessResponse = {
+  success: boolean;
+  data: WellnessLog[];
+};

--- a/frontend/src/schemas/type.ts
+++ b/frontend/src/schemas/type.ts
@@ -146,6 +146,8 @@ export type RootStackParamList = {
   RespectGiverScreen: undefined;
   ContentListScreen: { type: 'articles' | 'reposts' | 'saved' };
   PodcastEpisodesScreen: undefined;
+  NearbyHealthEventsScreen: undefined;
+  EventDetailsScreen: { event: HealthEvent; distance?: number };
 };
 
 export type RedirectTo = {
@@ -880,4 +882,32 @@ export type NotificationPreferencesResponse = {
   contentClusters?: Category[];
   message: string;
   error?: string;
+};
+
+export type EventType = 'Blood Donation Drive' | 'Health Camp' | 'Yoga / Wellness Meetup' | 'Community Health Event' | string;
+
+export type EventLocation = {
+  type: 'Point';
+  coordinates: [number, number]; // [longitude, latitude]
+};
+
+export type HealthEvent = {
+  _id: string;
+  title: string;
+  description: string;
+  organizer: string;
+  type: EventType;
+  address: string;
+  date: string;
+  time: string;
+  location: EventLocation;
+  createdAt: string;
+  updatedAt: string;
+  distance?: number;
+};
+
+export type NearbyEventsResponse = {
+  success: boolean;
+  message: string;
+  data: HealthEvent[];
 };

--- a/frontend/src/screens/settings/EventDetailsScreen.tsx
+++ b/frontend/src/screens/settings/EventDetailsScreen.tsx
@@ -1,0 +1,340 @@
+import React, { ComponentProps } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  TouchableOpacity,
+  useColorScheme,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { StatusBar } from 'expo-status-bar';
+import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
+import MaterialIcons from '@expo/vector-icons/MaterialIcons';
+import FontAwesome6 from '@expo/vector-icons/FontAwesome6';
+
+import { PRIMARY_COLOR } from '../../lib/ui/Theme';
+import { wp, hp, fp } from '../../lib/ui/Metric';
+import { formatDateShortYear } from '../../lib/utils/dateUtils';
+import { formatDistance } from '../../lib/utils/LocationUtils';
+import { safeOpenUrl } from '../../lib/utils/safeOpenUrl';
+import { HealthEvent, RootStackParamList } from '../../schemas/type';
+import { StackScreenProps } from '@react-navigation/stack';
+
+type EventDetailsScreenProps = StackScreenProps<
+  RootStackParamList,
+  'EventDetailsScreen'
+>;
+
+type EventTheme = {
+  bg: string;
+  text: string;
+  icon: ComponentProps<typeof MaterialCommunityIcons>['name'];
+};
+
+const EVENT_TYPE_THEMES: Record<string, EventTheme> = {
+  'Blood Donation Drive': { bg: 'rgba(239, 68, 68, 0.1)', text: '#EF4444', icon: 'water' },
+  'Health Camp': { bg: 'rgba(59, 130, 246, 0.1)', text: '#3B82F6', icon: 'hospital-box' },
+  'Yoga / Wellness Meetup': { bg: 'rgba(16, 185, 129, 0.1)', text: '#10B981', icon: 'spa' },
+  'Community Health Event': { bg: 'rgba(139, 92, 246, 0.1)', text: '#8B5CF6', icon: 'account-group' },
+};
+
+const DEFAULT_EVENT_THEME: EventTheme = {
+  bg: 'rgba(107, 114, 128, 0.1)',
+  text: '#6B7280',
+  icon: 'calendar',
+};
+
+const EventDetailsScreen = ({ route, navigation }: EventDetailsScreenProps) => {
+  const { event, distance } = route.params;
+  const isDark = useColorScheme() === 'dark';
+
+  const bg = isDark ? '#111827' : '#F9FAFB';
+  const cardBg = isDark ? '#1F2937' : '#FFFFFF';
+  const cardBorder = isDark ? '#374151' : '#E5E7EB';
+  const textColor = isDark ? '#F9FAFB' : '#111827';
+  const subtextColor = isDark ? '#9CA3AF' : '#6B7280';
+  const headerBg = isDark ? '#1F2937' : '#FFFFFF';
+  const headerBorder = isDark ? '#374151' : '#E5E7EB';
+
+  const getEventTypeTheme = (type: string): EventTheme => {
+    return EVENT_TYPE_THEMES[type] || DEFAULT_EVENT_THEME;
+  };
+
+  const theme = getEventTypeTheme(event.type);
+
+  const handleOpenMaps = async () => {
+    const coords = event.location?.coordinates;
+    if (!coords || !Array.isArray(coords) || coords.length !== 2) return;
+    const [longitude, latitude] = coords;
+    if (typeof longitude !== 'number' || typeof latitude !== 'number' || !isFinite(longitude) || !isFinite(latitude)) return;
+
+    const mapUrl = `https://www.google.com/maps/search/?api=1&query=${latitude},${longitude}`;
+    await safeOpenUrl(mapUrl, {
+      errorMessage: 'Could not open maps on your device.',
+      errorTitle: 'Directions Unavailable',
+    });
+  };
+
+  return (
+    <SafeAreaView style={[styles.container, { backgroundColor: bg }]}>
+      <StatusBar style={isDark ? 'light' : 'dark'} />
+
+      {/* Header */}
+      <View style={[styles.header, { backgroundColor: headerBg, borderBottomColor: headerBorder }]}>
+        <TouchableOpacity
+          style={styles.backButton}
+          onPress={() => navigation.goBack()}
+          accessibilityLabel="Go back"
+          accessibilityRole="button"
+        >
+          <FontAwesome6 name="arrow-left" size={18} color={textColor} />
+        </TouchableOpacity>
+        <Text style={[styles.headerTitle, { color: textColor }]}>Event Details</Text>
+        <View style={{ width: wp(10) }} />
+      </View>
+
+      <ScrollView contentContainerStyle={styles.scroll} showsVerticalScrollIndicator={false}>
+        {/* Event Classification Tag */}
+        <View style={[styles.typeBadge, { backgroundColor: theme.bg, borderColor: theme.text }]}>
+          <MaterialCommunityIcons name={theme.icon} size={18} color={theme.text} style={styles.badgeIcon} />
+          <Text style={[styles.typeText, { color: theme.text }]}>{event.type}</Text>
+        </View>
+
+        {/* Event Title */}
+        <Text style={[styles.title, { color: textColor }]}>{event.title}</Text>
+
+        {/* Organizer Section */}
+        <View style={[styles.sectionCard, { backgroundColor: cardBg, borderColor: cardBorder }]}>
+          <View style={styles.organizerRow}>
+            <View style={[styles.iconContainer, { backgroundColor: 'rgba(0, 10, 96, 0.06)' }]}>
+              <FontAwesome6 name="user-tie" size={16} color={PRIMARY_COLOR} />
+            </View>
+            <View style={styles.organizerDetails}>
+              <Text style={[styles.infoLabel, { color: subtextColor }]}>ORGANIZER</Text>
+              <Text style={[styles.infoValue, { color: textColor }]}>{event.organizer}</Text>
+            </View>
+          </View>
+        </View>
+
+        {/* Event Schedule Info */}
+        <View style={[styles.sectionCard, { backgroundColor: cardBg, borderColor: cardBorder }]}>
+          <Text style={[styles.sectionTitle, { color: textColor }]}>Schedule & Location</Text>
+
+          <View style={styles.infoRow}>
+            <MaterialCommunityIcons name="calendar-range" size={20} color={PRIMARY_COLOR} style={styles.infoIcon} />
+            <View style={styles.infoTextWrapper}>
+              <Text style={[styles.infoLabel, { color: subtextColor }]}>DATE</Text>
+              <Text style={[styles.infoValue, { color: textColor }]}>
+                {formatDateShortYear(event.date)}
+              </Text>
+            </View>
+          </View>
+
+          <View style={[styles.divider, { backgroundColor: cardBorder }]} />
+
+          <View style={styles.infoRow}>
+            <MaterialCommunityIcons name="clock-time-four-outline" size={20} color={PRIMARY_COLOR} style={styles.infoIcon} />
+            <View style={styles.infoTextWrapper}>
+              <Text style={[styles.infoLabel, { color: subtextColor }]}>TIME</Text>
+              <Text style={[styles.infoValue, { color: textColor }]}>{event.time}</Text>
+            </View>
+          </View>
+
+          {distance !== undefined ? (
+            <>
+              <View style={[styles.divider, { backgroundColor: cardBorder }]} />
+              <View style={styles.infoRow}>
+                <MaterialIcons name="navigation" size={20} color={PRIMARY_COLOR} style={styles.infoIcon} />
+                <View style={styles.infoTextWrapper}>
+                  <Text style={[styles.infoLabel, { color: subtextColor }]}>DISTANCE</Text>
+                  <Text style={[styles.infoValue, { color: textColor }]}>
+                    {formatDistance(distance)} away
+                  </Text>
+                </View>
+              </View>
+            </>
+          ) : null}
+
+          <View style={[styles.divider, { backgroundColor: cardBorder }]} />
+
+          <View style={styles.infoRow}>
+            <MaterialCommunityIcons name="map-marker-radius" size={20} color={PRIMARY_COLOR} style={styles.infoIcon} />
+            <View style={styles.infoTextWrapper}>
+              <Text style={[styles.infoLabel, { color: subtextColor }]}>ADDRESS</Text>
+              <Text style={[styles.infoValue, { color: textColor }]}>{event.address}</Text>
+            </View>
+          </View>
+
+          {event.location?.coordinates ? (
+            <TouchableOpacity
+              activeOpacity={0.8}
+              onPress={handleOpenMaps}
+              style={[styles.directionsButton, { backgroundColor: PRIMARY_COLOR }]}
+              accessibilityLabel="Get directions in Google Maps"
+              accessibilityRole="button"
+            >
+              <MaterialCommunityIcons name="google-maps" size={20} color="white" style={{ marginRight: 6 }} />
+              <Text style={styles.directionsText}>Get Directions</Text>
+            </TouchableOpacity>
+          ) : null}
+        </View>
+
+        {/* Description Section */}
+        <View style={[styles.sectionCard, { backgroundColor: cardBg, borderColor: cardBorder }]}>
+          <Text style={[styles.sectionTitle, { color: textColor }]}>About the Event</Text>
+          <Text style={[styles.description, { color: textColor }]}>{event.description}</Text>
+        </View>
+
+        {/* Safe Footnote */}
+        <View style={styles.footnoteWrapper}>
+          <MaterialIcons name="security" size={14} color={subtextColor} />
+          <Text style={[styles.footnote, { color: subtextColor }]}>
+            Verified event listed on UltimateHealth platform.
+          </Text>
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+};
+
+export default EventDetailsScreen;
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: wp(4),
+    paddingVertical: hp(1.5),
+    borderBottomWidth: 1,
+  },
+  backButton: {
+    width: wp(10),
+    height: wp(10),
+    borderRadius: wp(5),
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  headerTitle: {
+    fontSize: fp(5.2),
+    fontWeight: '700',
+  },
+  scroll: {
+    paddingHorizontal: wp(4),
+    paddingTop: hp(2.5),
+    paddingBottom: hp(6),
+  },
+  typeBadge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: hp(0.5),
+    paddingHorizontal: wp(3),
+    borderRadius: 16,
+    borderWidth: 1,
+    alignSelf: 'flex-start',
+    marginBottom: hp(1.5),
+  },
+  badgeIcon: {
+    marginRight: 6,
+  },
+  typeText: {
+    fontSize: fp(3.2),
+    fontWeight: '700',
+  },
+  title: {
+    fontSize: fp(5.6),
+    fontWeight: '800',
+    lineHeight: fp(7),
+    marginBottom: hp(2.2),
+  },
+  sectionCard: {
+    borderRadius: 16,
+    borderWidth: 1,
+    padding: wp(4.5),
+    marginBottom: hp(2),
+    elevation: 1,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.03,
+    shadowRadius: 6,
+  },
+  organizerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  iconContainer: {
+    width: wp(10),
+    height: wp(10),
+    borderRadius: wp(3),
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginRight: wp(3.5),
+  },
+  organizerDetails: {
+    flex: 1,
+  },
+  sectionTitle: {
+    fontSize: fp(4.2),
+    fontWeight: '700',
+    marginBottom: hp(1.8),
+  },
+  infoRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    paddingVertical: hp(1),
+  },
+  infoIcon: {
+    marginRight: wp(3.5),
+    marginTop: 2,
+  },
+  infoTextWrapper: {
+    flex: 1,
+  },
+  infoLabel: {
+    fontSize: fp(2.8),
+    fontWeight: '700',
+    letterSpacing: 0.5,
+    marginBottom: 2,
+  },
+  infoValue: {
+    fontSize: fp(3.8),
+    fontWeight: '600',
+  },
+  divider: {
+    height: 1,
+    marginVertical: hp(0.5),
+  },
+  directionsButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: hp(1.5),
+    borderRadius: 12,
+    marginTop: hp(2),
+  },
+  directionsText: {
+    color: 'white',
+    fontSize: fp(3.8),
+    fontWeight: '700',
+  },
+  description: {
+    fontSize: fp(3.8),
+    lineHeight: fp(5.6),
+    fontWeight: '400',
+  },
+  footnoteWrapper: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginTop: hp(1),
+  },
+  footnote: {
+    fontSize: fp(2.8),
+    fontWeight: '500',
+    marginLeft: wp(1.5),
+  },
+});

--- a/frontend/src/screens/settings/NearbyHealthEventsScreen.tsx
+++ b/frontend/src/screens/settings/NearbyHealthEventsScreen.tsx
@@ -1,0 +1,454 @@
+import React, { useState, useEffect, ComponentProps } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  FlatList,
+  TouchableOpacity,
+  useColorScheme,
+  Alert,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { StatusBar } from 'expo-status-bar';
+import * as Location from 'expo-location';
+import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
+import MaterialIcons from '@expo/vector-icons/MaterialIcons';
+import FontAwesome6 from '@expo/vector-icons/FontAwesome6';
+
+import { PRIMARY_COLOR } from '../../lib/ui/Theme';
+import { wp, hp, fp } from '../../lib/ui/Metric';
+import { useGetNearbyEvents } from '../../hooks/events/useGetNearbyEvents';
+import { calculateDistance, formatDistance } from '../../lib/utils/LocationUtils';
+import { formatDateShortYear } from '../../lib/utils/dateUtils';
+import { BaseEmptyState } from '../../components/common/EmptyStates';
+import LoadingSpinner from '../../components/common/LoadingSpinner';
+import { HealthEvent, RootStackParamList } from '../../schemas/type';
+import { StackScreenProps } from '@react-navigation/stack';
+import { debugError } from '../../lib/utils/debugLog';
+
+type NearbyHealthEventsScreenProps = StackScreenProps<
+  RootStackParamList,
+  'NearbyHealthEventsScreen'
+>;
+
+type EventTheme = {
+  bg: string;
+  text: string;
+  icon: ComponentProps<typeof MaterialCommunityIcons>['name'];
+};
+
+const EVENT_TYPE_THEMES: Record<string, EventTheme> = {
+  'Blood Donation Drive': { bg: 'rgba(239, 68, 68, 0.1)', text: '#EF4444', icon: 'water' },
+  'Health Camp': { bg: 'rgba(59, 130, 246, 0.1)', text: '#3B82F6', icon: 'hospital-box' },
+  'Yoga / Wellness Meetup': { bg: 'rgba(16, 185, 129, 0.1)', text: '#10B981', icon: 'spa' },
+  'Community Health Event': { bg: 'rgba(139, 92, 246, 0.1)', text: '#8B5CF6', icon: 'account-group' },
+};
+
+const DEFAULT_EVENT_THEME: EventTheme = {
+  bg: 'rgba(107, 114, 128, 0.1)',
+  text: '#6B7280',
+  icon: 'calendar',
+};
+
+const RADIUS_OPTIONS = [
+  { label: '5 km', value: 5000 },
+  { label: '10 km', value: 10000 },
+  { label: '25 km', value: 25000 },
+  { label: '50 km', value: 50000 },
+];
+
+const NearbyHealthEventsScreen = ({ navigation }: NearbyHealthEventsScreenProps) => {
+  const isDark = useColorScheme() === 'dark';
+  const [coords, setCoords] = useState<{ latitude: number; longitude: number } | null>(null);
+  const [permissionStatus, setPermissionStatus] = useState<Location.PermissionStatus | null>(null);
+  const [isLocating, setIsLocating] = useState(false);
+  const [radius, setRadius] = useState(10000); // Default 10km
+
+  const bg = isDark ? '#111827' : '#F9FAFB';
+  const cardBg = isDark ? '#1F2937' : '#FFFFFF';
+  const cardBorder = isDark ? '#374151' : '#E5E7EB';
+  const textColor = isDark ? '#F9FAFB' : '#111827';
+  const subtextColor = isDark ? '#9CA3AF' : '#6B7280';
+  const headerBg = isDark ? '#1F2937' : '#FFFFFF';
+  const headerBorder = isDark ? '#374151' : '#E5E7EB';
+
+  const requestLocation = async () => {
+    setIsLocating(true);
+    try {
+      const { status } = await Location.requestForegroundPermissionsAsync();
+      setPermissionStatus(status);
+      if (status !== Location.PermissionStatus.GRANTED) {
+        setIsLocating(false);
+        return;
+      }
+
+      const location = await Location.getCurrentPositionAsync({
+        accuracy: Location.Accuracy.Balanced,
+      });
+      setCoords({
+        latitude: location.coords.latitude,
+        longitude: location.coords.longitude,
+      });
+    } catch (error) {
+      debugError('Error requesting location:', error);
+      Alert.alert('Error', 'Failed to retrieve your current location. Please make sure location is enabled.');
+    } finally {
+      setIsLocating(false);
+    }
+  };
+
+  useEffect(() => {
+    requestLocation();
+  }, []);
+
+  const {
+    data: events,
+    isLoading: isQueryLoading,
+    isError,
+    refetch,
+    isRefetching,
+  } = useGetNearbyEvents(
+    coords ? coords.latitude : null,
+    coords ? coords.longitude : null,
+    radius,
+  );
+
+  const getEventTypeTheme = (type: string): EventTheme => {
+    return EVENT_TYPE_THEMES[type] || DEFAULT_EVENT_THEME;
+  };
+
+  const renderEventItem = ({ item }: { item: HealthEvent }) => {
+    const theme = getEventTypeTheme(item.type);
+    let distanceStr = '';
+    let meters: number | undefined = undefined;
+    if (coords && item.location?.coordinates) {
+      const [lng, lat] = item.location.coordinates;
+      meters = calculateDistance(coords.latitude, coords.longitude, lat, lng);
+      distanceStr = formatDistance(meters);
+    }
+
+    return (
+      <TouchableOpacity
+        activeOpacity={0.7}
+        onPress={() => navigation.navigate('EventDetailsScreen', { event: item, distance: meters })}
+        style={[styles.card, { backgroundColor: cardBg, borderColor: cardBorder }]}
+        accessibilityLabel={`View event details for ${item.title}`}
+        accessibilityRole="button"
+      >
+        <View style={styles.cardHeader}>
+          <View style={[styles.typeBadge, { backgroundColor: theme.bg }]}>
+            <MaterialCommunityIcons name={theme.icon} size={14} color={theme.text} style={styles.badgeIcon} />
+            <Text style={[styles.typeText, { color: theme.text }]}>{item.type}</Text>
+          </View>
+          {distanceStr ? (
+            <View style={styles.distanceBadge}>
+              <MaterialIcons name="navigation" size={12} color={PRIMARY_COLOR} />
+              <Text style={styles.distanceText}>{distanceStr}</Text>
+            </View>
+          ) : null}
+        </View>
+
+        <Text style={[styles.title, { color: textColor }]} numberOfLines={2}>
+          {item.title}
+        </Text>
+
+        <Text style={[styles.organizer, { color: subtextColor }]} numberOfLines={1}>
+          Organizer: {item.organizer}
+        </Text>
+
+        <View style={[styles.divider, { backgroundColor: cardBorder }]} />
+
+        <View style={styles.cardFooter}>
+          <View style={styles.footerItem}>
+            <MaterialCommunityIcons name="calendar" size={16} color={subtextColor} />
+            <Text style={[styles.footerText, { color: subtextColor }]}>
+              {formatDateShortYear(item.date)}
+            </Text>
+          </View>
+          <View style={styles.footerItem}>
+            <MaterialCommunityIcons name="clock-outline" size={16} color={subtextColor} />
+            <Text style={[styles.footerText, { color: subtextColor }]}>{item.time}</Text>
+          </View>
+        </View>
+
+        <View style={[styles.footerItem, { marginTop: hp(0.8) }]}>
+          <MaterialCommunityIcons name="map-marker-outline" size={16} color={subtextColor} />
+          <Text style={[styles.footerText, { color: subtextColor }]} numberOfLines={1}>
+            {item.address}
+          </Text>
+        </View>
+      </TouchableOpacity>
+    );
+  };
+
+  const handleRetry = () => {
+    if (permissionStatus !== Location.PermissionStatus.GRANTED) {
+      requestLocation();
+    } else {
+      refetch();
+    }
+  };
+
+  const renderContent = () => {
+    if (isLocating) {
+      return (
+        <LoadingSpinner
+          fullScreen
+          text="Retrieving your location..."
+          subText="Ensuring we look up the right wellness events near you."
+        />
+      );
+    }
+
+    if (permissionStatus === null) {
+      return null;
+    }
+
+    if (permissionStatus !== Location.PermissionStatus.GRANTED) {
+      return (
+        <BaseEmptyState
+          iconEmoji="🔒"
+          title="Location Permission Required"
+          description="UltimateHealth needs location access to find blood drives, wellness camps, and fitness drives in your neighborhood."
+          actionText="Allow Location Access"
+          onAction={requestLocation}
+        />
+      );
+    }
+
+    if (isQueryLoading) {
+      return (
+        <LoadingSpinner
+          fullScreen
+          text="Searching for health events..."
+          subText="Connecting to the backend to get active drives near you."
+        />
+      );
+    }
+
+    if (isError) {
+      return (
+        <BaseEmptyState
+          iconEmoji="⚠️"
+          title="Failed to Load Events"
+          description="A network issue occurred while retrieving events. Please check your connection and try again."
+          actionText="Try Again"
+          onAction={handleRetry}
+        />
+      );
+    }
+
+    if (!events || events.length === 0) {
+      return (
+        <BaseEmptyState
+          iconEmoji="📍"
+          title="No Nearby Events"
+          description={`We couldn't find any health events within ${radius / 1000} km of your location.`}
+          actionText="Refresh"
+          onAction={refetch}
+        />
+      );
+    }
+
+    return (
+      <FlatList
+        data={events}
+        renderItem={renderEventItem}
+        keyExtractor={(item) => item._id}
+        contentContainerStyle={styles.list}
+        showsVerticalScrollIndicator={false}
+        refreshing={isRefetching}
+        onRefresh={refetch}
+      />
+    );
+  };
+
+  return (
+    <SafeAreaView style={[styles.container, { backgroundColor: bg }]}>
+      <StatusBar style={isDark ? 'light' : 'dark'} />
+
+      {/* Header */}
+      <View style={[styles.header, { backgroundColor: headerBg, borderBottomColor: headerBorder }]}>
+        <TouchableOpacity
+          style={styles.backButton}
+          onPress={() => navigation.goBack()}
+          accessibilityLabel="Go back"
+          accessibilityRole="button"
+        >
+          <FontAwesome6 name="arrow-left" size={18} color={textColor} />
+        </TouchableOpacity>
+        <Text style={[styles.headerTitle, { color: textColor }]}>Nearby Health Events</Text>
+        <View style={{ width: wp(10) }} />
+      </View>
+
+      {/* Radius Selector */}
+      {permissionStatus === Location.PermissionStatus.GRANTED && !isLocating && (
+        <View style={styles.selectorWrapper}>
+          <Text style={[styles.selectorLabel, { color: textColor }]}>Search Radius:</Text>
+          <View style={styles.pillContainer}>
+            {RADIUS_OPTIONS.map((opt) => {
+              const active = radius === opt.value;
+              return (
+                <TouchableOpacity
+                  key={opt.value}
+                  activeOpacity={0.8}
+                  onPress={() => setRadius(opt.value)}
+                  style={[
+                    styles.pill,
+                    active && { backgroundColor: PRIMARY_COLOR },
+                    !active && { borderColor: cardBorder },
+                  ]}
+                  accessibilityLabel={`Filter by radius ${opt.label}`}
+                  accessibilityRole="button"
+                  accessibilityState={{ selected: active }}
+                >
+                  <Text
+                    style={[
+                      styles.pillText,
+                      { color: active ? 'white' : textColor },
+                    ]}
+                  >
+                    {opt.label}
+                  </Text>
+                </TouchableOpacity>
+              );
+            })}
+          </View>
+        </View>
+      )}
+
+      {renderContent()}
+    </SafeAreaView>
+  );
+};
+
+export default NearbyHealthEventsScreen;
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: wp(4),
+    paddingVertical: hp(1.5),
+    borderBottomWidth: 1,
+  },
+  backButton: {
+    width: wp(10),
+    height: wp(10),
+    borderRadius: wp(5),
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  headerTitle: {
+    fontSize: fp(5.2),
+    fontWeight: '700',
+  },
+  selectorWrapper: {
+    paddingHorizontal: wp(4),
+    paddingTop: hp(1.5),
+    paddingBottom: hp(1),
+  },
+  selectorLabel: {
+    fontSize: fp(3.5),
+    fontWeight: '600',
+    marginBottom: hp(0.8),
+  },
+  pillContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  pill: {
+    paddingVertical: hp(0.8),
+    paddingHorizontal: wp(3.5),
+    borderRadius: 20,
+    borderWidth: 1,
+    marginRight: wp(2.5),
+  },
+  pillText: {
+    fontSize: fp(3.2),
+    fontWeight: '600',
+  },
+  list: {
+    paddingHorizontal: wp(4),
+    paddingTop: hp(1),
+    paddingBottom: hp(4),
+  },
+  card: {
+    borderRadius: 16,
+    borderWidth: 1,
+    padding: wp(4),
+    marginBottom: hp(1.8),
+    elevation: 2,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.05,
+    shadowRadius: 8,
+  },
+  cardHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: hp(1),
+  },
+  typeBadge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: hp(0.4),
+    paddingHorizontal: wp(2.5),
+    borderRadius: 12,
+  },
+  badgeIcon: {
+    marginRight: 4,
+  },
+  typeText: {
+    fontSize: fp(3),
+    fontWeight: '700',
+  },
+  distanceBadge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: 'rgba(0, 191, 255, 0.08)',
+    paddingVertical: hp(0.4),
+    paddingHorizontal: wp(2.5),
+    borderRadius: 12,
+  },
+  distanceText: {
+    fontSize: fp(3),
+    fontWeight: '700',
+    color: PRIMARY_COLOR,
+    marginLeft: 3,
+  },
+  title: {
+    fontSize: fp(4.2),
+    fontWeight: '700',
+    lineHeight: fp(5.2),
+    marginBottom: hp(0.5),
+  },
+  organizer: {
+    fontSize: fp(3.2),
+    fontWeight: '500',
+    marginBottom: hp(1.2),
+  },
+  divider: {
+    height: 1,
+    marginVertical: hp(1),
+  },
+  cardFooter: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  footerItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginRight: wp(6),
+  },
+  footerText: {
+    fontSize: fp(3.2),
+    marginLeft: wp(1.5),
+    fontWeight: '500',
+  },
+});

--- a/frontend/src/screens/settings/SettingsScreen.tsx
+++ b/frontend/src/screens/settings/SettingsScreen.tsx
@@ -215,6 +215,15 @@ const SettingsScreen = ({ navigation }: SettingsScreenProps) => {
             onPress={() => go('WellnessDashboardScreen')}
             isDark={isDark}
           />
+          <View style={[styles.divider, { backgroundColor: isDark ? '#374151' : '#F3F4F6' }]} />
+          <SettingsRow
+            icon="map-marker-radius-outline"
+            iconColor="#10B981"
+            label="Nearby Health Events"
+            sublabel="Blood drives, health camps, meetups"
+            onPress={() => go('NearbyHealthEventsScreen')}
+            isDark={isDark}
+          />
         </View>
 
         {/* ── LEGAL & PRIVACY ── */}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -8872,6 +8872,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"expo-location@npm:^57.0.8":
+  version: 57.0.9
+  resolution: "expo-location@npm:57.0.9"
+  dependencies:
+    "@expo/image-utils": "npm:^0.11.4"
+  peerDependencies:
+    expo: "*"
+  checksum: 10c0/6b7c4ba484dba3421b7614878d78ed695e87fd97cffd5f7ac19e96dcd32a0f583bb2627312e0f59b7598c92a2c1e9c5b7ee3e5bc94f0a309798716c0021e237f
+  languageName: node
+  linkType: hard
+
 "expo-manifests@npm:~57.0.1":
   version: 57.0.1
   resolution: "expo-manifests@npm:57.0.1"
@@ -15379,6 +15390,7 @@ __metadata:
     expo-linear-gradient: "npm:~57.0.0"
     expo-linking: "npm:~57.0.4"
     expo-localization: "npm:~57.0.0"
+    expo-location: "npm:^57.0.8"
     expo-notifications: "npm:~57.0.7"
     expo-secure-store: "npm:~57.0.0"
     expo-speech: "npm:~57.0.0"


### PR DESCRIPTION
LiveReview Pre-Commit Check: ran (iter:4, coverage:98%)

## Summary

Implemented the "Localizing the Global Community — Nearby Health Events" feature in the UltimateHealth frontend.

The feature allows users to discover health-related events near their current location, filter events by radius, view event details, calculate distance, and get directions.

## Changes Made

### Frontend
- Added `NearbyHealthEventsScreen`
- Added `EventDetailsScreen`
- Added `useGetNearbyEvents` React Query hook
- Added Haversine-based distance calculation and distance formatting
- Added location permission handling using `expo-location`
- Added 5 km, 10 km, 25 km and 50 km radius filters
- Added event details including organizer, date, time, address and description
- Added Google Maps directions support
- Added accessibility labels and selected-state support
- Added navigation entries for the new screens
- Added nearby events API integration
- Added required Android and iOS location permissions
- Added TypeScript types for health events

### Backend Integration

The frontend integrates with the existing:

`GET /api/events/nearby`

API using:
- latitude
- longitude
- radius

The backend geospatial query returns nearby events using GeoJSON coordinates.

## Verification

- TypeScript type-check: PASS
- ESLint: PASS
- `git diff --cached --check`: PASS
- Backend API integration verified
- Location permission and error states implemented
- No mock event data included in the feature

## Testing

The feature was verified against the existing backend API and the implementation was checked for TypeScript and lint errors.

## Related Issue

Closes #2275 
