### PR TITLE
fix: stop logging full axios error objects in notification mutation error handlers

### DIFF
--- a/frontend/src/screens/notification/NotificationScreen.tsx
+++ b/frontend/src/screens/notification/NotificationScreen.tsx
@@ -91,8 +91,7 @@ const NotificationScreen = ({navigation}: any) => {
               duration: Snackbar.LENGTH_SHORT,
             });
           },
-          onError: error => {
-            console.log(error);
+          onError: () => {
             Snackbar.show({
               text: 'Internal server error, cannot mark the notification as read!',
               duration: Snackbar.LENGTH_SHORT,
@@ -150,8 +149,7 @@ const NotificationScreen = ({navigation}: any) => {
             refetch();
           }
         },
-        onError: error => {
-          console.log(error);
+        onError: () => {
           pendingDeletesRef.current.delete(snapshot.item._id);
           if (isMountedRef.current) {
             restoreDeletedNotification(snapshot);


### PR DESCRIPTION
﻿## Summary
Addresses #2380

## Problem
`NotificationScreen.tsx` has two mutation error handlers (`markNotificationAsRead` and `deleteNotification`) that call `console.log(error)` with the full axios error object on **every** failure, even though a user-facing Snackbar is shown in each handler. The error object can embed request/response payloads and internals, producing noisy and potentially sensitive output in the console on every failed request.

## Fix
Removed both `console.log(error)` calls from the error handlers. User-facing behaviour is unchanged ΓÇö the existing Snackbar error messages still display.

## Testing
- `yarn lint` ΓÇö 0 errors.
- No console.log statements remain in the file.



