### PR TITLE
fix: localize comment and notification timestamps

### DIFF
--- a/frontend/src/__tests__/lib/utils/dateUtils.test.ts
+++ b/frontend/src/__tests__/lib/utils/dateUtils.test.ts
@@ -6,6 +6,7 @@ import {
   formatDateShortYear,
   formatWithOrdinalAndDay,
   formatDateShort,
+  formatRelativeTime,
 } from '../../../lib/utils/dateUtils';
 
 jest.mock('expo-localization', () => ({
@@ -75,6 +76,45 @@ describe('dateUtils', () => {
       expect(formatWithOrdinalAndDay(null)).toBe('');
       expect(formatWithOrdinalAndDay(undefined)).toBe('');
       expect(formatWithOrdinalAndDay('invalid')).toBe('');
+    });
+
+    it('formats formatRelativeTime for recent timestamps', () => {
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date('2026-05-26T16:30:00Z'));
+
+      expect(formatRelativeTime('2026-05-26T16:25:00Z')).toBe('5 minutes ago');
+      expect(formatRelativeTime('2026-05-26T14:30:00Z')).toBe('about 2 hours ago');
+      expect(formatRelativeTime('2026-05-23T16:30:00Z')).toBe('3 days ago');
+      expect(formatRelativeTime('2026-05-19T16:30:00Z')).toBe('7 days ago');
+
+      jest.useRealTimers();
+    });
+
+    it('falls back to a localized full date for older timestamps', () => {
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date('2026-06-05T16:30:00Z'));
+
+      expect(formatRelativeTime('2026-05-26T14:30:00Z')).toBe(
+        '26 May, 2026, 2:30 PM'
+      );
+
+      // More than one month old
+      expect(formatRelativeTime('2026-04-26T14:30:00Z')).toBe(
+        '26 Apr, 2026, 2:30 PM'
+      );
+
+      // More than one year old
+      expect(formatRelativeTime('2025-05-26T14:30:00Z')).toBe(
+        '26 May, 2025, 2:30 PM'
+      );
+
+      jest.useRealTimers();
+    });
+
+    it('returns an empty string for invalid relative timestamps', () => {
+      expect(formatRelativeTime(null)).toBe('');
+      expect(formatRelativeTime(undefined)).toBe('');
+      expect(formatRelativeTime('invalid')).toBe('');
     });
 
     it('formats formatDateShort correctly', () => {

--- a/frontend/src/components/article/CommentItem.tsx
+++ b/frontend/src/components/article/CommentItem.tsx
@@ -68,7 +68,7 @@ export default function CommentItem({
   };
 
   const formatWithOrdinal = (date: string) =>
-    formatWithOrdinalAndDay(date);
+    formatRelativeTime(date);
 
   // Render mentions inline
   const renderTextWithMentions = (text: string) => {

--- a/frontend/src/components/notification/NotificationItem.tsx
+++ b/frontend/src/components/notification/NotificationItem.tsx
@@ -1,7 +1,5 @@
- 
- 
 // @ts-nocheck
-import {formatTimeWithDate} from '../../lib/utils/dateUtils';
+import {formatRelativeTime} from '../../lib/utils/dateUtils';
 import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import {
   PanResponder,
@@ -169,7 +167,7 @@ export default function NotificationItem({
             </Text>
             <Text style={styles.footerText}>
               Received at: {' '}
-              {formatTimeWithDate(item?.timestamp)}
+              {formatRelativeTime(item?.timestamp)}
             </Text>
           </View>
         </Pressable>
@@ -255,4 +253,3 @@ const styles = StyleSheet.create({
     marginLeft: 8,
   },
 });
-

--- a/frontend/src/components/notification/NotificationItem.tsx
+++ b/frontend/src/components/notification/NotificationItem.tsx
@@ -166,7 +166,6 @@ export default function NotificationItem({
               {item?.message} {' '}
             </Text>
             <Text style={styles.footerText}>
-              Received at: {' '}
               {formatRelativeTime(item?.timestamp)}
             </Text>
           </View>

--- a/frontend/src/lib/utils/dateUtils.ts
+++ b/frontend/src/lib/utils/dateUtils.ts
@@ -1,4 +1,4 @@
-import { format, isValid, getYear, parse, parseISO } from 'date-fns';
+import { format, isValid, getYear, parse, parseISO, formatDistanceToNow } from 'date-fns';
 import { enUS, es, fr, de, hi } from 'date-fns/locale';
 import type { Locale } from 'date-fns';
 import { TZDateMini } from '@date-fns/tz';
@@ -89,6 +89,33 @@ const getValidDate = (date: Date | string | number | null | undefined): Date | n
   }
   
   return null;
+};
+
+/**
+ * Format recent timestamps as relative time.
+ * Example: "5 minutes ago", "2 hours ago", "3 days ago".
+ * Falls back to a localized full date for older entries.
+ */
+export const formatRelativeTime = (
+  date: Date | string | number | null | undefined
+): string => {
+  const validDate = getValidDate(date);
+  if (!validDate) return '';
+
+  const now = new Date();
+  const diffInDays =
+    Math.abs(now.getTime() - validDate.getTime()) / (1000 * 60 * 60 * 24);
+
+  if (diffInDays <= 7) {
+    return formatDistanceToNow(validDate, {
+      addSuffix: true,
+      locale: activeLocale,
+    });
+  }
+
+  return format(validDate, "d MMM, yyyy, h:mm a", {
+    locale: activeLocale,
+  });
 };
 
 /**


### PR DESCRIPTION
## Description

Fixes #1745.

This PR updates comment and notification timestamps to display human-friendly relative time while respecting the user's locale and timezone.

### Changes

- Added reusable relative timestamp formatting using `date-fns`.
- Recent timestamps display relative values such as `5 minutes ago`, `2 hours ago`, and `3 days ago`.
- Older timestamps fall back to a localized date and time.
- Updated comment timestamps to use the new formatter.
- Updated notification timestamps to use the new formatter.
- Preserved the existing date parsing and formatting utilities.

### Related Issue

Fixes #1745

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

### Work Area

- [x] Frontend
- [ ] Backend
- [ ] Documentation
- [ ] Others

### Snapshot

Not applicable — this is a timestamp formatting/UI behavior fix.