### PR TITLE
Fix #1422: Footer copyright text invisible

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -1654,7 +1654,7 @@ footer {
 
 .footer-bottom-inner p {
   font-size: 0.82rem;
-  color: #334155;
+  color: #94a3b8;
 }
 
 .footer-bottom-links {


### PR DESCRIPTION
## Changes
- In `web/src/app/globals.css`, changed `.footer-bottom-inner p` color from `#334155` (dark slate) to `#94a3b8`.

## Why
The footer background is a dark gradient (`#0f172a` → `#1e293b`), but the copyright line was styled with the dark slate `#334155`, making it nearly invisible in both light and dark modes. `#94a3b8` matches the footer's base text color and is clearly readable against the dark background (WCAG contrast ≈ 7:1).

## Verification
- `npm run build` compiles CSS successfully; only the pre-existing type errors remain (page.tsx:677, ScrollToTop.tsx:45) — no new errors introduced.

Fixes #1422