### PR TITLE
fix(auth): redact OTP and registration error logs to stop credential leakage

### DIFF
--- a/frontend/src/screens/auth/OtpScreen.tsx
+++ b/frontend/src/screens/auth/OtpScreen.tsx
@@ -56,7 +56,6 @@ export default function OtpScreen({navigation, route}: OtpScreenProp) {
             });
           },
           onError: (error: AxiosError) => {
-            console.log('OTP ERROR', error);
             setErrorMessages(['The code you entered is invalid or has expired. Please try again.']);
             Alert.alert('Invalid or expired OTP', 'Please request a new code and try again.');
           },

--- a/frontend/src/screens/auth/SignUpScreenFirst.tsx
+++ b/frontend/src/screens/auth/SignUpScreenFirst.tsx
@@ -172,7 +172,6 @@ const SignupPageFirst = ({navigation}: SignUpScreenFirstProp) => {
                   });
               }
             } else {
-              console.log('Email Verification error', err);
               Snackbar.show({
                 text: 'An error occured, try again!',
                 duration: Snackbar.LENGTH_SHORT,
@@ -274,7 +273,6 @@ const SignupPageFirst = ({navigation}: SignUpScreenFirstProp) => {
                 );
             }
           } else {
-            console.log('General User Registration Error', err);
             Alert.alert('Registration failed', 'Please try again');
           }
         },

--- a/frontend/src/screens/auth/SignUpScreenSecond.tsx
+++ b/frontend/src/screens/auth/SignUpScreenSecond.tsx
@@ -129,7 +129,6 @@ const SignupPageSecond = ({navigation, route}: SignUpScreenSecondProp) => {
               }
             }
           } else {
-            console.log('General User Registration Error', err);
             Alert.alert('Registration failed', 'Please try again');
           }
         },


### PR DESCRIPTION
## Summary
Fixes #2365

Removes the unredacted `console.log(error)` calls in the OTP and registration flows that printed the raw axios error object — including the stringified request body with **email, OTP, password and phone number** — to device logs in production builds.

## Changes
- `frontend/src/screens/auth/OtpScreen.tsx`: removed `console.log('OTP ERROR', error)`
- `frontend/src/screens/auth/SignUpScreenFirst.tsx`: removed `console.log('Email Verification error', err)` and `console.log('General User Registration Error', err)`
- `frontend/src/screens/auth/SignUpScreenSecond.tsx`: removed `console.log('General User Registration Error', err)`

User-facing feedback via `Alert`/`Snackbar` is preserved. Same defect class as #2318, #2320 and #2352.

## Testing
- `yarn lint`
- `yarn type-check`
- `yarn test`
