### PR TITLE
fix: preload splash screen assets (#737)

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -1,10 +1,17 @@
-import React, { useEffect, useState } from 'react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { setAudioModeAsync } from 'expo-audio';
+import React, {useEffect, useState} from 'react';
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import {setAudioModeAsync} from 'expo-audio';
 import * as Sentry from '@sentry/react-native';
-import { logger } from './src/lib/services/monitoring/logger';
+import * as SplashScreen from 'expo-splash-screen';
+import {loadAsync} from 'expo-font';
+import {Asset} from 'expo-asset';
+import {logger} from './src/lib/services/monitoring/logger';
 
 import AppContent from './src/components/common/AppContent';
+
+SplashScreen.preventAutoHideAsync().catch(() => {
+  // Splash screen may already be controlled by the native runtime.
+});
 
 function App() {
   const [queryClient] = useState(
@@ -19,37 +26,68 @@ function App() {
       }),
   );
 
+  const [appReady, setAppReady] = useState(false);
+
   useEffect(() => {
     let isMounted = true;
 
-    const configureAudio = async () => {
+    const initializeApp = async () => {
       try {
-        await setAudioModeAsync({
-          playsInSilentMode: true,
-          allowsRecording: true,
-        });
-      } catch (error) {
-        // Prevent state/logging side-effects if unmounted
-        if (!isMounted) return;
+        await Promise.all([
+          loadAsync({
+            Lobster: require('./assets/fonts/Lobster-Regular.ttf'),
+          }),
 
+          Asset.loadAsync([
+            require('./assets/images/adaptive-icon.png'),
+            require('./assets/images/ic_ultimatehealth_appicon.png'),
+          ]),
+
+          setAudioModeAsync({
+            playsInSilentMode: true,
+            allowsRecording: true,
+          }),
+        ]);
+      } catch (error) {
         Sentry.captureException(error, {
-          tags: { feature: 'audio_playback' },
-          extra: { context: 'App startup audio configuration' },
+          tags: {feature: 'app_initialization'},
+          extra: {context: 'App startup resource preloading'},
         });
 
         if (__DEV__) {
-          logger.error('[App] Failed to configure audio mode:', error);
+          logger.error(
+            '[App] Failed to preload startup resources:',
+            error,
+          );
+        }
+      } finally {
+        if (!isMounted) return;
+
+        setAppReady(true);
+
+        try {
+          await SplashScreen.hideAsync();
+        } catch (error) {
+          if (__DEV__) {
+            logger.error(
+              '[App] Failed to hide native splash screen:',
+              error,
+            );
+          }
         }
       }
     };
 
-    configureAudio();
+    initializeApp();
 
-    // Cleanup function
     return () => {
       isMounted = false;
     };
   }, []);
+
+  if (!appReady) {
+    return null;
+  }
 
   return (
     <QueryClientProvider client={queryClient}>
@@ -58,5 +96,4 @@ function App() {
   );
 }
 
-// 3. Using standard Sentry wrapping (or keep your custom one if verified)
 export default Sentry.wrap(App);


### PR DESCRIPTION
#### PR Description
Preloaded startup resources and improved splash screen handling so the app keeps the native splash screen visible until required assets and initialization are complete.
Details:
Preloads the Lobster font during app startup.
Preloads required app icon assets.
Initializes audio alongside the other startup resources using Promise.all.
Prevents the native splash screen from hiding prematurely.
Hides the splash screen after startup initialization completes.
Keeps the app from rendering AppContent until initialization is ready.

#### Type of Change
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update

#### Select your work-area
- [x] Frontend
- [ ] Backend
- [ ] Documentation
- [ ] Others

#### Related Issue
https://github.com/SB2318/UltimateHealth/issues/737

#### Fixes (mention the issue number which this fixes)
closes #737 

#### Checklist
- [ ] I have updated my branch and synced it with the project's 'develop' branch before making this PR.
- [x] I have optimized the file changes.
- [ ] I have added a snapshot of my work example.
- [ ] I have made a PR to the project's develop branch.

#### Undertaking
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have checked for plagiarism and assure its authenticity.
- [x] I have read and followed the code of conduct for this repository. I understand that violation of this undertaking may have legal consequences.

- [x] I Agree
