### PR TITLE
Fix #1725: Chat typing bubble shows on load

### DIFF
--- a/frontend/src/screens/ChatbotScreen.tsx
+++ b/frontend/src/screens/ChatbotScreen.tsx
@@ -53,7 +53,7 @@ const ChatbotScreen = ({navigation}: ChatBotScreenProps) => {
   const {isConnected} = useSelector((state: any) => state.network);
 
   const [messages, setMessages] = useState<IMessage[]>([]);
-  const [isTyping, setIsTyping] = useState<boolean>(true);
+  const [isTyping, setIsTyping] = useState<boolean>(false);
   const isMountedRef = useRef(true);
   const dispatch = useDispatch();
   const {data: user} = useGetProfile();
@@ -103,10 +103,12 @@ const ChatbotScreen = ({navigation}: ChatBotScreenProps) => {
         },
         ...refined.reverse(),
       ]);
-
-      safeSetIsTyping(false);
     }
   }, [conversations, safeSetIsTyping, safeSetMessages]);
+
+  useEffect(() => {
+    safeSetIsTyping(messageProcessPending);
+  }, [messageProcessPending, safeSetIsTyping]);
 
   const convertToGiftedFormat = (items: Message[]): IMessage[] => {
     return items.map(m => ({

--- a/frontend/src/screens/__tests__/ChatbotScreen.test.tsx
+++ b/frontend/src/screens/__tests__/ChatbotScreen.test.tsx
@@ -1,0 +1,148 @@
+import React from 'react';
+import {render} from '@testing-library/react-native';
+import ChatbotScreen from '../ChatbotScreen';
+
+const mockNavigate = jest.fn();
+const mockMutate = jest.fn();
+let mockIsPending = false;
+
+jest.mock('@expo/vector-icons/Ionicons', () => {
+  const React = require('react');
+  const {Text} = require('react-native');
+  const MockIcon = ({name}: {name: string}) =>
+    React.createElement(Text, null, name);
+  MockIcon.displayName = 'Ionicons';
+  return MockIcon;
+});
+
+jest.mock('@expo/vector-icons/MaterialCommunityIcons', () => {
+  const React = require('react');
+  const {Text} = require('react-native');
+  const MockIcon = ({name}: {name: string}) =>
+    React.createElement(Text, null, name);
+  MockIcon.displayName = 'MaterialCommunityIcons';
+  return MockIcon;
+});
+
+jest.mock('react-native-safe-area-context', () => {
+  const React = require('react');
+  const {View} = require('react-native');
+  const MockSafeAreaView = ({children, ...props}: any) =>
+    React.createElement(View, props, children);
+  MockSafeAreaView.displayName = 'SafeAreaView';
+  return {SafeAreaView: MockSafeAreaView};
+});
+
+jest.mock('react-native-gifted-chat', () => {
+  const React = require('react');
+  const {View} = require('react-native');
+  const MockComponent = ({children, ...props}: any) =>
+    React.createElement(View, props, children);
+  MockComponent.displayName = 'GiftedChat';
+  return {
+    GiftedChat: MockComponent,
+    Bubble: MockComponent,
+    InputToolbar: MockComponent,
+    Send: MockComponent,
+  };
+});
+
+jest.mock('react-native-snackbar', () => ({
+  show: jest.fn(),
+  LENGTH_SHORT: 0,
+}));
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+  useDispatch: jest.fn(() => jest.fn()),
+}));
+
+jest.mock('../../helper/Theme', () => ({
+  PRIMARY_COLOR: '#4ACDFF',
+}));
+
+jest.mock('../../helper/APIUtils', () => ({
+  GET_STORAGE_DATA: 'https://example.com',
+}));
+
+jest.mock('../../helper/Metric', () => ({
+  hp: (value: number) => value,
+}));
+
+jest.mock('../../hooks/useGetProfile', () => ({
+  useGetProfile: jest.fn(),
+}));
+
+jest.mock('../../hooks/useSendMessageToGemini', () => ({
+  useSendMessageToGemini: jest.fn(),
+}));
+
+jest.mock('../../hooks/useLoadAIChats', () => ({
+  useLoadAIConversations: jest.fn(),
+}));
+
+const mockUseSelector = require('react-redux').useSelector as jest.Mock;
+const mockUseGetProfile =
+  require('../../hooks/useGetProfile').useGetProfile as jest.Mock;
+const mockUseSendMessageToGemini =
+  require('../../hooks/useSendMessageToGemini')
+    .useSendMessageToGemini as jest.Mock;
+const mockUseLoadAIConversations =
+  require('../../hooks/useLoadAIChats').useLoadAIConversations as jest.Mock;
+
+describe('ChatbotScreen typing indicator', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsPending = false;
+    mockUseSelector.mockImplementation((selector: any) =>
+      selector({
+        user: {
+          user_token: 'token',
+          user_id: 'user-1',
+        },
+        network: {
+          isConnected: true,
+        },
+      }),
+    );
+    mockUseGetProfile.mockReturnValue({data: null});
+    mockUseSendMessageToGemini.mockReturnValue({
+      mutate: mockMutate,
+      isPending: mockIsPending,
+    });
+    mockUseLoadAIConversations.mockReturnValue({
+      data: null,
+      isLoading: false,
+    });
+  });
+
+  it('does not show typing indicator on initial screen load', () => {
+    const {queryByText} = render(
+      <ChatbotScreen navigation={{goBack: mockNavigate} as any} />,
+    );
+
+    expect(queryByText('typing...')).toBeNull();
+  });
+
+  it('shows typing indicator only while a response is being generated', () => {
+    mockIsPending = true;
+    mockUseSendMessageToGemini.mockReturnValue({
+      mutate: mockMutate,
+      isPending: mockIsPending,
+    });
+    const {queryByText, rerender} = render(
+      <ChatbotScreen navigation={{goBack: mockNavigate} as any} />,
+    );
+
+    expect(queryByText('typing...')).toBeTruthy();
+
+    mockIsPending = false;
+    mockUseSendMessageToGemini.mockReturnValue({
+      mutate: mockMutate,
+      isPending: mockIsPending,
+    });
+    rerender(<ChatbotScreen navigation={{goBack: mockNavigate} as any} />);
+
+    expect(queryByText('typing...')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Description

Fixes the chatbot typing indicator bug from issue #1725 (part 3: Chatbot Typing Indicator Incorrect on Initial Load).

`ChatbotScreen` initialized `isTyping` to `true`, so the "typing..." bubble rendered as soon as the screen loaded, before any message had been sent.

## Changes

- `frontend/src/screens/ChatbotScreen.tsx`:
  - Initialize `isTyping` to `false` so the indicator stays hidden on screen load.
  - Added an effect that syncs `isTyping` with the mutation's `isPending` state, so the typing indicator appears only while the AI response is being generated and is cleared when the request settles (success, error, or cancellation).
  - Removed the now-redundant `safeSetIsTyping(false)` from the conversation-loading effect (initial state is already `false`; this also avoids clearing the indicator if a request is in flight when history finishes loading).
- `frontend/src/screens/__tests__/ChatbotScreen.test.tsx` (new): unit tests asserting the typing indicator is hidden on initial load and only shown while a response is pending.

## Verification

- `tsc --noEmit` in `frontend/`: 58 pre-existing errors before and after — no new errors added.
- `npx jest src/screens/__tests__/ChatbotScreen.test.tsx`: 2 tests pass.

Fixes #1725