### PR TITLE
Fix #2362: use stable key (item._id) instead of index for category chips

### DIFF
--- a/frontend/src/components/article/FilterModal.tsx
+++ b/frontend/src/components/article/FilterModal.tsx
@@ -258,9 +258,9 @@ const FilterModal = ({
                   <Text style={styles.selectedCategoriesLabel}>Selected:</Text>
                   <ScrollView horizontal showsHorizontalScrollIndicator={false}>
                     <View style={styles.selectedCategoriesChips}>
-                      {selectCategoryList.map((item, index) => (
+                      {selectCategoryList.map((item) => (
                         <TouchableOpacity
-                          key={index}
+                          key={item._id}
                           style={styles.selectedCategoryChip}
                           onPress={() => handleCategorySelection(item)}>
                           <Text style={styles.selectedCategoryChipText}>
@@ -275,7 +275,7 @@ const FilterModal = ({
               )}
 
               <View style={styles.categoryGrid}>
-                {filteredCategories.map((item, index) => {
+                {filteredCategories.map((item) => {
                   const isSelected = selectCategoryList.some(i => 
                     (i.id !== undefined && item?.id !== undefined && i.id === item.id) ||
                     (i._id !== undefined && item?._id !== undefined && i._id === item._id) ||
@@ -283,7 +283,7 @@ const FilterModal = ({
                   );
                   return (
                     <TouchableOpacity
-                      key={index}
+                      key={item._id}
                       style={[
                         styles.categoryCard,
                         isSelected && styles.categoryCardSelected,

--- a/frontend/src/screens/home/HomeScreen.tsx
+++ b/frontend/src/screens/home/HomeScreen.tsx
@@ -721,11 +721,11 @@ useEffect(() => {
             {selectedTags &&
               selectedTags.length > 0 &&
               !searchMode &&
-              selectedTags.map((item: Category, index: number) => {
+              selectedTags.map((item: Category) => {
                 const isActive = selectedCategory && (selectedCategory._id === item._id || selectedCategory.id === item.id || selectedCategory.name === item.name);
                 return (
                   <TouchableOpacity
-                    key={index}
+                    key={item._id}
                     style={{
                       ...styles.button,
                       backgroundColor: isActive ? '#000A60' : 'white',
@@ -881,7 +881,7 @@ useEffect(() => {
           {selectedTags &&
             selectedTags.length > 0 &&
             !searchMode &&
-            selectedTags.map((item: Category, index: number) => {
+            selectedTags.map((item: Category) => {
               // Category chips visually appear inactive when Saved filter is on —
               // they are still clickable to switch away from Saved mode.
               const isActive = !showSavedOnly &&
@@ -889,7 +889,7 @@ useEffect(() => {
                 (selectedCategory._id === item._id || selectedCategory.id === item.id || selectedCategory.name === item.name);
               return (
                 <TouchableOpacity
-                  key={index}
+                  key={item._id}
                   style={{
                     ...styles.button,
                     backgroundColor: isActive ? '#000A60' : 'white',


### PR DESCRIPTION


**Fixes #2362**

## Summary

This PR replaces `key={index}` with `key={item._id}` for the four `Category` list renders affected by this issue:

* `HomeScreen.tsx` — category chip row on the default home screen
* `HomeScreen.tsx` — category chip row in the saved-filter view
* `FilterModal.tsx` — selected categories chip row
* `FilterModal.tsx` — full category grid

`Category._id` is a unique string field defined in `schemas/type.ts`, so it provides a stable identity for these dynamic lists.

I also removed the unused `index` parameter from the affected `.map()` callbacks since it was only needed for the React key.

## Why

These category lists can change as users add and remove categories, including removing items from the middle of the list.

Previously, using the array index as the key meant React was identifying items by their position rather than by the category itself. For example, if the first selected category was removed, every category after it would shift one position. React could then reuse the previous component instance for a different category, which could lead to stale active states or `onPress` behavior for a render.

Using `item._id` gives each category a stable identity, so React can correctly track each chip even when the list changes.

## Changes

Updated:

* `frontend/src/screens/home/HomeScreen.tsx`
* `frontend/src/components/article/FilterModal.tsx`

## Verification

*  Ran `npx tsc --noEmit` — no new type errors were introduced in the affected files.
*  Checked `CategoriesFlatlistModal.tsx` for the same pattern. It already uses a proper `keyExtractor={(item) => item.id.toString()}` with `BottomSheetFlatList`, so no change was needed there.
*  Manually verified the behavior by:

  * Adding multiple categories
  * Removing the first category
  * Removing a middle category
  * Removing the last category
  * Re-adding a previously removed category
  * Switching between different filter combinations

In each case, the remaining chips and checklist items stayed associated with the correct category and retained the expected active state and behavior.
