### PR TITLE
fix: remove console.log calls from notification preferences screen

### DIFF
--- a/frontend/src/screens/notification/NotificationPreferencesScreen.tsx
+++ b/frontend/src/screens/notification/NotificationPreferencesScreen.tsx
@@ -39,21 +39,17 @@ const NotificationPreferencesScreen = ({
   const {data: preferencesData, isLoading: prefsLoading} =
     useGetNotificationPreferences(isConnected);
 
-  console.log("Preference data", preferencesData);
   // Mutation to save
   const {mutate: updatePreferences, isPending: isSaving} =
     useUpdateNotificationPreferences();
 
   // Pre-fill selections once both data sets are ready
   useEffect(() => {
-    console.log('Fetched Preferences Data:', preferencesData);
     if (preferencesData) {
       // Support both { preferences: { contentClusters: [] } } and { contentClusters: [] }
       const clusters =
         preferencesData.preferences?.contentClusters ||
         preferencesData.contentClusters;
-
-      console.log("Clusters", clusters);
 
       if (Array.isArray(clusters)) {
         setSelectedIds(clusters.map(cluster => cluster._id));
@@ -121,7 +117,6 @@ const NotificationPreferencesScreen = ({
       {contentClusters: payload},
       {
         onSuccess: () => {
-          console.log('Preferences saved successfully:', selectedIds);
           queryClient.invalidateQueries({
             queryKey: ['notification-preferences'],
           });


### PR DESCRIPTION
﻿## Summary
Addresses #2379

## Problem
`NotificationPreferencesScreen.tsx` logs raw data to the console unconditionally:
- `console.log("Preference data", preferencesData)` on every render
- `console.log('Fetched Preferences Data:', preferencesData)` on every fetch
- `console.log("Clusters", clusters)` inside the pre-fill effect
- `console.log('Preferences saved successfully:', selectedIds)` after each save

This leaks preference payloads into production console output on every render/save and adds noise to dev logs.

## Fix
Removed all four `console.log` calls. No behavioural change ΓÇö the pre-fill and `invalidateQueries` logic is untouched.

## Testing
- `yarn lint` ΓÇö 0 errors.
- No console.log statements remain in the file.



