### PR TITLE
Fix #1652: Frontend TypeScript build errors

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -137,6 +137,10 @@
     "@tamagui/web": "^1.135.6",
     "@tamagui/core": "^1.135.6"
   },
+  "overrides": {
+    "@tamagui/web": "^1.135.6",
+    "@tamagui/core": "^1.135.6"
+  },
   "workspaces": [
     "modules/*"
   ],


### PR DESCRIPTION
## Summary
Fixes the frontend build failure reported in #1652 (`npm run type-check` / `tsc --noEmit` crashes with TypeScript/JSX errors).

## Root cause
The project pins tamagui versions via yarn's `resolutions` field (`@tamagui/web` and `@tamagui/core` to `^1.135.6`), but **npm ignores `resolutions`**. Installing with `npm install` (as the frontend README instructs) therefore resolves `@tamagui/web@2.7.6` alongside `@tamagui/core@1.144.4`, producing two incompatible tamagui type identities. Every tamagui component's props then collapse to `Property 'children' is incompatible with index signature ... not assignable to type 'undefined'`, producing **~2100 TS errors across 60+ files** (auth screens, article components, podcast, wellness, etc.) and breaking the entire build.

## Fix
- `frontend/package.json`: added npm `overrides` mirroring the existing yarn `resolutions` so `npm install` resolves `@tamagui/web@1.144.4` consistently.

## Verification
- `npm install` + `tsc --noEmit`: **0 errors** (was ~2100)
- CI toolchain `yarn install --frozen-lockfile` + `yarn type-check`: **0 errors**, lockfile untouched
- `yarn lint`: 0 errors
- Jest: auth suites 15/15 (41 tests) and article suites 5/5 (21 tests) pass

Fixes #1652