### PR TITLE
fix: improve Go to Top button accessibility and add tooltip

### DIFF
--- a/web/src/components/ScrollToTop.tsx
+++ b/web/src/components/ScrollToTop.tsx
@@ -41,9 +41,10 @@ export default function ScrollToTop() {
     <button
       className="scroll-to-top"
       onClick={scrollToTop}
-      aria-label="Scroll to top"
+      aria-label="Scroll back to top"
+      title="Back to top"
     >
-      <svg className="progress-ring" width="56" height="56">
+      <svg className="progress-ring" width="56" height="56" aria-hidden="true">
         <circle
           cx="28"
           cy="28"
@@ -60,7 +61,7 @@ export default function ScrollToTop() {
         />
       </svg>
 
-      <span className="arrow">↑</span>
+      <span className="arrow" aria-hidden="true">↑</span>
     </button>
   );
 }


### PR DESCRIPTION
## Description
Fixes the unclear "Go to Top" button by adding a tooltip and proper accessibility label, so users and screen reader users can clearly understand what the button does.

## Changes
- Added `title="Back to top"` on the button for a hover tooltip
- Updated `aria-label` to `"Scroll back to top"` for clearer screen reader announcement
- Added `aria-hidden="true"` on the decorative SVG and arrow span so screen readers don't double-announce the icon content

## Testing
- Verified tooltip appears on hover (native browser tooltip)
- Verified `aria-label` and `title` attributes render correctly via DevTools inspection
- Verified `aria-hidden="true"` applied to SVG and arrow span
- Confirmed scroll-to-top click functionality still works as expected


Fixes #2348