### PR TITLE
Fix #1395: Duplicate screenshot in gallery

### DIFF
--- a/web/src/app/[locale]/page.tsx
+++ b/web/src/app/[locale]/page.tsx
@@ -23,7 +23,7 @@ const userScreenshots = [
   { src: "/assets/podcast-form.jpeg", caption: "Podcast Form" },
   { src: "/assets/podcast-list-screen.jpeg", caption: "Podcast Listing" },
   { src: "/assets/podcast-play-screen.jpeg", caption: "Podcast Player" },
-  { src: "/assets/podcast-play-screen-2.jpeg", caption: "Podcast Player" },
+  { src: "/assets/podcast-play-screen-2.jpeg", caption: "Now Playing" },
   { src: "/assets/podcast-recording.jpeg", caption: "Podcast Recorder" },
   { src: "/assets/podcast-upload.jpeg", caption: "Podcast Upload" },
   { src: "/assets/notification-screen.jpeg", caption: "Notification" },

--- a/web/src/components/home/ScreenshotGallery.tsx
+++ b/web/src/components/home/ScreenshotGallery.tsx
@@ -14,7 +14,7 @@ const userScreenshots = [
   { src: "/assets/podcast-form.jpeg", caption: "Podcast Form" },
   { src: "/assets/podcast-list-screen.jpeg", caption: "Podcast Listing" },
   { src: "/assets/podcast-play-screen.jpeg", caption: "Podcast Player" },
-  { src: "/assets/podcast-play-screen-2.jpeg", caption: "Podcast Player" },
+  { src: "/assets/podcast-play-screen-2.jpeg", caption: "Now Playing" },
   { src: "/assets/podcast-recording.jpeg", caption: "Podcast Recorder" },
   { src: "/assets/podcast-upload.jpeg", caption: "Podcast Upload" },
   { src: "/assets/notification-screen.jpeg", caption: "Notification" },


### PR DESCRIPTION
## What

The gallery labelled two different screenshots with the exact same caption **"Podcast Player"**:

- `web/src/components/home/ScreenshotGallery.tsx` (lines 16-17)
- `web/src/app/[locale]/page.tsx` (lines 25-26) — the live home page

Both entries pointed at distinct assets (`podcast-play-screen.jpeg` and `podcast-play-screen-2.jpeg`) but displayed identical captions, making them look like an exact duplicate and reducing the perceived diversity of features (issue #1395).

## Fix

Renamed the second entry's caption from "Podcast Player" to **"Now Playing"**, matching the on-screen header text ("NOW PLAYING") visible in the screenshot asset (`podcast-play-screen-2.jpeg`), which shows the podcast player with playback progress (1:24 elapsed). The gallery now shows distinct captions for two genuinely different screen states while keeping the same content.

## Verification

- Both files now show unique captions; no remaining "Podcast Player" duplicates.
- Ran `npm install` and `npm run build` (Next.js 16): app **compiles successfully**; the build fails only at two **pre-existing** type errors unrelated to this change (verified identical on clean upstream/web HEAD via stash):
  - `src/app/[locale]/page.tsx:677` — `HeroAndDownload` props mismatch
  - `src/components/ScrollToTop.tsx:45` — duplicate JSX attribute
- Change is limited to 2 caption-string edits (2 files, +2/-2).

Fixes #1395