### PR TITLE
fix: remove unused @lottiefiles/dotlottie-react to fix npm install

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,7 +27,6 @@
     "@expo/vector-icons": "^15.0.3",
     "@gorhom/bottom-sheet": "^5.2.6",
     "@hookform/resolvers": "^5.4.0",
-    "@lottiefiles/dotlottie-react": "^0.19.4",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-community/netinfo": "12.0.1",
     "@react-native-community/slider": "5.2.0",


### PR DESCRIPTION
Remove unused `@lottiefiles/dotlottie-react` dependency that caused an ERESOLVE peer dependency conflict with `lottie-react-native@7.4.0`. The package was never imported anywhere in the codebase.

Fixes #2410