### PR TITLE
fix: stop persisting auth token in plaintext offline write queue

### DIFF
--- a/frontend/src/__tests__/lib/api/offlineQueue.test.ts
+++ b/frontend/src/__tests__/lib/api/offlineQueue.test.ts
@@ -1,0 +1,159 @@
+﻿import AsyncStorage from '@react-native-async-storage/async-storage';
+import axios from 'axios';
+import {
+  enqueueOfflineWrite,
+  clearOfflineQueue,
+  flushOfflineQueue,
+} from '../../../lib/api/offlineQueue';
+
+jest.mock('axios');
+
+const mockedAxios = axios as jest.MockedFunction<typeof axios>;
+
+describe('offlineQueue', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('persists url/method/data but never headers', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+
+    await enqueueOfflineWrite({
+      url: '/article/like',
+      method: 'POST',
+      data: {articleId: '42'},
+    });
+
+    expect(AsyncStorage.setItem).toHaveBeenCalledTimes(1);
+    const [key, serialized] = (AsyncStorage.setItem as jest.Mock).mock
+      .calls[0] as [string, string];
+
+    expect(key).toBe('offline_write_queue');
+
+    const saved = JSON.parse(serialized);
+    expect(saved).toHaveLength(1);
+    expect(saved[0]).toEqual({
+      url: '/article/like',
+      method: 'POST',
+      data: {articleId: '42'},
+    });
+    expect(saved[0]).not.toHaveProperty('headers');
+  });
+
+  it('drops headers even when a caller passes them', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+
+    await enqueueOfflineWrite({
+      url: '/article/follow',
+      method: 'PUT',
+      data: {id: '7'},
+      headers: {Authorization: 'Bearer SECRET_TOKEN'},
+    } as any);
+
+    const [, serialized] = (AsyncStorage.setItem as jest.Mock).mock
+      .calls[0] as [string, string];
+    const saved = JSON.parse(serialized);
+    expect(saved[0]).not.toHaveProperty('headers');
+    expect(saved[0].headers).toBeUndefined();
+  });
+
+  it('ignores a corrupted non-array queue instead of overwriting it', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(
+      JSON.stringify({not: 'an array'}),
+    );
+
+    await enqueueOfflineWrite({url: '/x', method: 'POST'});
+
+    expect(AsyncStorage.setItem).not.toHaveBeenCalled();
+  });
+
+  it('clears the queue', async () => {
+    await clearOfflineQueue();
+
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith(
+      'offline_write_queue',
+    );
+  });
+
+  it('flushes queued writes without replaying stored headers', async () => {
+    mockedAxios.mockResolvedValue({data: {ok: true}} as any);
+
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(
+      JSON.stringify([
+        {
+          url: '/article/like',
+          method: 'POST',
+          data: {articleId: '42'},
+          headers: {Authorization: 'Bearer LEAKED_TOKEN'},
+        },
+      ]),
+    );
+
+    await flushOfflineQueue();
+
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith(
+      'offline_write_queue',
+    );
+    expect(mockedAxios).toHaveBeenCalledTimes(1);
+    const call = mockedAxios.mock.calls[0][0] as any;
+    expect(call.url).toBe('/article/like');
+    expect(call.method).toBe('POST');
+    expect(call.data).toEqual({articleId: '42'});
+    expect(call.headers).toBeUndefined();
+  });
+
+  it('re-enqueues a request that fails with a network error', async () => {
+    mockedAxios.mockRejectedValueOnce({
+      isAxiosError: true,
+      response: undefined,
+    });
+
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(
+      JSON.stringify([
+        {url: '/article/like', method: 'POST', data: {articleId: '42'}},
+      ]),
+    );
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+
+    await flushOfflineQueue();
+
+    expect(AsyncStorage.setItem).toHaveBeenCalledTimes(1);
+    const [, serialized] = (AsyncStorage.setItem as jest.Mock).mock
+      .calls[0] as [string, string];
+    const saved = JSON.parse(serialized);
+    expect(saved).toEqual([
+      {url: '/article/like', method: 'POST', data: {articleId: '42'}},
+    ]);
+  });
+
+  it('does not run two flushes concurrently', async () => {
+    let resolveFirst: () => void;
+    const gate = new Promise<void>(resolve => {
+      resolveFirst = resolve;
+    });
+
+    mockedAxios.mockImplementationOnce(
+      () => gate.then(() => ({data: {ok: true}} as any)),
+    );
+    mockedAxios.mockResolvedValue({data: {ok: true}} as any);
+
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(
+      JSON.stringify([
+        {url: '/a', method: 'POST', data: {id: 1}},
+        {url: '/b', method: 'POST', data: {id: 2}},
+      ]),
+    );
+
+    const first = flushOfflineQueue();
+    const second = flushOfflineQueue();
+    (resolveFirst as () => void)();
+
+    await Promise.all([first, second]);
+
+    expect(mockedAxios).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/__tests__/screens/podcast/PodcastDetail.test.tsx
+++ b/frontend/src/__tests__/screens/podcast/PodcastDetail.test.tsx
@@ -300,7 +300,7 @@ describe('PodcastDetail', () => {
   it('switches play control state when the play button is pressed', () => {
     const {getByLabelText} = renderScreen();
 
-    fireEvent.press(getByLabelText('podcast-play-pause-button'));
+    fireEvent.press(getByLabelText('Play podcast'));
 
     expect(mockPlayer.play).toHaveBeenCalled();
   });
@@ -308,9 +308,9 @@ describe('PodcastDetail', () => {
   it('renders accessible controls and slider labels', () => {
     const {getByLabelText, getByTestId} = renderScreen();
 
-    expect(getByLabelText('podcast-back-button')).toBeTruthy();
-    expect(getByLabelText('podcast-play-pause-button')).toBeTruthy();
-    expect(getByLabelText('podcast-forward-button')).toBeTruthy();
+    expect(getByLabelText('Rewind 5 seconds')).toBeTruthy();
+    expect(getByLabelText('Play podcast')).toBeTruthy();
+    expect(getByLabelText('Forward 5 seconds')).toBeTruthy();
     expect(getByTestId('podcast-progress-slider')).toBeTruthy();
   });
 
@@ -495,7 +495,7 @@ describe('PodcastDetail', () => {
 
     // Play the audio
     await act(async () => {
-      fireEvent.press(getByLabelText('podcast-play-pause-button'));
+      fireEvent.press(getByLabelText('Play podcast'));
     });
 
     // 1.5 -> 2.0 (playing)

--- a/frontend/src/lib/api/offlineQueue.ts
+++ b/frontend/src/lib/api/offlineQueue.ts
@@ -8,38 +8,78 @@ interface QueuedRequest {
   url: string;
   method: string;
   data?: any;
-  headers?: any;
 }
+
+/**
+ * Guards against overlapping flushes.
+ *
+ * `flushOfflineQueue` reads the whole queue, removes it, then replays each
+ * request. Without this flag two concurrent flushes (e.g. rapid connectivity
+ * transitions) would both read the same snapshot and replay every request,
+ * producing duplicate POSTs/PUTs/DELETEs (duplicate likes, follows, writes).
+ */
+let flushInProgress = false;
 
 export const enqueueOfflineWrite = async (request: QueuedRequest) => {
   try {
     const queueJson = await AsyncStorage.getItem(OFFLINE_QUEUE_KEY);
     const queue: QueuedRequest[] = queueJson ? JSON.parse(queueJson) : [];
-    queue.push(request);
+    if (!Array.isArray(queue)) {
+      return;
+    }
+    // Persist only url/method/data. An Authorization header (or any other
+    // header) passed by a caller must never reach AsyncStorage, so build a
+    // fresh object instead of spreading `request`.
+    queue.push({
+      url: request.url,
+      method: request.method,
+      data: request.data,
+    });
     await AsyncStorage.setItem(OFFLINE_QUEUE_KEY, JSON.stringify(queue));
   } catch (error) {
     console.error('Failed to enqueue offline write:', error);
   }
 };
 
+/**
+ * Discards every queued write. Called during logout / session teardown so
+ * that writes enqueued under one identity can never be replayed under another
+ * user's session (or as an unauthenticated guest, which would 401 and trigger
+ * a spurious session-expiry teardown).
+ */
+export const clearOfflineQueue = async () => {
+  try {
+    await AsyncStorage.removeItem(OFFLINE_QUEUE_KEY);
+  } catch (error) {
+    console.error('Failed to clear offline write queue:', error);
+  }
+};
+
 export const flushOfflineQueue = async () => {
+  if (flushInProgress) {
+    return;
+  }
+  flushInProgress = true;
   try {
     const queueJson = await AsyncStorage.getItem(OFFLINE_QUEUE_KEY);
     if (!queueJson) return;
 
     const queue: QueuedRequest[] = JSON.parse(queueJson);
-    if (queue.length === 0) return;
+    if (!Array.isArray(queue) || queue.length === 0) return;
 
     // Clear the queue before processing to avoid duplicates if flushed concurrently
     await AsyncStorage.removeItem(OFFLINE_QUEUE_KEY);
 
     for (const req of queue) {
       try {
+        // Headers are intentionally NOT persisted: the Authorization header
+        // contains the bearer token, which must never be written to plaintext
+        // AsyncStorage. On replay, the global axios request interceptor
+        // re-attaches a fresh token for the current session.
         await axios({
           url: req.url,
           method: req.method,
           data: req.data,
-          headers: req.headers,
         });
       } catch (error: any) {
         // Re-enqueue only if it's a network error
@@ -50,6 +90,8 @@ export const flushOfflineQueue = async () => {
     }
   } catch (error) {
     console.error('Failed to flush offline queue:', error);
+  } finally {
+    flushInProgress = false;
   }
 };
 

--- a/frontend/src/lib/api/sessionTeardown.ts
+++ b/frontend/src/lib/api/sessionTeardown.ts
@@ -7,6 +7,7 @@ import {
 } from '../../store/UserSlice';
 import {KEYS, removeItem} from '../utils/Utils';
 import {SECURE_KEYS, secureRemoveItem} from '../storage/SecureStorageUtils';
+import {clearOfflineQueue} from './offlineQueue';
 
 /**
  * Shared session-teardown state for the 401 handling in the axios layer.
@@ -53,6 +54,7 @@ const clearExpiredSession = async (): Promise<void> => {
       removeItem(KEYS.USER_TOKEN_EXPIRY_DATE),
       removeItem(KEYS.USER_ID),
       removeItem(KEYS.USER_HANDLE),
+      clearOfflineQueue(),
     ]);
   } catch (storageError) {
     console.error('Failed to clear auth storage safely:', storageError);

--- a/frontend/src/lib/api/setupAxiosInterceptor.ts
+++ b/frontend/src/lib/api/setupAxiosInterceptor.ts
@@ -93,8 +93,13 @@ const handleError = async (error: any) => {
   const method = error.config?.method?.toUpperCase();
   
   if (isNetworkError && method && method !== 'GET') {
-    const { url, method: configMethod, data, headers } = error.config;
-    await enqueueOfflineWrite({ url, method: configMethod, data, headers });
+    // NEVER persist `headers`: error.config.headers contains the live
+    // `Authorization: Bearer <token>`, and writing it to AsyncStorage would
+    // store the session credential in plaintext on disk. The replay path in
+    // offlineQueue relies on the global request interceptor to re-attach a
+    // fresh token for the current session instead.
+    const { url, method: configMethod, data } = error.config;
+    await enqueueOfflineWrite({ url, method: configMethod, data });
   }
 
   // A 401 from a credential-check endpoint (login, OTP, password change, ...)

--- a/frontend/src/lib/utils/Utils.ts
+++ b/frontend/src/lib/utils/Utils.ts
@@ -12,6 +12,7 @@ if (Platform.OS !== 'web') {
 }
 
 import {secureClearAllItems} from '../storage/SecureStorageUtils';
+import {clearOfflineQueue} from '../api/offlineQueue';
 import { debugLog, debugWarn, debugError } from '../utils/debugLog';
 import {
   deleteItem as deletePodcastCache,
@@ -148,6 +149,7 @@ export const clearStorage = async () => {
       AsyncStorage.removeItem(KEYS.USER_TOKEN_EXPIRY_DATE),
       AsyncStorage.removeItem(KEYS.USER_ID),
       AsyncStorage.removeItem(KEYS.USER_HANDLE),
+      clearOfflineQueue(),
     ]);
     await secureClearAllItems();
     debugLog('All user-related storage cleared successfully.');


### PR DESCRIPTION
Fixes #2399

## Summary
The offline write queue was persisting the raw axios request headers — including the `Authorization: Bearer <JWT>` header — to `AsyncStorage` in plaintext. Any app that writes the offline queue on every network failure (retry logic) was leaking the user's auth token to a store that is readable by other apps / extracted from device backups. Additionally, concurrent flush invocations could run twice because `flushOfflineQueue` had no in-flight guard, duplicating writes.

## Changes
- `offlineQueue.ts`: stop persisting request headers; only persist `method`, `url`, `data`; add an in-flight flush guard (`isFlushing`) so concurrent flushes cannot duplicate writes; reject a corrupted (non-array) stored queue instead of crashing or recursing; export `clearOfflineQueue`.
- `setupAxiosInterceptor.ts`: stop forwarding `error.config.headers` when enqueuing an offline write.
- `sessionTeardown.ts` + `Utils.ts`: call `clearOfflineQueue()` on 401 teardown / `clearStorage` (logout) so the token-bearing queue can never survive past session end.
- Added `frontend/src/__tests__/lib/api/offlineQueue.test.ts` (7 tests) covering header stripping, flush-in-progress guard, corruption handling, and queue clearing.

## Testing
- New tests pass locally (`yarn test`).
- Also includes `test: sync podcast player assertions with accessibility labels` to fix the pre-existing CI failure on `main` (labels renamed in #2386).
