### PR TITLE
fix(web): remove excessive card containers on landing page

### DIFF
--- a/web/src/app/[locale]/page.tsx
+++ b/web/src/app/[locale]/page.tsx
@@ -937,26 +937,15 @@ export default function Home() {
         <PageWrapper>
           <h2>Be a Member: Guardian of Content Integrity</h2>
           <p className="center">Help maintain quality and safety across the platform</p>
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-6 md:gap-8 mt-16 w-full">
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 md:gap-8 mt-16 w-full">
             {[
               { icon: "fa-sync-alt", title: "Interactive Review", desc: "Manage the full lifecycle of content with a streamlined approval, rejection, and feedback loop for contributors." },
               { icon: "fa-microchip", title: "Content Integrity", desc: "Leverage automated plagiarism and grammar engines to maintain professional clarity and originality scores." },
               { icon: "fa-shield-alt", title: "Visual Asset Audit", desc: "Validation for image quality and automated compliance checks for brand logos and visual safety. (Coming Soon)" },
-            ].map((f, i) => (
-              <div className="feature-card mod-card w-full fade-in" key={i}>
-                <div className="mod-icon"><i className={`fas ${f.icon}`}></i></div>
-                <h3>{f.title}</h3>
-                <p>{f.desc}</p>
-              </div>
-            ))}
-          </div>
-
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-6 md:gap-8 mt-6 mx-auto" style={{ maxWidth: "66.666%", marginLeft: "auto", marginRight: "auto", marginTop: "20px" }}>
-            {[
               { icon: "fa-gavel", title: "Community Safety", desc: "Investigate flagged content and manage user reports through a robust system designed to keep the platform safe." },
               { icon: "fa-fingerprint", title: "Advanced Security", desc: "Role-based access control (RBAC) ensuring only verified Reviewers and Admins can access protected operations." },
             ].map((f, i) => (
-              <div className="feature-card mod-card w-full fade-in" key={i}>
+              <div className="mod-card w-full fade-in" key={i}>
                 <div className="mod-icon"><i className={`fas ${f.icon}`}></i></div>
                 <h3>{f.title}</h3>
                 <p>{f.desc}</p>

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -1149,12 +1149,12 @@ p.center {
 
 .mod-icon {
   display: flex;
-  justify-content: left;
-  align-items: left;
-  font-size: 2.5rem;
-  margin-bottom: 20px;
-  color: #667eea ;
-  transition: transform 0.35s ease;
+  justify-content: flex-start;
+  align-items: flex-start;
+  font-size: 1.75rem;
+  margin-bottom: 14px;
+  color: #667eea;
+  transition: color 0.35s ease;
 }
 .mod-icon i {
   background: var(--gradient-primary);
@@ -1162,17 +1162,23 @@ p.center {
   background-clip: text;
 }
 .mod-card {
-  border: 2px solid rgba(102, 126, 234, 0.1); 
-  transition: all 0.35s ease;
-  border-radius: 16 px;
+  border-left: 3px solid rgba(102, 126, 234, 0.25);
+  padding: 4px 0 4px 24px;
+  transition: border-color 0.35s ease;
 }
-.mod-card:hover { 
-  transform: translateY(-10px);
-  border-color: var(--primary); 
-  box-shadow: 0 20px 40px -10px rgba(102, 126, 234, 0.25); 
+.mod-card:hover {
+  border-left-color: var(--primary);
 }
-.mod-card:hover .mod-icon {
-  transform: rotate(8deg);
+.mod-card h3 {
+  font-size: 1.2rem;
+  margin-bottom: 10px;
+  color: var(--text-dark);
+  font-weight: 700;
+}
+.mod-card p {
+  color: var(--text-muted);
+  line-height: 1.7;
+  margin: 0;
 }
 
 /* ==================== PROGRAM CARDS ==================== */
@@ -1309,7 +1315,7 @@ section#contact.contact-section > .container > p.center {
 .contact-info-cards {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 4px;
   margin-bottom: 32px;
   position: relative;
 }
@@ -1318,17 +1324,17 @@ section#contact.contact-section > .container > p.center {
   display: flex;
   align-items: flex-start;
   gap: 14px;
-  background: rgba(255, 255, 255, 0.07);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: 14px;
-  padding: 15px 18px;
-  transition: var(--transition);
+  padding: 16px 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  transition: border-color 0.2s ease;
+}
+
+.contact-info-card:last-child {
+  border-bottom: none;
 }
 
 .contact-info-card:hover {
-  background: rgba(255, 255, 255, 0.13);
   border-color: rgba(196, 181, 253, 0.4);
-  transform: translateX(4px);
 }
 
 .contact-info-icon {
@@ -3141,12 +3147,17 @@ html.dark .feature-card-premium {
 }
 html.dark .feature-item,
 html.dark .feature-card,
-html.dark .mod-card,
 html.dark .program-card,
 html.dark .download-card,
 html.dark .modal-content {
   background: #1e293b;
   border-color: rgba(255,255,255,0.05);
+}
+html.dark .mod-card {
+  border-left-color: rgba(167, 139, 250, 0.35);
+}
+html.dark .mod-card h3 {
+  color: #f1f5f9;
 }
 
 html.dark section#contact.contact-section { background: #0f172a; }


### PR DESCRIPTION
## Summary
Audits the landing page and removes card containers that don't add meaningful grouping or hierarchy, replacing them with open layouts, spacing, and dividers as requested in #2288.

## Changes
- **Moderator section** — removed the card-box treatment (borders, shadows, hover lift) from the 5 moderator items and merged the two disjoint grids (3 + 2 cards with an awkward 66% width wrapper) into a single responsive open layout using a left accent border, spacing, and dividers.
- **Contact section** — converted the three stacked `contact-info-card` boxes into open rows separated by dividers inside the existing contact panel. Cards no longer render as individual boxes; the panel itself provides the grouping.
- Cleaned up the invalid `border-radius: 16 px;` declaration on `.mod-card` and removed decorative hover rotate/translate effects.

## Preserved
Cards that improve usability are kept as-is:
- Feature highlight grid
- Programs section
- Screenshot carousel
- Upcoming features

Responsive breakpoints (grid columns, spacing) are maintained in both light and dark mode.

## Screenshots
- No UI screenshots available in this environment; changes are CSS/layout only and can be previewed locally with `npm run dev` in `web/`.
