### PR TITLE
Fix #1351: Article view count display

### DIFF
--- a/frontend/src/helper/Utils.ts
+++ b/frontend/src/helper/Utils.ts
@@ -130,6 +130,11 @@ export function formatCount(count: number) {
   }
 }
 
+export function formatViewCount(count?: number) {
+  const views = count ?? 0;
+  return `${views} ${views === 1 ? 'view' : 'views'}`;
+}
+
 export const handleExternalClick = (request: any) => {
   const {url} = request;
 

--- a/frontend/src/helper/__tests__/Utils.test.ts
+++ b/frontend/src/helper/__tests__/Utils.test.ts
@@ -1,0 +1,17 @@
+import {formatViewCount} from '../Utils';
+
+describe('formatViewCount', () => {
+  it('returns 0 views for undefined', () => {
+    expect(formatViewCount(undefined)).toBe('0 views');
+  });
+
+  it('returns singular for 1 view', () => {
+    expect(formatViewCount(1)).toBe('1 view');
+  });
+
+  it('returns plural for counts other than 1', () => {
+    expect(formatViewCount(0)).toBe('0 views');
+    expect(formatViewCount(2)).toBe('2 views');
+    expect(formatViewCount(125)).toBe('125 views');
+  });
+});

--- a/frontend/src/screens/article/ArticleScreen.tsx
+++ b/frontend/src/screens/article/ArticleScreen.tsx
@@ -27,6 +27,7 @@ import { generateArticleSummary, ArticleSummary } from '../../services/SummarySe
 
 import {
   formatCount,
+  formatViewCount,
   handleExternalClick,
   retrieveItem,
   StatusEnum,
@@ -762,9 +763,7 @@ const ArticleScreen = ({navigation, route}: ArticleScreenProp) => {
         <View style={styles.contentContainer}>
           {article && (
             <Text style={{...styles.viewText, marginBottom: 10}}>
-              {article?.viewCount
-                ? article.viewCount > 1
-                : `${article.viewCount} view`}
+              {formatViewCount(article.viewCount)}
             </Text>
           )}
           {article && article?.tags && (


### PR DESCRIPTION
## Description
The article detail screen rendered a boolean expression instead of a readable view-count label (frontend/src/screens/article/ArticleScreen.tsx). React Native does not render booleans as text, so the view count appeared missing for any article with `viewCount > 0`, and showed an incorrect "0 view" otherwise.

## Changes
- Added `formatViewCount(count?: number)` helper in frontend/src/helper/Utils.ts (next to existing `formatCount`): renders `0 views`, `1 view`, `N views` with proper singular/plural handling.
- Replaced the boolean expression in ArticleScreen.tsx with `formatViewCount(article.viewCount)`.
- Added unit tests in frontend/src/helper/__tests__/Utils.test.ts covering undefined, 0, 1, 2 and 125 counts.

## Verification
- `tsc --noEmit`: 58 errors on baseline main, 58 after change (no new errors).
- `npx jest src/helper/__tests__/Utils.test.ts src/screens/__tests__/ArticleScreen.readEvent.test.tsx`: 8/8 tests pass (note: the repo's transformIgnorePatterns needed broadening under pnpm/nested node_modules to load at all — pre-existing environment issue, unrelated to this change).

Fixes #1351