### PR TITLE
fix: self-heal corrupted reading history entries on read

### DIFF
--- a/frontend/src/__tests__/lib/services/ReadingHistoryService.test.ts
+++ b/frontend/src/__tests__/lib/services/ReadingHistoryService.test.ts
@@ -57,6 +57,63 @@ describe('ReadingHistoryService', () => {
     expect(mockStorage.remove).toHaveBeenCalledWith('reading_history');
   });
 
+  it('prunes malformed entries on read and self-heals storage', () => {
+    const valid = {
+      articleId: '1',
+      title: 'Test',
+      authorName: 'Author',
+      category: 'Health',
+      coverImage: '',
+      viewedAt: 123,
+    };
+
+    mockStorage.getString.mockReturnValue(
+      JSON.stringify([valid, null, {}, {articleId: '3'}]),
+    );
+
+    expect(getReadingHistory()).toEqual([valid]);
+    expect(mockStorage.set).toHaveBeenCalledTimes(1);
+
+    const savedHistory = JSON.parse(
+      mockStorage.set.mock.calls[0][1],
+    );
+    expect(savedHistory).toEqual([valid]);
+  });
+
+  it('keeps recording new views after a corrupted entry is pruned', () => {
+    const valid = {
+      articleId: '1',
+      title: 'Test',
+      authorName: 'Author',
+      category: 'Health',
+      coverImage: '',
+      viewedAt: 1000,
+    };
+
+    mockStorage.getString.mockReturnValue(
+      JSON.stringify([valid, null, {}]),
+    );
+
+    jest.spyOn(Date, 'now').mockReturnValue(2000);
+
+    recordArticleView({
+      articleId: '2',
+      title: 'Newest',
+      authorName: 'Author',
+      category: 'Health',
+      coverImage: '',
+    });
+
+    const setCalls = mockStorage.set.mock.calls;
+    const savedHistory = JSON.parse(
+      setCalls[setCalls.length - 1][1],
+    );
+
+    expect(savedHistory[0].articleId).toBe('2');
+    expect(savedHistory).toHaveLength(2);
+    expect(savedHistory[1]).toEqual(valid);
+  });
+
   it('records a new article view with timestamp', () => {
     mockStorage.getString.mockReturnValue(undefined);
 

--- a/frontend/src/__tests__/screens/podcast/PodcastDetail.test.tsx
+++ b/frontend/src/__tests__/screens/podcast/PodcastDetail.test.tsx
@@ -300,7 +300,7 @@ describe('PodcastDetail', () => {
   it('switches play control state when the play button is pressed', () => {
     const {getByLabelText} = renderScreen();
 
-    fireEvent.press(getByLabelText('podcast-play-pause-button'));
+    fireEvent.press(getByLabelText('Play podcast'));
 
     expect(mockPlayer.play).toHaveBeenCalled();
   });
@@ -308,9 +308,9 @@ describe('PodcastDetail', () => {
   it('renders accessible controls and slider labels', () => {
     const {getByLabelText, getByTestId} = renderScreen();
 
-    expect(getByLabelText('podcast-back-button')).toBeTruthy();
-    expect(getByLabelText('podcast-play-pause-button')).toBeTruthy();
-    expect(getByLabelText('podcast-forward-button')).toBeTruthy();
+    expect(getByLabelText('Rewind 5 seconds')).toBeTruthy();
+    expect(getByLabelText('Play podcast')).toBeTruthy();
+    expect(getByLabelText('Forward 5 seconds')).toBeTruthy();
     expect(getByTestId('podcast-progress-slider')).toBeTruthy();
   });
 
@@ -495,7 +495,7 @@ describe('PodcastDetail', () => {
 
     // Play the audio
     await act(async () => {
-      fireEvent.press(getByLabelText('podcast-play-pause-button'));
+      fireEvent.press(getByLabelText('Play podcast'));
     });
 
     // 1.5 -> 2.0 (playing)

--- a/frontend/src/lib/services/ReadingHistoryService.ts
+++ b/frontend/src/lib/services/ReadingHistoryService.ts
@@ -29,8 +29,33 @@ export type ReadingHistoryItem = {
 };
 
 /**
+ * Runtime shape check for a stored history entry.
+ *
+ * History is persisted as opaque JSON, so a single malformed entry (a `null`,
+ * an empty object, or a partial write from an interrupted `set`) must never be
+ * able to crash `recordArticleView` (which reads `h.articleId`) or the Reading
+ * History screen (which reads `item.title`, `item.coverImage`, ...).
+ */
+function isValidHistoryItem(item: unknown): item is ReadingHistoryItem {
+  return (
+    !!item &&
+    typeof item === 'object' &&
+    typeof (item as ReadingHistoryItem).articleId === 'string' &&
+    typeof (item as ReadingHistoryItem).title === 'string' &&
+    typeof (item as ReadingHistoryItem).authorName === 'string' &&
+    typeof (item as ReadingHistoryItem).category === 'string' &&
+    typeof (item as ReadingHistoryItem).coverImage === 'string' &&
+    typeof (item as ReadingHistoryItem).viewedAt === 'number' &&
+    Number.isFinite((item as ReadingHistoryItem).viewedAt)
+  );
+}
+
+/**
  * Load the history array from MMKV.
  * Returns [] on missing key, MMKV unavailable, or corrupted JSON.
+ *
+ * Malformed elements are pruned on read (self-healing) so one bad record can
+ * never brick history recording; the cleaned array is written back.
  */
 export function getReadingHistory(): ReadingHistoryItem[] {
   try {
@@ -40,7 +65,11 @@ export function getReadingHistory(): ReadingHistoryItem[] {
     if (!raw) return [];
     const parsed = JSON.parse(raw);
     if (!Array.isArray(parsed)) return [];
-    return parsed as ReadingHistoryItem[];
+    const valid = parsed.filter(isValidHistoryItem);
+    if (valid.length !== parsed.length) {
+      saveHistory(valid);
+    }
+    return valid;
   } catch {
     // Corrupted data — wipe and start fresh
     try { getStorage()?.remove(HISTORY_KEY); } catch {}
@@ -107,6 +136,6 @@ export function recordArticleView(
  */
 export function clearReadingHistory(): void {
   try {
-    getStorage()?.remove(HISTORY_KEY)
+    getStorage()?.remove(HISTORY_KEY);
   } catch {}
 }


### PR DESCRIPTION
Fixes #2401

## Summary
A single corrupted entry in the persisted reading-history list (e.g. an entry missing `articleId`, or a stray `null`/`undefined` element) crashes the Reading History screen and permanently bricks history recording: `findIndex`/map callbacks throw, so the screen never renders, and the corrupted array is re-written on every read, so the failure never heals itself.

## Changes
- `ReadingHistoryService.ts`: validate each persisted entry on read; prune malformed entries (missing `articleId`, non-object, or `null`/`undefined` elements) and persist the cleaned array so the feature self-heals and history recording continues.
- Added regression tests to `frontend/src/__tests__/lib/services/ReadingHistoryService.test.ts` (10 total) covering corrupted arrays, null elements, and heal-on-read behavior.

## Testing
- New tests pass locally (`yarn test`).
- Also includes `test: sync podcast player assertions with accessibility labels` to fix the pre-existing CI failure on `main` (labels renamed in #2386).
