### PR TITLE
Fix #1934: Prevent like/unlike race condition on rapid taps

### DIFF
--- a/frontend/src/hooks/useLikeArticle.ts
+++ b/frontend/src/hooks/useLikeArticle.ts
@@ -1,21 +1,38 @@
 import axios, {AxiosError} from 'axios';
 import {ArticleData} from '../type';
+import {useCallback, useRef} from 'react';
 import {useMutation, UseMutationResult} from '@tanstack/react-query';
 import {LIKE_ARTICLE} from '../helper/APIUtils';
 import {useSelector} from 'react-redux';
 
+export type LikeArticleResponse = {
+  article: ArticleData;
+  likeStatus: boolean;
+};
+
+type LikeArticleVariables = undefined;
+type MutationOptions = Parameters<
+  UseMutationResult<
+    LikeArticleResponse,
+    AxiosError,
+    LikeArticleVariables
+  >['mutate']
+>[1];
+
 export const useLikeArticle = (
   articleId: number,
 ): UseMutationResult<
-  {
-    article: ArticleData;
-    likeStatus: boolean;
-  },
-  AxiosError
+  LikeArticleResponse,
+  AxiosError,
+  LikeArticleVariables
 > => {
   const isGuest = useSelector((state: any) => state.user.isGuest);
 
-  return useMutation({
+  const mutation = useMutation<
+    LikeArticleResponse,
+    AxiosError,
+    LikeArticleVariables
+  >({
     mutationKey: ['update-like-status', articleId],
 
     mutationFn: async () => {
@@ -26,10 +43,33 @@ export const useLikeArticle = (
         article_id: articleId,
       });
 
-      return res.data.data as {
-        article: ArticleData;
-        likeStatus: boolean;
-      };
+      return res.data.data as LikeArticleResponse;
     },
   });
+
+  // Guard against rapid taps: only one like/unlike request may be in flight
+  // at a time per hook instance (fixes #1934 race condition).
+  const inFlightRef = useRef(false);
+
+  const guardedMutate = useCallback(
+    (
+      variables: LikeArticleVariables,
+      options?: MutationOptions,
+    ) => {
+      if (inFlightRef.current) {
+        return;
+      }
+      inFlightRef.current = true;
+      mutation.mutate(variables, {
+        ...options,
+        onSettled: (data, error, vars, context) => {
+          inFlightRef.current = false;
+          options?.onSettled?.(data, error, vars, context);
+        },
+      });
+    },
+    [mutation],
+  );
+
+  return {...mutation, mutate: guardedMutate};
 };

--- a/frontend/src/hooks/useLikePodcast.ts
+++ b/frontend/src/hooks/useLikePodcast.ts
@@ -1,20 +1,26 @@
 import { useMutation, UseMutationResult } from "@tanstack/react-query";
 import axios, { AxiosError } from "axios";
+import { useCallback, useRef } from "react";
 import { LIKE_PODCAST } from "../helper/APIUtils";
 import { useSelector } from "react-redux";
 
-export const useLikePodcast = (): UseMutationResult<
-any,
-AxiosError,
-string
->=>{
-    const isGuest = useSelector((state: any) => state.user.isGuest);
+type PodcastMutationVariables = string;
+type MutationOptions = Parameters<
+  UseMutationResult<any, AxiosError, PodcastMutationVariables>["mutate"]
+>[1];
 
-    return useMutation({
-    mutationKey: ['update-podcast-like-count'],
+export const useLikePodcast = (): UseMutationResult<
+  any,
+  AxiosError,
+  PodcastMutationVariables
+> => {
+  const isGuest = useSelector((state: any) => state.user.isGuest);
+
+  const mutation = useMutation({
+    mutationKey: ["update-podcast-like-count"],
     mutationFn: async (podcastId: string) => {
       if (isGuest) {
-        return Promise.reject(new Error('Guest cannot like podcasts'));
+        return Promise.reject(new Error("Guest cannot like podcasts"));
       }
       const res = await axios.post(
         `${LIKE_PODCAST}`,
@@ -24,6 +30,31 @@ string
       );
       return res.data as any;
     },
- 
   });
-}
+
+  // Guard against rapid taps: only one like/unlike request may be in flight
+  // at a time per hook instance (fixes #1934 race condition).
+  const inFlightRef = useRef(false);
+
+  const guardedMutate = useCallback(
+    (
+      variables: PodcastMutationVariables,
+      options?: MutationOptions,
+    ) => {
+      if (inFlightRef.current) {
+        return;
+      }
+      inFlightRef.current = true;
+      mutation.mutate(variables, {
+        ...options,
+        onSettled: (data, error, vars, context) => {
+          inFlightRef.current = false;
+          options?.onSettled?.(data, error, vars, context);
+        },
+      });
+    },
+    [mutation],
+  );
+
+  return {...mutation, mutate: guardedMutate};
+};


### PR DESCRIPTION
## Problem
Rapidly tapping the Like button fired multiple concurrent like/unlike API requests that could land out of order (e.g. a "like" arriving before an "unlike"), leaving the server in a state that contradicts the UI.

## Fix
Added an in-flight guard to both `useLikeArticle` and `useLikePodcast` hooks:
- At most one like/unlike request per hook instance
- Taps while a request is pending are dropped instead of queueing conflicting requests
- Guard resets in `onSettled`, preserving the TanStack Query v5 `mutate(variables, options)` API so all existing callers (ArticleScreen, ArticleCard, PodcastDetail) work unchanged

## Verification
- `tsc --noEmit` passes clean
- Caller API unchanged (`likeMutation(undefined, {...})`, `likePodcast(trackId, {...})`)

Fixes #1934