### PR TITLE
fix(web): order landing sections to match the navigation

### DIFF
--- a/web/src/app/[locale]/page.tsx
+++ b/web/src/app/[locale]/page.tsx
@@ -658,8 +658,8 @@ export default function Home() {
         </PageWrapper>
 
         <nav className={`mobile-nav${mobileMenuOpen ? " open" : ""}`}>
-          <a href="#screenshots" onClick={() => setMobileMenuOpen(false)}>App Experience</a>
           <a href="#features" onClick={() => setMobileMenuOpen(false)}>Platform Highlights</a>
+          <a href="#screenshots" onClick={() => setMobileMenuOpen(false)}>App Experience</a>
           <a href="#programs" onClick={() => setMobileMenuOpen(false)}>Community Programs</a>
           <Link href={withBasePath("/articles")} onClick={() => setMobileMenuOpen(false)}>Read Articles</Link>
           <Link href={withBasePath("/medical-glossary")} onClick={() => setMobileMenuOpen(false)}>Medical Glossary</Link>
@@ -677,90 +677,6 @@ export default function Home() {
         onJoinTestFlight={openAppleModal}
         onShowComingSoon={openComingSoonModal}
       />
-
-      {/* ── Screenshots ── */}
-      <Section id="screenshots">
-        <PageWrapper>
-          <h2>App Experience</h2>
-          <p className="center">A closer look at what UltimateHealth offers, screen by screen</p>
-
-          <div className="screenshot-details">
-            <div className="screenshot-summary" onClick={() => setUserSliderOpen((o) => !o)} role="button" tabIndex={0}
-              onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") setUserSliderOpen((o) => !o); }}>
-              <span style={{ color: "var(--primary)" }}>{userSliderOpen ? "▼" : "▶"}</span> UltimateHealth App
-            </div>
-            {userSliderOpen && (
-              <div className="screenshot-slider-container">
-                <div className="screenshots-wrapper" ref={userSliderRef}>
-                  {extendedUserScreenshots.map((s, i) => (
-                    <div
-                      key={`user-${i}`}
-                      className="screenshot-box"
-                      onClick={() => openScreenshotModal(s.src)}
-                      onKeyDown={(e) => handleScreenshotCardKeyDown(e, s.src)}
-                      role="button"
-                      tabIndex={0}
-                      aria-label={`Open ${s.caption} screenshot`}
-                    >
-                      <div className="screenshot-image-frame">
-                        <Image
-                          src={s.src}
-                          alt={s.caption}
-                          fill
-                          sizes="(max-width: 768px) 260px, 300px"
-                          className="screenshot-image"
-                        />
-                      </div>
-                      <div className="screenshot-card-caption">{s.caption}</div>
-                    </div>
-                  ))}
-                </div>
-                <div className="slider-nav">
-                  <button className="nav-btn" type="button" aria-label="Previous UltimateHealth screenshot" onClick={() => handleManualSlide(userSliderRef, -1, userScreenshots.length)}><i className="fas fa-chevron-left"></i></button>
-                  <button className="nav-btn" type="button" aria-label="Next UltimateHealth screenshot" onClick={() => handleManualSlide(userSliderRef, 1, userScreenshots.length)}><i className="fas fa-chevron-right"></i></button>
-                </div>
-              </div>
-            )}
-          </div>
-
-          <div className="screenshot-details">
-            <div className="screenshot-summary" onClick={() => setAdminSliderOpen((o) => !o)} role="button" tabIndex={0}
-              onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") setAdminSliderOpen((o) => !o); }}>
-              <span style={{ color: "var(--primary)" }}>{adminSliderOpen ? "▼" : "▶"}</span> UHealth Admin App
-            </div>
-            {adminSliderOpen && (
-              <div className="screenshot-slider-container">
-                <div className="screenshots-wrapper" ref={adminSliderRef}>
-                  {extendedAdminScreenshots.map((s, i) => (
-                    <div
-                      key={`admin-${i}`}
-                      className="screenshot-box"
-                      onClick={() => openScreenshotModal(s.src)}
-                      onKeyDown={(e) => handleScreenshotCardKeyDown(e, s.src)}
-                      role="button"
-                      tabIndex={0}
-                      aria-label={`Open ${s.caption} screenshot`}
-                    >
-                      <Image
-                        src={s.src}
-                        alt={s.caption}
-                        fill
-                        sizes="(max-width: 768px) 260px, 300px"
-                        className="screenshot-image"
-                      />
-                      <div className="screenshot-card-caption">{s.caption}</div>
-                    </div>
-                  ))}
-                </div>
-                <div className="slider-nav">
-                  <button className="nav-btn" type="button" aria-label="Previous UHealth Admin screenshot" onClick={() => handleManualSlide(adminSliderRef, -1, adminScreenshots.length)}><i className="fas fa-chevron-left"></i></button>
-                  <button className="nav-btn" type="button" aria-label="Next UHealth Admin screenshot" onClick={() => handleManualSlide(adminSliderRef, 1, adminScreenshots.length)}><i className="fas fa-chevron-right"></i></button>
-                </div>
-              </div>
-            )}
-          </div>
-        </PageWrapper>
-      </Section>
 
       {/* ── Features ── */}
       <Section id="features" className="feature-section-premium scroll-reveal">
@@ -928,6 +844,90 @@ export default function Home() {
                 </div>
               ))}
             </div>
+          </div>
+        </PageWrapper>
+      </Section>
+
+      {/* ── Screenshots ── */}
+      <Section id="screenshots">
+        <PageWrapper>
+          <h2>App Experience</h2>
+          <p className="center">A closer look at what UltimateHealth offers, screen by screen</p>
+
+          <div className="screenshot-details">
+            <div className="screenshot-summary" onClick={() => setUserSliderOpen((o) => !o)} role="button" tabIndex={0}
+              onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") setUserSliderOpen((o) => !o); }}>
+              <span style={{ color: "var(--primary)" }}>{userSliderOpen ? "▼" : "▶"}</span> UltimateHealth App
+            </div>
+            {userSliderOpen && (
+              <div className="screenshot-slider-container">
+                <div className="screenshots-wrapper" ref={userSliderRef}>
+                  {extendedUserScreenshots.map((s, i) => (
+                    <div
+                      key={`user-${i}`}
+                      className="screenshot-box"
+                      onClick={() => openScreenshotModal(s.src)}
+                      onKeyDown={(e) => handleScreenshotCardKeyDown(e, s.src)}
+                      role="button"
+                      tabIndex={0}
+                      aria-label={`Open ${s.caption} screenshot`}
+                    >
+                      <div className="screenshot-image-frame">
+                        <Image
+                          src={s.src}
+                          alt={s.caption}
+                          fill
+                          sizes="(max-width: 768px) 260px, 300px"
+                          className="screenshot-image"
+                        />
+                      </div>
+                      <div className="screenshot-card-caption">{s.caption}</div>
+                    </div>
+                  ))}
+                </div>
+                <div className="slider-nav">
+                  <button className="nav-btn" type="button" aria-label="Previous UltimateHealth screenshot" onClick={() => handleManualSlide(userSliderRef, -1, userScreenshots.length)}><i className="fas fa-chevron-left"></i></button>
+                  <button className="nav-btn" type="button" aria-label="Next UltimateHealth screenshot" onClick={() => handleManualSlide(userSliderRef, 1, userScreenshots.length)}><i className="fas fa-chevron-right"></i></button>
+                </div>
+              </div>
+            )}
+          </div>
+
+          <div className="screenshot-details">
+            <div className="screenshot-summary" onClick={() => setAdminSliderOpen((o) => !o)} role="button" tabIndex={0}
+              onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") setAdminSliderOpen((o) => !o); }}>
+              <span style={{ color: "var(--primary)" }}>{adminSliderOpen ? "▼" : "▶"}</span> UHealth Admin App
+            </div>
+            {adminSliderOpen && (
+              <div className="screenshot-slider-container">
+                <div className="screenshots-wrapper" ref={adminSliderRef}>
+                  {extendedAdminScreenshots.map((s, i) => (
+                    <div
+                      key={`admin-${i}`}
+                      className="screenshot-box"
+                      onClick={() => openScreenshotModal(s.src)}
+                      onKeyDown={(e) => handleScreenshotCardKeyDown(e, s.src)}
+                      role="button"
+                      tabIndex={0}
+                      aria-label={`Open ${s.caption} screenshot`}
+                    >
+                      <Image
+                        src={s.src}
+                        alt={s.caption}
+                        fill
+                        sizes="(max-width: 768px) 260px, 300px"
+                        className="screenshot-image"
+                      />
+                      <div className="screenshot-card-caption">{s.caption}</div>
+                    </div>
+                  ))}
+                </div>
+                <div className="slider-nav">
+                  <button className="nav-btn" type="button" aria-label="Previous UHealth Admin screenshot" onClick={() => handleManualSlide(adminSliderRef, -1, adminScreenshots.length)}><i className="fas fa-chevron-left"></i></button>
+                  <button className="nav-btn" type="button" aria-label="Next UHealth Admin screenshot" onClick={() => handleManualSlide(adminSliderRef, 1, adminScreenshots.length)}><i className="fas fa-chevron-right"></i></button>
+                </div>
+              </div>
+            )}
           </div>
         </PageWrapper>
       </Section>


### PR DESCRIPTION
Closes #1948

## Problem

The landing page navigation lists **Platform Highlights** (`#features`) before **App Experience** (`#screenshots`), but the page rendered `<Section id="screenshots">` before `<Section id="features">`. Scrolling therefore reached the two sections in the opposite order to the nav tabs.

The mobile menu had the same two links in the reverse order to the desktop nav, so the two menus disagreed with each other as well.

## Changes

`web/src/app/[locale]/page.tsx`:

- Moved the `#features` section above the `#screenshots` section so the scroll order is Hero → Platform Highlights → App Experience → Community Programs → Contact, matching the nav.
- Swapped the `#features` / `#screenshots` entries in the mobile menu so it matches the desktop nav order.

The section move is a **pure reorder** — the JSX inside both blocks is byte-for-byte unchanged (85 insertions / 85 deletions is the same block relocated). No markup, styling, ids, anchors, or logic were touched, so all `#features` / `#screenshots` anchors, the `IntersectionObserver` active-tab highlighting, and the screenshot carousels behave exactly as before.

## Verification

Run from `web/`:

- **Lossless reorder:** programmatically un-swapped the two blocks and diffed against the original file — byte-identical.
- **`npx eslint "src/app/[locale]/page.tsx"`:** 0 errors. The 2 warnings (unused `Navbar` import, unused `_realCount` param) are pre-existing and untouched.
- **`npx tsc --noEmit`:** output is **byte-identical before and after** this change (one pre-existing `HeroAndDownload` prop error at `page.tsx:677`, in the hero block this PR does not touch).
- **`npm test`:** 14/15 pass. The one failure — `landing-performance.test.mjs > "the landing page is a server component"` — is **pre-existing on `web`**: `page.tsx` currently starts with `"use client"`. I confirmed it fails identically on a clean checkout of `web` before this change.

Both pre-existing failures are left alone to keep this PR scoped to the issue; happy to open separate issues for them if useful.

## Checklist

- [x] Targets the `web` branch
- [x] Branch follows the `fix/web-<bug-name>` convention
- [x] No unrelated files included
- [x] Single, clean commit
