### PR TITLE
Fix #1879: Broken avatar image after upload

### DIFF
--- a/frontend/src/screens/ProfileEditScreen.tsx
+++ b/frontend/src/screens/ProfileEditScreen.tsx
@@ -29,6 +29,7 @@ import {
 import ImageResizer from '@bam.tech/react-native-image-resizer';
 import useUploadImage from '../hooks/useUploadImage';
 import Snackbar from 'react-native-snackbar';
+import {useQueryClient} from '@tanstack/react-query';
 import {useGetUserDetails} from '../hooks/useGetUserDetails';
 import {useUpdatePassword} from '../hooks/useUpdatePassword';
 import {useUpdateProfileImage} from '../hooks/useUpdateProfileImage';
@@ -77,15 +78,18 @@ const ProfileEditScreen = ({navigation}: ProfileEditScreenProp) => {
 
   const {data: user} = useGetUserDetails(isConnected);
 
+  const queryClient = useQueryClient();
 
+  const getProfileImageUrl = (image: string): string =>
+    image
+      ? image.startsWith('http')
+        ? image
+        : `${GET_STORAGE_DATA}/${image}`
+      : '';
 
   useEffect(() => {
     if (user) {
-      setUserProfileImage(
-        user.Profile_image ?
-        user.Profile_image.startsWith("http") ? user.Profile_image :
-         `${GET_STORAGE_DATA}/${user.Profile_image}` : '',
-      );
+      setUserProfileImage(getProfileImageUrl(user.Profile_image));
     }
   }, [user]);
   // Boolean to check if the user is a doctor
@@ -410,7 +414,9 @@ const ProfileEditScreen = ({navigation}: ProfileEditScreenProp) => {
                   {
                     text: 'Cancel',
                     onPress: () => {
-                      setUserProfileImage(user?.Profile_image || '');
+                      setUserProfileImage(
+                        getProfileImageUrl(user?.Profile_image || ''),
+                      );
                     },
                     style: 'cancel',
                   },
@@ -423,6 +429,12 @@ const ProfileEditScreen = ({navigation}: ProfileEditScreenProp) => {
 
                           updateProfileImage(result as string, {
                             onSuccess: _data => {
+                              setUserProfileImage(
+                                getProfileImageUrl(result as string),
+                              );
+                              queryClient.invalidateQueries({
+                                queryKey: ['get-user-details-by-id'],
+                              });
                               Alert.alert(
                                 'Success',
                                 'Profile updated successfully',


### PR DESCRIPTION
## Root cause

In `ProfileEditScreen`, after a successful avatar upload the local `user_profile_image` state still pointed at the **resized local cache file** (`file://` URI from `ImageResizer`), and the `get-user-details-by-id` react-query key was **never invalidated**. As a result the avatar kept rendering from a temp file that Android can purge, and the fresh `Profile_image` URL from the server only surfaced after a full app restart (when the react-query cache cleared and the query refetched). The Cancel path also restored the raw storage key (unprefixed) instead of the full URL.

## Changes (`frontend/src/screens/ProfileEditScreen.tsx`)

- Added a `getProfileImageUrl` helper that normalizes relative storage keys with the `GET_STORAGE_DATA` prefix (mirrors `ProfileHeader.tsx` / the existing effect logic).
- `updateProfileImage` `onSuccess` now sets `user_profile_image` to the **new server URL** immediately, so the new avatar renders without refresh, and calls `queryClient.invalidateQueries({queryKey: ['get-user-details-by-id']})` so profile data refreshes app-wide (no restart needed).
- Cancel path now restores the full normalized URL instead of the raw key.
- Replaced the inline URL-building in the `useEffect` with the shared helper.

## Verification

- `tsc --noEmit` in `frontend/`: 58 errors — identical pre-existing set, **none** in changed files.
- Jest suite fails to boot in this environment at `react-native/jest/setup.js` ("Cannot use import statement outside a module") — reproduced identically on unmodified `main`; no tests cover `ProfileEditScreen` (checked `frontend/src/screens/__tests__`).

Fixes #1879