### PR TITLE
Change article link to internal route

### DIFF
--- a/web/src/app/[locale]/contribute/page.tsx
+++ b/web/src/app/[locale]/contribute/page.tsx
@@ -1762,10 +1762,9 @@ export default function ContributePage() {
     { href: '/#screenshots', label: 'Screenshots', icon: 'fa-image' },
     { href: '/#programs', label: 'Community Programs', icon: 'fa-code-branch' },
     {
-      href: 'https://uhsocial.in/docs',
-      label: 'Read Articles',
-      icon: 'fa-file-lines',
-      external: true,
+  href: '/articles',
+  label: 'Read Articles',
+  icon: 'fa-file-lines',
     },
     { href: '/#downloads', label: 'Login / Register', icon: 'fa-user' },
   ]


### PR DESCRIPTION
## PR Description

This PR fixes the navigation issue on the Contribute page where the "Read Articles" navigation item redirected users to an outdated external deployment.

The link has been updated to point to the current internal `/articles` route so users can access the latest Articles page without being redirected to the old deployment.

## Type of Change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update

## Select your work-area

- [x] Frontend
- [ ] Backend
- [ ] Documentation
- [ ] Others

## Related Issue

Fixes #2051

## Changes Made

- Updated the "Read Articles" navigation link on the Contribute page.
- Replaced the outdated `https://uhsocial.in/docs` URL with `/articles`.
- Removed the `external: true` configuration because the destination is now an internal application route.

## Work Example

The "Read Articles" item in the Contribute page navigation now opens the current Articles page within the application.

## Fixes

Closes #2051

## Checklist

- [x] I have updated my branch and synced it with the project's `web` branch before making this PR.
- [x] I have optimized the file changes.
- [x] I have added a snapshot of my work example.
- [x] I have made a PR to the project's `web` branch.

## Undertaking

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have checked for plagiarism and assure its authenticity.
- [x] I have read and followed the code of conduct for this repository.

- [x] I Agree