### PR TITLE
fix(web): prevent auth inputs from overflowing

### DIFF
--- a/web/src/components/auth/AuthShell.tsx
+++ b/web/src/components/auth/AuthShell.tsx
@@ -45,7 +45,7 @@ export default function AuthShell({
           width === "lg" ? "max-w-xl" : "max-w-md"
         )}
       >
-        <div className="rounded-3xl border border-white/70 bg-white shadow-xl transition-colors duration-300 dark:border-white/10 dark:bg-slate-900 dark:shadow-xl">
+        <div className="min-w-0 max-w-full rounded-3xl border border-white/70 bg-white shadow-xl transition-colors duration-300 dark:border-white/10 dark:bg-slate-900 dark:shadow-xl">
           <div className="flex flex-col items-center gap-3 px-6! pt-8! text-center sm:px-9!">
             <Link
               href={withBasePath("/")}
@@ -73,7 +73,9 @@ export default function AuthShell({
             />
           </div>
 
-          <div className="px-6! py-7! sm:px-9!">{children}</div>
+          <div className="w-full min-w-0 max-w-full px-6! py-7! sm:px-9!">
+            {children}
+          </div>
         </div>
 
         {footer && (
@@ -88,7 +90,7 @@ export default function AuthShell({
 
 /** Input styling shared by every auth field, so focus states stay consistent. */
 export const authFieldClass =
-  "h-11! px-3.5! rounded-xl border-slate-200 bg-white/70 text-slate-900 shadow-sm transition-all duration-200 placeholder:text-slate-400 focus-visible:border-[#667eea] focus-visible:ring-4 focus-visible:ring-[#667eea]/15 dark:border-white/10 dark:bg-white/5 dark:text-slate-100 dark:placeholder:text-slate-500 dark:focus-visible:border-[#818cf8] dark:focus-visible:ring-[#818cf8]/20";
+   "h-11! w-full max-w-full min-w-0 px-3.5! rounded-xl border-slate-200 bg-white/70 text-slate-900 shadow-sm transition-all duration-200 placeholder:text-slate-400 focus-visible:border-[#667eea] focus-visible:ring-4 focus-visible:ring-[#667eea]/15 dark:border-white/10 dark:bg-white/5 dark:text-slate-100 dark:placeholder:text-slate-500 dark:focus-visible:border-[#818cf8] dark:focus-visible:ring-[#818cf8]/20";
 
 /** The primary action on every auth form. */
 export const authSubmitClass =


### PR DESCRIPTION
## PR Description

Fixes the responsive login input overflow reported in issue #1545.

The authentication card and its content wrapper are now explicitly constrained to the available width. Auth input fields also use responsive width constraints so they cannot exceed their parent container on narrow screens.

### Changes

- Added `min-w-0` and `max-w-full` to the authentication card.
- Added `w-full`, `min-w-0`, and `max-w-full` to the authentication content wrapper.
- Added `w-full`, `min-w-0`, and `max-w-full` to the shared authentication input styling.
- Tested the login page at narrow viewport widths, including 280px and 320px.

## Type of Change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update

## Select your work-area

- [x] Frontend
- [ ] Backend
- [ ] Documentation
- [ ] Others

## Related Issue

https://github.com/SB2318/UltimateHealth/issues/1545

## Add your Work Example

📷 Add a Snapshot

## Fixes

#closes #1545

## Checklist

- [ ] I have updated my branch and synced it with the project's 'develop' branch before making this PR.
- [x] I have optimized the file changes.
- [x] I have added a snapshot of my work example.
- [ ] I have made a PR to the project's develop branch.

## Undertaking

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have checked for plagiarism and assure its authenticity.
- [x] I have read and followed the code of conduct for this repository. I understand that violation of this undertaking may have legal consequences.

- [x] I Agree