### PR TITLE
fix(articles): surface paginated article fetch errors instead of swallowing them

### DIFF
--- a/frontend/src/__tests__/hooks/article/useGetPaginatedArticles.test.ts
+++ b/frontend/src/__tests__/hooks/article/useGetPaginatedArticles.test.ts
@@ -32,15 +32,16 @@ describe('useGetPaginatedArticle', () => {
     expect(result.current.data?.totalPages).toBe(5);
   });
 
-  it('returns null on catch', async () => {
+  it('surfaces request failures as query errors instead of swallowing them', async () => {
     mockedAxios.get.mockRejectedValueOnce(new Error('Network Error'));
 
     const {result} = renderHook(() => useGetPaginatedArticle(true, 1), {
       wrapper: makeWrapper(),
     });
 
-    await waitFor(() => expect(result.current.isSuccess).toBe(true)); // Try/catch inside queryFn
-    expect(result.current.data).toBeNull();
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.data).toBeUndefined();
   });
 
   it('does not fetch if not connected', async () => {

--- a/frontend/src/components/article/CommentItem.tsx
+++ b/frontend/src/components/article/CommentItem.tsx
@@ -10,7 +10,7 @@ import Animated, {
 } from 'react-native-reanimated';
 import Entypo from '@expo/vector-icons/Entypo';
 import {FontAwesome, Fontisto} from '@expo/vector-icons';
-import { formatWithOrdinalAndDay } from '../../lib/utils/dateUtils';
+import {formatRelativeTime, formatWithOrdinalAndDay} from '../../lib/utils/dateUtils';
 import ArticleFloatingMenu from '../home/AnimatedMenu';
 import {PRIMARY_COLOR} from '../../lib/ui/Theme';
 import {Comment} from '../../schemas/type';

--- a/frontend/src/hooks/article/useGetPaginatedArticles.ts
+++ b/frontend/src/hooks/article/useGetPaginatedArticles.ts
@@ -1,9 +1,7 @@
 import { PROD_URL } from '@/src/lib/api/APIUtils';
 import { ArticleData } from '@/src/schemas/type';
-import {useQuery, UseQueryResult} from '@tanstack/react-query';
+import { useQuery, UseQueryResult } from '@tanstack/react-query';
 import axios from 'axios';
-
-
 
 type AxiosError = any;
 
@@ -11,6 +9,7 @@ type ArticleRes = {
   articles: ArticleData[];
   totalPages: number;
 };
+
 export const useGetPaginatedArticle = (
   isConnected: boolean,
   page: number,
@@ -18,17 +17,13 @@ export const useGetPaginatedArticle = (
   return useQuery({
     queryKey: ['get-all-articles', page],
     queryFn: async () => {
-      try {
-       // const token = await secureRetrieveItem(SECURE_KEYS.USER_TOKEN);
-       // console.log('token: ', token);
-         console.log('response url: ', `${PROD_URL}/articles?page=${page}`);
-        const response = await axios.get(`${PROD_URL}/articles?page=${page}`);
-       
-        return response.data as ArticleRes;
-      } catch (err) {
-        console.error('Error fetching articles:', err);
-        return null;
+      if (__DEV__) {
+        console.log('response url: ', `${PROD_URL}/articles?page=${page}`);
       }
+
+      const response = await axios.get(`${PROD_URL}/articles?page=${page}`);
+
+      return response.data as ArticleRes;
     },
     enabled: !!isConnected && !!page,
   });


### PR DESCRIPTION
## What
`useGetPaginatedArticles` swallowed every request failure inside a `try/catch` and returned `null`, so the UI had no way to distinguish "no articles" from "request failed". It also left a leftover commented-out token block and an unconditional `console.log`.

## Changes
- Removed the `try/catch` in `queryFn` — errors now propagate to react-query's `error` state (`isError`).
- `console.log` gated behind `__DEV__`.
- Bonus: fixed pre-existing `CommentItem.tsx` type error from #2406 (missing `formatRelativeTime` import) which was breaking `yarn type-check` on `main`.

## Test
- Updated the hook test to assert `isError === true` and a real `Error` is surfaced (previously asserted `isSuccess` with `null` data).
- `yarn jest src/__tests__/hooks/article/useGetPaginatedArticles.test.ts` — 3 passed
- `yarn type-check` — clean

Closes #2408