### PR TITLE
fix(web): glossary search matches term names only

### DIFF
--- a/web/src/app/[locale]/medical-glossary/MedicalGlossaryExplorer.tsx
+++ b/web/src/app/[locale]/medical-glossary/MedicalGlossaryExplorer.tsx
@@ -86,9 +86,7 @@ export default function MedicalGlossaryExplorer() {
   const filteredEntries = useMemo(() => {
     const q = searchQuery.toLowerCase();
     return glossaryEntries.filter((entry) => {
-      const matchesSearch =
-        entry.term.toLowerCase().includes(q) ||
-        entry.definition.toLowerCase().includes(q);
+      const matchesSearch = entry.term.toLowerCase().includes(q);
       const matchesCategory =
         selectedCategory === "All" || entry.category === selectedCategory;
       return matchesSearch && matchesCategory;


### PR DESCRIPTION
## Summary
Fixes #1761 — the Medical Glossary search now matches query terms against glossary **term names** only, instead of matching against the full definition text. This makes search behave like a dictionary lookup and removes irrelevant results that matched only inside definitions.

## Problem
`MedicalGlossaryExplorer.tsx` filtered entries with:
```ts
entry.term.toLowerCase().includes(q) || entry.definition.toLowerCase().includes(q)
```
So searching "Press" returned both "Blood Pressure" (relevant) and "Hypertension" (matched only because the keyword appears inside its definition/related content).

## Change
```ts
const matchesSearch = entry.term.toLowerCase().includes(q);
```

## Behavior after fix
- "Ast" → Asthma (plus any other term whose **name** contains "ast")
- "Press" → Blood Pressure only
- "Hyper" → Hypertension
- Empty query still shows all terms; category filter still works; related-term chips still jump to the term name.

Per the issue, definition-content search is intentionally not part of the default glossary search (could be a separate advanced feature later).

## Verification
- No `node_modules` available locally, so `npm test`/`lint` couldn't run in `web/`; the change is a single boolean condition and is covered by CI.
