### PR TITLE
fix(web): de-slop upcoming features and feature cards

### DIFF
--- a/web/src/app/[locale]/page.tsx
+++ b/web/src/app/[locale]/page.tsx
@@ -937,26 +937,15 @@ export default function Home() {
         <PageWrapper>
           <h2>Be a Member: Guardian of Content Integrity</h2>
           <p className="center">Help maintain quality and safety across the platform</p>
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-6 md:gap-8 mt-16 w-full">
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 md:gap-8 mt-16 w-full">
             {[
               { icon: "fa-sync-alt", title: "Interactive Review", desc: "Manage the full lifecycle of content with a streamlined approval, rejection, and feedback loop for contributors." },
               { icon: "fa-microchip", title: "Content Integrity", desc: "Leverage automated plagiarism and grammar engines to maintain professional clarity and originality scores." },
               { icon: "fa-shield-alt", title: "Visual Asset Audit", desc: "Validation for image quality and automated compliance checks for brand logos and visual safety. (Coming Soon)" },
-            ].map((f, i) => (
-              <div className="feature-card mod-card w-full fade-in" key={i}>
-                <div className="mod-icon"><i className={`fas ${f.icon}`}></i></div>
-                <h3>{f.title}</h3>
-                <p>{f.desc}</p>
-              </div>
-            ))}
-          </div>
-
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-6 md:gap-8 mt-6 mx-auto" style={{ maxWidth: "66.666%", marginLeft: "auto", marginRight: "auto", marginTop: "20px" }}>
-            {[
               { icon: "fa-gavel", title: "Community Safety", desc: "Investigate flagged content and manage user reports through a robust system designed to keep the platform safe." },
               { icon: "fa-fingerprint", title: "Advanced Security", desc: "Role-based access control (RBAC) ensuring only verified Reviewers and Admins can access protected operations." },
             ].map((f, i) => (
-              <div className="feature-card mod-card w-full fade-in" key={i}>
+              <div className="mod-card w-full fade-in" key={i}>
                 <div className="mod-icon"><i className={`fas ${f.icon}`}></i></div>
                 <h3>{f.title}</h3>
                 <p>{f.desc}</p>

--- a/web/src/app/[locale]/page.tsx
+++ b/web/src/app/[locale]/page.tsx
@@ -712,134 +712,67 @@ export default function Home() {
           </div>
 
           {/* ── Upcoming Features ── */}
-          <div style={{ marginTop: '80px' }}>
-            <div style={{ textAlign: 'center', marginBottom: '40px' }}>
-              <div style={{
-                display: 'inline-flex', alignItems: 'center', gap: '8px',
-                background: 'linear-gradient(135deg, rgba(102,126,234,0.12), rgba(245,87,108,0.12))',
-                border: '1px solid rgba(102,126,234,0.25)',
-                borderRadius: '50px', padding: '6px 18px', marginBottom: '16px',
-                fontSize: '0.75rem', fontWeight: 800, letterSpacing: '0.1em',
-                textTransform: 'uppercase', color: '#667eea',
-              }}>
-                <i className="fas fa-rocket" style={{ fontSize: '0.7rem' }}></i>
+          <div className="upcoming-section">
+            <div className="upcoming-header">
+              <span className="upcoming-badge-main">
+                <i className="fas fa-rocket"></i>
                 Arriving October 2026
-              </div>
-              <h3 style={{
-                fontSize: 'clamp(1.4rem, 3vw, 2rem)', fontWeight: 900, color: '#1e293b',
-                marginBottom: '10px', lineHeight: 1.3,
-              }}>
-                What&apos;s Coming Next
-              </h3>
-              <p style={{ color: '#64748b', fontSize: '1rem', maxWidth: '520px', margin: '0 auto', lineHeight: 1.7 }}>
+              </span>
+              <h3>What&apos;s Coming Next</h3>
+              <p>
                 As an open-source project, these upcoming features are community-built and <strong>free for all</strong>.
               </p>
             </div>
 
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6 w-full">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6 md:gap-8 w-full">
               {[
                 {
                   icon: 'fa-comments',
-                  emoji: '🤖',
                   title: 'AI Personal Chat',
                   sub: 'Characters Chat',
                   desc: 'Chat with AI-powered health personas — a compassionate doctor, a mindful therapist, or a wellness coach — available anytime, completely free.',
                   accent: '#667eea',
-                  glow: 'rgba(102,126,234,0.15)',
                 },
                 {
                   icon: 'fa-hospital',
-                  emoji: '🏥',
                   title: 'Hospital Learning System',
                   sub: 'Structured Health Education',
                   desc: 'A modular learning platform bringing hospital-grade health education directly to patients, students, and caregivers — no fees, no barriers.',
                   accent: '#22c55e',
-                  glow: 'rgba(34,197,94,0.12)',
                 },
                 {
                   icon: 'fa-user-md',
-                  emoji: '👨‍⚕️',
                   title: 'Connect with a Doctor',
                   sub: 'Voluntary Suggestions Only',
                   desc: 'Doctors who choose to volunteer their time can offer health suggestions to the community. No one is forced — only those who genuinely want to help.',
                   accent: '#f59e0b',
-                  glow: 'rgba(245,158,11,0.12)',
                 },
                 {
                   icon: 'fa-dna',
-                  emoji: '🧬',
                   title: 'AI Health Analytics',
                   sub: 'Personalized Wellness Insights',
                   desc: 'Track your health patterns with AI-driven insights — personalized reports, trend analysis, and proactive wellness recommendations, built open-source.',
                   accent: '#f5576c',
-                  glow: 'rgba(245,87,108,0.12)',
                 },
               ].map((f, i) => (
-                <div
-                  key={i}
-                  className="fade-in"
-                  style={{
-                    background: `linear-gradient(135deg, #0f172a 0%, #1e1b4b 100%)`,
-                    borderRadius: '20px',
-                    padding: '32px 28px',
-                    border: `1.5px solid ${f.accent}33`,
-                    position: 'relative',
-                    overflow: 'hidden',
-                    transition: 'transform 0.3s, box-shadow 0.3s',
-                  }}
-                  onMouseEnter={e => {
-                    (e.currentTarget as HTMLDivElement).style.transform = 'translateY(-5px)'
-                      ; (e.currentTarget as HTMLDivElement).style.boxShadow = `0 20px 50px ${f.glow}`
-                  }}
-                  onMouseLeave={e => {
-                    (e.currentTarget as HTMLDivElement).style.transform = 'translateY(0)'
-                      ; (e.currentTarget as HTMLDivElement).style.boxShadow = 'none'
-                  }}
-                >
-                  {/* glow blob */}
-                  <div style={{
-                    position: 'absolute', top: '-30px', right: '-30px', width: '120px', height: '120px',
-                    borderRadius: '50%', background: f.glow, filter: 'blur(30px)', pointerEvents: 'none',
-                  }} />
-
-                  {/* top row */}
-                  <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', marginBottom: '20px' }}>
-                    <div style={{
-                      width: 52, height: 52, borderRadius: '14px',
-                      background: `linear-gradient(135deg, ${f.accent}33, ${f.accent}18)`,
-                      border: `1px solid ${f.accent}44`,
-                      display: 'flex', alignItems: 'center', justifyContent: 'center',
-                      fontSize: '1.5rem',
-                    }}>
-                      {f.emoji}
+                <div className="upcoming-card fade-in" key={i}>
+                  <div
+                    className="upcoming-icon"
+                    style={{ color: f.accent, background: `${f.accent}1f`, borderColor: `${f.accent}33` }}
+                  >
+                    <i className={`fas ${f.icon}`}></i>
+                  </div>
+                  <div className="upcoming-body">
+                    <div className="upcoming-top">
+                      <h3>{f.title}</h3>
+                      <span className="upcoming-tag">Oct – Nov 2026</span>
                     </div>
-                    <span style={{
-                      fontSize: '0.65rem', fontWeight: 800, letterSpacing: '0.1em',
-                      textTransform: 'uppercase', color: '#fbbf24',
-                      background: 'rgba(251,191,36,0.12)', border: '1px solid rgba(251,191,36,0.25)',
-                      borderRadius: '50px', padding: '3px 10px',
-                      whiteSpace: 'nowrap',
-                    }}>
-                      Oct – Nov 2026
-                    </span>
-                  </div>
-
-                  <div style={{ fontSize: '1.15rem', fontWeight: 800, color: 'white', marginBottom: '4px', lineHeight: 1.3 }}>
-                    {f.title}
-                  </div>
-                  <div style={{ fontSize: '0.75rem', fontWeight: 700, color: f.accent, marginBottom: '12px', letterSpacing: '0.04em' }}>
-                    {f.sub}
-                  </div>
-                  <p style={{ color: 'rgba(255,255,255,0.6)', fontSize: '0.9rem', lineHeight: 1.7, margin: 0 }}>
-                    {f.desc}
-                  </p>
-
-                  {/* bottom divider + free badge */}
-                  <div style={{ marginTop: '20px', paddingTop: '16px', borderTop: '1px solid rgba(255,255,255,0.07)', display: 'flex', alignItems: 'center', gap: '8px' }}>
-                    <i className="fas fa-lock-open" style={{ color: f.accent, fontSize: '0.75rem' }}></i>
-                    <span style={{ fontSize: '0.75rem', color: 'rgba(255,255,255,0.4)', fontWeight: 600 }}>
-                      Open Source · Free for All
-                    </span>
+                    <span className="upcoming-sub" style={{ color: f.accent }}>{f.sub}</span>
+                    <p>{f.desc}</p>
+                    <div className="upcoming-footer">
+                      <i className="fas fa-lock-open" style={{ color: f.accent }}></i>
+                      <span>Open Source · Free for All</span>
+                    </div>
                   </div>
                 </div>
               ))}

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -1149,12 +1149,12 @@ p.center {
 
 .mod-icon {
   display: flex;
-  justify-content: left;
-  align-items: left;
-  font-size: 2.5rem;
-  margin-bottom: 20px;
-  color: #667eea ;
-  transition: transform 0.35s ease;
+  justify-content: flex-start;
+  align-items: flex-start;
+  font-size: 1.75rem;
+  margin-bottom: 14px;
+  color: #667eea;
+  transition: color 0.35s ease;
 }
 .mod-icon i {
   background: var(--gradient-primary);
@@ -1162,17 +1162,23 @@ p.center {
   background-clip: text;
 }
 .mod-card {
-  border: 2px solid rgba(102, 126, 234, 0.1); 
-  transition: all 0.35s ease;
-  border-radius: 16 px;
+  border-left: 3px solid rgba(102, 126, 234, 0.25);
+  padding: 4px 0 4px 24px;
+  transition: border-color 0.35s ease;
 }
-.mod-card:hover { 
-  transform: translateY(-10px);
-  border-color: var(--primary); 
-  box-shadow: 0 20px 40px -10px rgba(102, 126, 234, 0.25); 
+.mod-card:hover {
+  border-left-color: var(--primary);
 }
-.mod-card:hover .mod-icon {
-  transform: rotate(8deg);
+.mod-card h3 {
+  font-size: 1.2rem;
+  margin-bottom: 10px;
+  color: var(--text-dark);
+  font-weight: 700;
+}
+.mod-card p {
+  color: var(--text-muted);
+  line-height: 1.7;
+  margin: 0;
 }
 
 /* ==================== PROGRAM CARDS ==================== */
@@ -1309,7 +1315,7 @@ section#contact.contact-section > .container > p.center {
 .contact-info-cards {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 4px;
   margin-bottom: 32px;
   position: relative;
 }
@@ -1318,17 +1324,17 @@ section#contact.contact-section > .container > p.center {
   display: flex;
   align-items: flex-start;
   gap: 14px;
-  background: rgba(255, 255, 255, 0.07);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: 14px;
-  padding: 15px 18px;
-  transition: var(--transition);
+  padding: 16px 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  transition: border-color 0.2s ease;
+}
+
+.contact-info-card:last-child {
+  border-bottom: none;
 }
 
 .contact-info-card:hover {
-  background: rgba(255, 255, 255, 0.13);
   border-color: rgba(196, 181, 253, 0.4);
-  transform: translateX(4px);
 }
 
 .contact-info-icon {
@@ -3141,12 +3147,17 @@ html.dark .feature-card-premium {
 }
 html.dark .feature-item,
 html.dark .feature-card,
-html.dark .mod-card,
 html.dark .program-card,
 html.dark .download-card,
 html.dark .modal-content {
   background: #1e293b;
   border-color: rgba(255,255,255,0.05);
+}
+html.dark .mod-card {
+  border-left-color: rgba(167, 139, 250, 0.35);
+}
+html.dark .mod-card h3 {
+  color: #f1f5f9;
 }
 
 html.dark section#contact.contact-section { background: #0f172a; }

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -996,63 +996,26 @@ p.center {
   padding: 100px 0;
 }
 
-.feature-section-premium::before {
-  content: "";
-  position: absolute;
-  top: -20%; left: -10%;
-  width: 500px; height: 500px;
-  background: radial-gradient(circle, rgba(102,126,234,0.15) 0%, rgba(255,255,255,0) 70%);
-  border-radius: 50%;
-  pointer-events: none;
-}
-
-.feature-section-premium::after {
-  content: "";
-  position: absolute;
-  bottom: -20%; right: -10%;
-  width: 600px; height: 600px;
-  background: radial-gradient(circle, rgba(118,75,162,0.1) 0%, rgba(255,255,255,0) 70%);
-  border-radius: 50%;
-  pointer-events: none;
-}
 .feature-card-premium {
   position: relative;
-  background: rgba(255, 255, 255, 0.6);
-  backdrop-filter: blur(16px);
-  -webkit-backdrop-filter: blur(16px);
-
-  border: 1px solid rgba(255, 255, 255, 0.8);
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(0, 0, 0, 0.06);
   border-left: 3px solid transparent;
-  border-radius: 24px;
-  padding: 40px 32px;
-  box-shadow: 0 4px 30px rgba(0, 0, 0, 0.05);
+  border-radius: 20px;
+  padding: 32px;
   transition: transform 0.3s ease,
               box-shadow 0.3s ease,
               background 0.3s ease,
               border-left-color 0.3s ease;
-  overflow: hidden;
   display: flex;
   flex-direction: column;
   z-index: 1;
 }
 
-.feature-card-premium::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  border-radius: 24px;
-  padding: 2px;
-  background: linear-gradient(135deg, rgba(255,255,255,0.8), rgba(255,255,255,0));
-  -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
-  -webkit-mask-composite: xor;
-  mask-composite: exclude;
-  pointer-events: none;
-}
-
 .feature-card-premium:hover {
-  transform: translateY(-8px);
-  box-shadow: 0 20px 40px rgba(102, 126, 234, 0.18);
-  background: rgba(255, 255, 255, 0.85);
+  transform: translateY(-4px);
+  box-shadow: var(--shadow-md);
+  background: rgba(255, 255, 255, 0.9);
   border-left-color: #764ba2;
 }
 
@@ -1098,13 +1061,11 @@ p.center {
 }
 
 .feature-card-premium h3 {
-  font-size: 1.4rem;
+  font-size: 1.25rem;
   font-weight: 800;
-  margin-bottom: 16px;
-  background: var(--gradient-primary);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  line-height: 1.3;
+  margin-bottom: 12px;
+  color: var(--text-dark);
+  line-height: 1.35;
 }
 
 .feature-card-premium p {
@@ -1112,6 +1073,162 @@ p.center {
   font-size: 1.05rem;
   line-height: 1.7;
   flex-grow: 1;
+}
+
+/* ==================== UPCOMING FEATURES ==================== */
+.upcoming-section {
+  margin-top: 80px;
+}
+
+.upcoming-header {
+  text-align: center;
+  margin-bottom: 40px;
+}
+
+.upcoming-badge-main {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: rgba(102, 126, 234, 0.08);
+  border: 1px solid rgba(102, 126, 234, 0.2);
+  color: #667eea;
+  border-radius: 50px;
+  padding: 6px 16px;
+  margin-bottom: 16px;
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.upcoming-header h3 {
+  font-size: clamp(1.4rem, 3vw, 2rem);
+  font-weight: 800;
+  color: var(--text-dark);
+  margin-bottom: 10px;
+  line-height: 1.3;
+}
+
+.upcoming-header p {
+  color: var(--text-light);
+  font-size: 1rem;
+  max-width: 520px;
+  margin: 0 auto;
+  line-height: 1.7;
+}
+
+.upcoming-card {
+  display: flex;
+  align-items: flex-start;
+  gap: 20px;
+  padding: 28px;
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  border-radius: 20px;
+  transition: border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.upcoming-card:hover {
+  border-color: rgba(102, 126, 234, 0.35);
+  box-shadow: var(--shadow-md);
+}
+
+.upcoming-icon {
+  flex-shrink: 0;
+  width: 48px;
+  height: 48px;
+  border-radius: 12px;
+  border: 1px solid;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.15rem;
+}
+
+.upcoming-body {
+  flex: 1;
+}
+
+.upcoming-top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 4px;
+}
+
+.upcoming-top h3 {
+  font-size: 1.1rem;
+  font-weight: 800;
+  color: var(--text-dark);
+  line-height: 1.3;
+  margin: 0;
+}
+
+.upcoming-tag {
+  flex-shrink: 0;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-light);
+  background: rgba(0, 0, 0, 0.05);
+  border-radius: 50px;
+  padding: 3px 10px;
+  white-space: nowrap;
+}
+
+.upcoming-sub {
+  display: block;
+  font-size: 0.78rem;
+  font-weight: 700;
+  margin-bottom: 10px;
+  letter-spacing: 0.04em;
+}
+
+.upcoming-body p {
+  color: var(--text-light);
+  font-size: 0.9rem;
+  line-height: 1.7;
+  margin: 0 0 16px;
+}
+
+.upcoming-footer {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding-top: 14px;
+  border-top: 1px solid rgba(0, 0, 0, 0.07);
+}
+
+.upcoming-footer span {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-light);
+}
+
+html.dark .upcoming-card {
+  background: rgba(30, 41, 59, 0.6);
+  border-color: rgba(255, 255, 255, 0.08);
+}
+html.dark .upcoming-card:hover {
+  border-color: rgba(167, 139, 250, 0.4);
+}
+html.dark .upcoming-top h3,
+html.dark .upcoming-header h3 {
+  color: #f1f5f9;
+}
+html.dark .upcoming-tag {
+  background: rgba(255, 255, 255, 0.08);
+  color: #94a3b8;
+}
+html.dark .upcoming-footer {
+  border-top-color: rgba(255, 255, 255, 0.08);
+}
+html.dark .upcoming-footer span,
+html.dark .upcoming-body p,
+html.dark .upcoming-header p {
+  color: #94a3b8;
 }
 
 /* ==================== FEATURE GRID ==================== */
@@ -3144,6 +3261,9 @@ html.dark .member-section {
 html.dark .feature-card-premium {
   background: rgba(30,41,59,0.6);
   border-color: rgba(255,255,255,0.1);
+}
+html.dark .feature-card-premium h3 {
+  color: #f1f5f9;
 }
 html.dark .feature-item,
 html.dark .feature-card,


### PR DESCRIPTION
﻿## Summary
Polish pass on the landing page for #2286. Fixes #2286.

## Summary Polish pass on the landing page for #2286: replace the "AI-slop" styling in the Upcoming Features section and simplify the feature grid cards so the page relies on consistent typography, spacing, and visual hierarchy instead of glow effects, emoji, and frosted-glass chrome.  ## Changes ### Upcoming Features section - Replaced emoji icons + blurred glow blobs with Font Awesome icons inside an accent-tinted tile (matching the icon treatment already used across the app). - Removed the forced dark navy gradient card background and hard-coded white/amber text so the section now follows the theme (light + dark mode) through shared CSS variables. - Extracted the section header into reusable classes (`.upcoming-section`, `.upcoming-header`, `.upcoming-badge-main`) and toned down the rocket badge. - Normalized spacing: 28px card padding, 20px radius, 20px icon-to-text gap, and a cleaner title/tag layout with a divider + "Open Source ┬╖ Free for All" footer.  ### Feature grid - Removed the `::before` gradient-border mask and `backdrop-filter` blur from `.feature-card-premium` ΓÇö replaced the frosted look with a solid subtle surface. - Replaced gradient-text `<h3>` with solid `--text-dark` color for better contrast/readability (with dark-mode override). - Removed the two decorative radial blobs from `.feature-section-premium`. - Tuned hover: `-8px` ΓåÆ `-4px` lift, `--shadow-md` instead of a purple glow.  ## Not changed - All markup/logic and responsive breakpoints are preserved. - Other sections (hero, download CTA, programs, screenshots, testimonials) are untouched to keep the diff focused. 
