### PR TITLE
feat: add theme toggle to articles and medical glossary navigation

### DIFF
--- a/web/src/components/layout/Navbar.tsx
+++ b/web/src/components/layout/Navbar.tsx
@@ -1,5 +1,5 @@
 "use client";
-
+import { ModeToggle } from "@/components/mode-toggle";
 import Image from "next/image";
 import Link from "next/link";
 import { useEffect, useState } from "react";
@@ -112,6 +112,15 @@ export default function Navbar({ activeSection }: NavbarProps) {
               <span className="nav-item-text">Join Us to Contribute</span>
             </Link>
           </li>
+          <li
+            style={{
+              display: "flex",
+              alignItems: "center",
+              marginLeft: "10px",
+            }}
+          >
+            <ModeToggle />
+          </li>
           <li style={{ display: "flex", alignItems: "center" }}>
             <a href={withBasePath("/#downloads")} className="nav-btn-sm">
               <i className="fas fa-user" aria-hidden="true"></i>
@@ -159,6 +168,15 @@ export default function Navbar({ activeSection }: NavbarProps) {
           Join Us to Contribute
         </Link>
         <a href={withBasePath("/#downloads")} onClick={() => setMobileMenuOpen(false)}>Login / Register</a>
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "center",
+            padding: "1rem",
+          }}
+        >
+          <ModeToggle />
+        </div>
       </nav>
     </header>
   );


### PR DESCRIPTION
#### PR Description

The Read Articles and Medical Glossary pages currently support dark mode styling, but they don't provide a visible theme switch button.

This makes it difficult for users to switch between light and dark themes while browsing these pages.

This PR focuses on adding a similar theme switch button to both the pages using the already available components maintaining similar flow of code and reusable code. 

Fixes #2398 

#### Type of Change
- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Documentation update

#### Select your work-area
- [x] Frontend
- [ ] Backend
- [ ] Documentation
- [ ] Others



#### Related Issue
Closes #2398 

#### Add your Work Example

Before:

<img width="1682" height="362" alt="image" src="https://github.com/user-attachments/assets/04e80f61-39dd-405f-8239-43e20e8de016" />



After:

https://github.com/user-attachments/assets/bbfdfe61-eb4a-472d-9902-833140faab51



#### Fixes 2398
#closes #2398 

#### Checklist
- [x] I have updated my branch and synced it with the project's 'develop' branch before making this PR.
- [x] I have optimized the file changes.
- [x] I have added a snapshot of my work example.
- [x] I have made a PR to the project's develop branch.

#### Undertaking
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have checked for plagiarism and assure its authenticity.
- [x] I have read and followed the code of conduct for this repository. I understand that violation of this undertaking may have legal consequences.

- [x] I Agree
