### PR TITLE
Fix : Scope `zod-validation-error` override to `eslint-plugin-react-hooks`

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -171,5 +171,10 @@
       }
     }
   },
-  "packageManager": "yarn@4.18.0"
+  "packageManager": "yarn@4.18.0",
+  "overrides": {
+    "eslint-plugin-react-hooks": {
+      "zod-validation-error": "^4.0.2"
+    }
+  }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -171,10 +171,10 @@
       }
     }
   },
-  "packageManager": "yarn@4.18.0",
   "overrides": {
     "eslint-plugin-react-hooks": {
       "zod-validation-error": "^4.0.2"
     }
-  }
+  },
+  "packageManager": "yarn@4.18.0"
 }


### PR DESCRIPTION


**Fixes #2373**

## Summary

ESLint was crashing during startup with `ERR_PACKAGE_PATH_NOT_EXPORTED` before it could lint any files.

This PR fixes the dependency mismatch by adding a scoped npm override for `zod-validation-error` under `eslint-plugin-react-hooks`.

## Root Cause

`eslint-plugin-react-hooks@7.1.1`, which is pulled in through `eslint-config-expo`, supports both `zod-validation-error` 3.x and 4.x:

```text
zod-validation-error: ^3.5.0 || ^4.0.0
```

The project uses `zod@4.4.3`, so `eslint-plugin-react-hooks` attempts to load the `./v4` subpath from `zod-validation-error`.

However, npm resolved `zod-validation-error` to `3.5.4`.

Although `3.5.4` satisfies the `^3.5.0` part of the dependency range, it does not expose the `./v4` subpath. That export was introduced in `zod-validation-error@4.0.0`.

As a result, `eslint-plugin-react-hooks` attempts to load:

```text
zod-validation-error/v4
```

and Node.js throws:

```text
ERR_PACKAGE_PATH_NOT_EXPORTED
```

There is also a separate dependency chain through `eslint-plugin-react-compiler@19.1.0-rc.2`, which depends on `zod-validation-error@^3.0.3` and correctly uses its `3.5.4` copy. That dependency is unrelated to this issue and is intentionally left unchanged.

## Fix

Added a scoped override to `frontend/package.json`:

```json
"overrides": {
  "eslint-plugin-react-hooks": {
    "zod-validation-error": "^4.0.2"
  }
}
```

This ensures that `eslint-plugin-react-hooks` gets a compatible `zod-validation-error` version that provides the required `./v4` export.

The override is scoped specifically to `eslint-plugin-react-hooks`, so the `eslint-plugin-react-compiler` dependency remains on `zod-validation-error@3.5.4`.

## Verification

### Dependency tree

Ran:

```bash
npm ls zod-validation-error
```

Confirmed:

* `eslint-plugin-react-hooks` → `zod-validation-error@4.0.2`
* `eslint-plugin-react-compiler` → `zod-validation-error@3.5.4`
* No `invalid` or `ELSPROBLEMS` warnings

### ESLint

Ran:

```bash
npx eslint . --ext .ts,.tsx
```

ESLint now starts successfully and reports the project's actual lint warnings instead of crashing.

The verification produced approximately 158–163 warnings with **0 startup crashes**.

### TypeScript

Ran:

```bash
npx tsc --noEmit
```

The error count remained **1117 before and after** the change.

The comparison was performed on the same machine using `git stash` / `git stash pop`, confirming that the dependency override did not introduce additional TypeScript errors.

## Note

The project currently requires `--legacy-peer-deps` during installation because of an existing peer dependency conflict between `lottie-react-native` and `@lottiefiles/dotlottie-react`.

This is unrelated to the current fix and is not caused by the `zod-validation-error` override.
