### PR TITLE
fix: don't tear down session on 401 from auth-attempt endpoints (login/OTP/password)

### DIFF
--- a/frontend/src/__tests__/lib/api/SessionExpiry.test.ts
+++ b/frontend/src/__tests__/lib/api/SessionExpiry.test.ts
@@ -3,7 +3,12 @@ import {Alert} from 'react-native';
 import * as SecureStore from 'expo-secure-store';
 import authAxios from '../../../lib/api/authAxios';
 import store from '../../../store/ReduxStore';
-import {setUserHandle, setUserId, setUserToken} from '../../../store/UserSlice';
+import {
+  setGuestMode,
+  setUserHandle,
+  setUserId,
+  setUserToken,
+} from '../../../store/UserSlice';
 import {SECURE_KEYS} from '../../../lib/storage/SecureStorageUtils';
 import {
   resetSessionExpiredNotification,
@@ -25,6 +30,11 @@ let secureStoreData: Record<string, string> = {};
 let deleteGate: Promise<void> | null = null;
 
 const unauthorizedError = () => ({response: {status: 401}});
+
+const unauthorizedErrorFor = (url: string) => ({
+  response: {status: 401},
+  config: {url},
+});
 
 const flushMicrotasks = () => new Promise(resolve => setImmediate(resolve));
 
@@ -71,6 +81,7 @@ describe('401 session teardown', () => {
     store.dispatch(setUserToken('stale-token'));
     store.dispatch(setUserId('user-1'));
     store.dispatch(setUserHandle('@user'));
+    store.dispatch(setGuestMode(false));
   });
 
   afterEach(() => {
@@ -214,5 +225,48 @@ describe('401 session teardown', () => {
 
     expect(SecureStore.deleteItemAsync).not.toHaveBeenCalled();
     expect(store.getState().user.user_token).toBe('stale-token');
+  });
+
+  describe('auth-attempt 401 (#2366)', () => {
+    const authAttemptUrls = [
+      '/api/user/login',
+      '/api/user/register',
+      '/api/user/forgotpassword',
+      '/api/user/verifyOtp',
+      '/api/user/verifypassword',
+      '/api/user/update-password',
+      '/api/user/verifyEmail',
+      '/api/user/resend-verification-mail',
+    ];
+
+    it.each(authAttemptUrls)(
+      'does NOT tear down the session when %s rejects with 401',
+      async url => {
+        setupAxiosInterceptor();
+        const onError = getResponseErrorHandler();
+
+        const error = unauthorizedErrorFor(url);
+        await expect(onError(error)).rejects.toBe(error);
+
+        expect(SecureStore.deleteItemAsync).not.toHaveBeenCalled();
+        const state = store.getState().user;
+        expect(state.user_token).toBe('stale-token');
+        expect(state.isGuest).toBe(false);
+      },
+    );
+
+    it('tears down for a 401 on a protected resource (getprofile)', async () => {
+      setupAxiosInterceptor();
+      const onError = getResponseErrorHandler();
+
+      await expect(
+        onError(unauthorizedErrorFor('/api/user/getprofile')),
+      ).rejects.toBeDefined();
+
+      expect(SecureStore.deleteItemAsync).toHaveBeenCalledWith(
+        SECURE_KEYS.USER_TOKEN,
+      );
+      expect(store.getState().user.isGuest).toBe(true);
+    });
   });
 });

--- a/frontend/src/lib/api/setupAxiosInterceptor.ts
+++ b/frontend/src/lib/api/setupAxiosInterceptor.ts
@@ -37,6 +37,31 @@ let _axiosResId: number | null = null;
 let _authAxiosResId: number | null = null;
 
 /**
+ * Session-creation / credential-check endpoints that legitimately return HTTP
+ * 401 when the supplied credentials are wrong (login, registration, OTP
+ * verification, email verification, password change). A 401 from these
+ * endpoints is a *credential failure*, NOT an expired session — tearing down
+ * the user's otherwise-valid session here would force-log them out to guest
+ * mode. Genuine session expiry only produces a 401 on requests against
+ * protected resources, which are not listed here.
+ */
+const AUTH_ATTEMPT_ENDPOINTS = [
+  '/user/login',
+  '/user/register',
+  '/user/forgotpassword',
+  '/user/verifyOtp',
+  '/user/verifypassword',
+  '/user/update-password',
+  '/user/verifyEmail',
+  '/user/resend-verification-mail',
+];
+
+const isAuthAttemptEndpoint = (error: any): boolean => {
+  const url: string = error?.config?.url ?? '';
+  return AUTH_ATTEMPT_ENDPOINTS.some(path => url.includes(path));
+};
+
+/**
  * Resets the session-expired notification flag.
  * Call this from your login success handler so that if the *new* session
  * later expires, the user sees the notification again.
@@ -72,7 +97,11 @@ const handleError = async (error: any) => {
     await enqueueOfflineWrite({ url, method: configMethod, data, headers });
   }
 
-  if (error?.response?.status === 401) {
+  // A 401 from a credential-check endpoint (login, OTP, password change, ...)
+  // means the submitted credentials were wrong — not that the session expired.
+  // Only tear down the session when a 401 rejects an authenticated request
+  // against a protected resource.
+  if (error?.response?.status === 401 && !isAuthAttemptEndpoint(error)) {
     try {
       await teardownExpiredSession();
     } catch (teardownError) {


### PR DESCRIPTION
﻿## Summary
Fixes #2366

## Problem
The global axios interceptor in `frontend/src/lib/api/setupAxiosInterceptor.ts` tears down the **entire session** on every HTTP 401, with no endpoint filter:

```ts
if (error?.response?.status === 401) {
  await teardownExpiredSession();
  // 'Your session has expired. You are now browsing as a guest.'
}
```

This interceptor is attached to the global axios instance, which is also used by **credential-check endpoints**:
- `POST /user/login` (wrong password ΓåÆ 401)
- `POST /user/register`
- `POST /user/forgotpassword`
- `POST /user/verifyOtp` (invalid/expired OTP ΓåÆ 401)
- `POST /user/verifypassword` (wrong old password ΓåÆ 401)
- `PUT /user/update-password` (wrong old password in profile settings ΓåÆ 401)
- `POST /user/verifyEmail`
- `POST /user/resend-verification-mail`

A **logged-in** user who enters a wrong old password (or wrong password/OTP anywhere in the auth flow) receives a 401 which the interceptor misinterprets as *session expiry* ΓÇö wiping their valid token, flipping `isGuest=true`, and force-logging them out to guest mode.

## Fix
- Introduced an `AUTH_ATTEMPT_ENDPOINTS` allow-list of session-creation / credential-check paths.
- The 401 teardown + "Session Expired" notification now runs **only when the request is NOT one of those endpoints** (i.e. a genuine expired-session rejection of an authenticated request against a protected resource).
- Genuine session expiry behaviour (dedupe notification, idempotent awaited teardown, storage clears) is preserved.

## Tests
Added regression tests in `frontend/src/__tests__/lib/api/SessionExpiry.test.ts`:
- 401 from each auth-attempt endpoint ΓåÆ session is **not** torn down (token preserved, `isGuest` stays `false`).
- 401 from a protected resource (`/user/getprofile`) ΓåÆ session **is** torn down (existing behaviour).
- Also fixed a state leak in the test suite's `beforeEach` (guest mode is now reset, so tests are isolated).

## Testing
- [x] `yarn lint` (0 errors)
- [x] `yarn type-check` (no errors from changed files; pre-existing local `expo-image` module-resolution issue unrelated to this PR)
- [x] `yarn test` ΓÇö 145 suites / 563 tests pass



